### PR TITLE
Ord2 changes

### DIFF
--- a/docs/ord_tutorial.py
+++ b/docs/ord_tutorial.py
@@ -181,8 +181,9 @@ Inv().schematic
 
 # ### 4.4 Connections
 #
-# Connections between elements are another unique feature of the ORD language. 
-# They use the `--` operator and should always be connected from an instance to a `port` or `net`.
+# Connections between elements are another unique feature of the ORD language.
+# They use the `--` pseudo-operator to connect an instance pin to a `port` or `net`.
+# The operator is commutative: `inst.d -- vss` and `vss -- inst.d` are equivalent.
 
 # ### 4.5 Nets
 #

--- a/docs/ref/constraints.rst
+++ b/docs/ref/constraints.rst
@@ -23,14 +23,14 @@ Only :class:`ConstrainableAttr` attributes can be constrained.
     l.r2 = LayoutRect(layer=layers.Metal1)
 
     s = Solver(l)
-    s.constrain(l.r1.rect.height >= 500)
-    s.constrain(l.r1.rect.width >= 150)
-    s.constrain(l.r1.rect.southwest == (100, -100)
-    s.constrain(l.r2.rect.lx >= l.r1.rect.ux + 150)
-    s.constrain(l.r2.rect.width == -l.r1.rect.height + 800)
-    s.constrain(l.r2.rect.width <= 150)
-    s.constrain(l.r2.rect.height == 150)
-    s.constrain(l.r2.rect.cy == l.r1.rect.cy)
+    s.constrain(l.r1.height >= 500)
+    s.constrain(l.r1.width >= 150)
+    s.constrain(l.r1.southwest == (100, -100))
+    s.constrain(l.r2.lx >= l.r1.ux + 150)
+    s.constrain(l.r2.width == -l.r1.height + 800)
+    s.constrain(l.r2.width <= 150)
+    s.constrain(l.r2.height == 150)
+    s.constrain(l.r2.cy == l.r1.cy)
     s.solve()
 
 

--- a/docs/ref/ord1.rst
+++ b/docs/ref/ord1.rst
@@ -13,27 +13,21 @@ ORD1 is the initial version of the IC design language in the ORDeC project. It w
 Parser
 ------
 
-.. autofunction:: load_ord_from_string
-.. autofunction:: ord1_to_py
+.. autofunction:: ordec.ord1.parser.load_ord_from_string
+.. autofunction:: ordec.ord1.parser.ord1_to_py
 
 Lark Transformer
 ----------------
 
-.. autoclass:: OrdecTransformer
+.. autoclass:: ordec.ord1.lark_transformer.OrdecTransformer
 
 AST Transformer
 ---------------
 
-.. autoclass:: SchematicModifier
+.. autoclass:: ordec.ord1.ast_transformer.SchematicModifier
 	:members:
-
-Implicit Processing
--------------------
-
-.. autofunction:: preprocess
-.. autofunction:: postprocess
 
 Optimize Position
 -----------------
 
-.. autofunction:: get_pos_with_constraints
+.. autofunction:: ordec.ord1.optimize_position.get_pos_with_constraints

--- a/docs/ref/ord2.rst
+++ b/docs/ref/ord2.rst
@@ -28,9 +28,31 @@ The dotted syntax of ORD, which accesses the parent element, requires having a r
 	# Type 2
 	port xyz(.pos=(1,2))
 
-To demonstrate how the ORD context works and how the conversion from ORD to Python looks, consider the following two examples. Every time a context element (viewgen, port, or a schematic instance) is defined, the element is saved as a local variable `ctx` and a `with` context is opened. The dotted
+Node Statements
+^^^^^^^^^^^^^^^
+
+A **node statement** is the ``A B`` construct that creates and names an element in the current context. There are three types of node statements:
+
+1. **Node class statements** — the type is a Node subclass, e.g., ``LayoutRect x``
+2. **Node instance statements** — the type is a Cell class or instance, e.g., ``Nmos x``
+3. **Node keyword statements** — the type is a built-in keyword, e.g., ``input x``, ``output y``, ``port z``
+
+A node statement may have an optional body (indented block after ``:``) for setting attributes:
+
+.. code-block::
+
+	Nmos pd:
+		.$l = 400n
+
+Or it can be bodyless:
+
+.. code-block::
+
+	Nmos pd
+
+To demonstrate how the ORD context works and how the conversion from ORD to Python looks, consider the following two examples. Every time a node statement (viewgen, port, or a schematic instance) is encountered, the element is saved as a local variable and a `with` context is opened. The dotted
 access is converted into `ctx.root`. If multiple dots are written prior to the identifier, the dots are
-converted to `ctx.root(.parent)*`. Accesses outside the context are still possible through the local variable. An access like this is visible in the for loop of the example. 
+converted to `ctx.root(.parent)*`. Accesses outside the context are still possible through the local variable. An access like this is visible in the for loop of the example.
 
 **ORD code**
 

--- a/docs/ref/ord2.rst
+++ b/docs/ref/ord2.rst
@@ -137,23 +137,50 @@ Every time a node statement (viewgen, port, or a schematic instance) is encounte
 
                 pd = context.add(('pd',), SchemInstanceUnresolved(resolver = lambda **params: Nmos(**params).symbol))
                 with context.Context(pd):
-                    context.root().s.__wire_op__(vss.ref)
-                    context.root().b.__wire_op__(vss.ref)
-                    context.root().d.__wire_op__(y.ref)
+                    context.root().s -- vss.ref
+                    context.root().b -- vss.ref
+                    context.root().d -- y.ref
                     context.root().pos = (3,2)
                     context.root().params.l = R('400n')
 
                 pu = context.add(('pu',), SchemInstanceUnresolved(resolver = lambda **params: Pmos(**params).symbol))
                 with context.Context(pu):
-                    context.root().s.__wire_op__(vdd.ref)
-                    context.root().b.__wire_op__(vdd.ref)
-                    context.root().d.__wire_op__(y.ref)
+                    context.root().s -- vdd.ref
+                    context.root().b -- vdd.ref
+                    context.root().d -- y.ref
                     context.root().pos = (3,8)
                     context.root().params.l = R('400n')
 
                 for instance in pu, pd:
-                    instance.g.__wire_op__(a.ref)
+                    instance.g -- a.ref
                 return context.root().postprocess()
+
+
+Connection Operator ``--``
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``--`` operator connects an instance pin to a net (or vice versa).  It is
+not a dedicated grammar rule but a **pseudo-operator** that relies on standard
+Python parsing: ``a -- b`` is parsed as ``a - (-b)``, combining subtraction
+(``__sub__``) and negation (``__neg__``).  Both operand orders are supported,
+so ``inst.d -- vss`` and ``vss -- inst.d`` are equivalent.
+
+Internally, the negation step returns a ``NegatedWireOperand`` and the
+subtraction step detects this sentinel and calls ``__wire_op__`` to create the
+actual connection node (``SchemInstanceConn`` or
+``SchemInstanceUnresolvedConn``).
+
+.. code-block::
+
+    # These two forms are equivalent:
+    inst.d -- vss      # pin -- net
+    vss -- inst.d      # net -- pin
+
+    # Python sees:  inst.d.__sub__(vss.__neg__())
+    #          or:  vss.__sub__(inst.d.__neg__())  → fallback to _NegatedForWire.__rsub__
+
+Because ``--`` is plain Python arithmetic, it coexists with regular numeric
+expressions: ``2 -- 2`` evaluates to ``4`` as expected.
 
 
 The following summary shows the most important functions and classes of ORD2. Please refer to the Python codebase for more background information and details.

--- a/docs/ref/ord2.rst
+++ b/docs/ref/ord2.rst
@@ -156,6 +156,50 @@ Every time a node statement (viewgen, port, or a schematic instance) is encounte
                 return context.root().postprocess()
 
 
+Anonymous Node Statements
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Prepending a node statement with the ``anonymous`` keyword creates the node
+**without** registering it in the ORDB path system.  The node is still assigned
+to a local Python variable, so it can be referenced in subsequent code.  This
+is useful inside loops or other situations where multiple nodes of the same type
+would cause NPath name clashes:
+
+.. code-block::
+
+    for sd in (.m8.sd[1], .m7.sd[1]):
+        anonymous LayoutRect r:
+            .layer = layers.Metal1
+        ! r.contains(sd.rect)
+
+Without ``anonymous``, writing ``LayoutRect r`` twice (across loop iterations)
+would attempt to register the path name ``r`` twice, causing a conflict.  With
+``anonymous``, each iteration creates a fresh node that is only accessible
+through the local variable ``r``.
+
+Anonymous node statements support all the same forms as regular node statements:
+
+.. code-block::
+
+    # Bodyless
+    anonymous Pin a
+
+    # With body
+    anonymous LayoutRect r:
+        .layer = layers.Metal1
+
+    # Multiple targets (bodyless only)
+    anonymous Pin x, y, z
+
+``anonymous`` is a **soft keyword**: it can still be used as a regular
+identifier (variable name, function name, etc.) in all other contexts.
+
+Internally, ``anonymous LayoutRect r`` compiles to
+``r = context.add_element(None, LayoutRect)``.  When ``add`` receives ``None``
+as the name tuple, it adds the node to the subgraph without creating an NPath
+entry.
+
+
 Connection Operator ``--``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/ref/ord2.rst
+++ b/docs/ref/ord2.rst
@@ -73,43 +73,43 @@ converted to `ctx.root(.parent)*`. Accesses outside the context are still possib
 	class Inv(Cell):
 	    @generate
 	    def symbol(self) -> Symbol:
-	        with OrdContext(root=Symbol(cell=self), parent=self):
+	        with OrdContext(Symbol(cell=self)):
 	            vdd = ctx.add(('vdd',), Pin(pintype=PinType.Inout))
-	            with OrdContext(root=vdd):
+	            with OrdContext(vdd):
 	                ctx.root.align = North
 	            vss = ctx.add(('vss',), Pin(pintype=PinType.Inout))
-	            with OrdContext(root=vss):
+	            with OrdContext(vss):
 	                ctx.root.align = South
 	            a = ctx.add(('a',), Pin(pintype=PinType.In))
-	            with OrdContext(root=a):
+	            with OrdContext(a):
 	                ctx.root.align = West
 	            y = ctx.add(('y',), Pin(pintype=PinType.Out))
-	            with OrdContext(root=y):
+	            with OrdContext(y):
 	                ctx.root.align = East
 	            return ctx.symbol_postprocess()
 
 	    @generate
 	    def schematic(self) -> Schematic:
-	        with OrdContext(root=Schematic(cell=self, symbol=self.symbol), parent=self):
+	        with OrdContext(Schematic(cell=self, symbol=self.symbol)):
 	            vss = ctx.add_port(('vss',))
-	            with OrdContext(root=vss):
+	            with OrdContext(vss):
 	                ctx.root.pos = (2,1)
 	                ctx.root.align = South
 	            vdd = ctx.add_port(('vdd',))
-	            with OrdContext(root=vdd):
+	            with OrdContext(vdd):
 	                ctx.root.pos = (2,13)
 	                ctx.root.align = North
 	            y = ctx.add_port(('y',))
-	            with OrdContext(root=y):
+	            with OrdContext(y):
 	                ctx.root.pos = (9,7)
 	                ctx.root.align = West
 	            a = ctx.add_port(('a',))
-	            with OrdContext(root=a):
+	            with OrdContext(a):
 	                ctx.root.pos = (1,7)
 	                ctx.root.align = East
 	      
 	            pd = ctx.add(('pd',), SchemInstanceUnresolved(resolver = lambda **params: Nmos(**params).symbol))
-	            with OrdContext (root=pd):
+	            with OrdContext(pd):
 	                ctx.root.s.__wire_op__(vss.ref)
 	                ctx.root.b.__wire_op__(vss.ref)
 	                ctx.root.d.__wire_op__(y.ref)
@@ -117,7 +117,7 @@ converted to `ctx.root(.parent)*`. Accesses outside the context are still possib
 	                ctx.root.params.l = R('400n')
 
 	            pu = ctx.add(('pu',), SchemInstanceUnresolved(resolver = lambda **params: Pmos(**params).symbol))
-	            with OrdContext (root=pu):
+	            with OrdContext(pu):
 	                ctx.root.s.__wire_op__(vdd.ref)
 	                ctx.root.b.__wire_op__(vdd.ref)
 	                ctx.root.d.__wire_op__(y.ref)

--- a/docs/ref/ord2.rst
+++ b/docs/ref/ord2.rst
@@ -2,7 +2,7 @@
 ===================================
 
 ORD2 is a programming language that offers full support of Python, plus additional ORD syntax (a *Python-superset*) to improve textual IC design within the ORDeC project. It currently focuses on simplifying the schematic entry phase, while also supporting the usual Python syntax for simulations or layouts. The language revision described in this file is called **ORD2**; it is a reworked version of the former **ORD1**, which had its own grammar and was not based on the Python language. Execution of ORD code results in a one-pass compiler step that transforms the input into context-based Python code. 
-This is only made possible by leveraging the power of the :class:`OrdContext`, which is explained in a later paragraph. The actual ORD grammar is written in Lark. Lark is a well-known and efficient Python parsing framework for grammars in EBNF form. The function call :func:`ord2_to_py` summarizes the necessary function calls for a proper ORD to Python conversion. The conversion is mostly dependent on the :class:`Ord2Transformer` that inherits from :class:`PythonTransformer`. The **PythonTransformer** is capable of transforming any Python code written in ORD back to Python, and the **Ord2Transformer** handles the conversion of the ORD syntax. The following paragraphs will summarize the logic behind the ORD to Python conversion. 
+This is only made possible by leveraging the power of the :class:`Context`, which is explained in a later paragraph. The actual ORD grammar is written in Lark. Lark is a well-known and efficient Python parsing framework for grammars in EBNF form. The function call :func:`ord2_to_py` summarizes the necessary function calls for a proper ORD to Python conversion. The conversion is mostly dependent on the :class:`Ord2Transformer` that inherits from :class:`PythonTransformer`. The **PythonTransformer** is capable of transforming any Python code written in ORD back to Python, and the **Ord2Transformer** handles the conversion of the ORD syntax. The following paragraphs will summarize the logic behind the ORD to Python conversion. 
 
 
 For a practical demonstration, please visit the ORD tutorial :ref:`ord_tutorial` page!
@@ -18,7 +18,7 @@ Mastering the ORD language requires understanding two crucial parts. First, the 
 ORD2 Contexts
 -------------
 
-The dotted syntax of ORD, which accesses the parent element, requires having a reference to the parent element. This structure therefore necessitates that statements and expressions inside a context block have a reference to the parent even after transformation of ORD back to Python. This logic is implemented with the so-called :class:`OrdContext`. It uses the Python `with` environment together with a context variable :class:`ContextVar` to always maintain a reference without requiring information about the parent during transformation. With ORD, we try to keep the transformation logic as simple as possible and leverage the power of Python to supply the necessary constructs during execution.
+The dotted syntax of ORD, which accesses the parent element, requires having a reference to the parent element. This structure therefore necessitates that statements and expressions inside a context block have a reference to the parent even after transformation of ORD back to Python. This logic is implemented with the so-called :class:`Context`. It uses the Python `with` environment together with a context variable :class:`ContextVar` to always maintain a reference without requiring information about the parent during transformation. With ORD, we try to keep the transformation logic as simple as possible and leverage the power of Python to supply the necessary constructs during execution.
 
 .. code-block::
 
@@ -50,9 +50,7 @@ Or it can be bodyless:
 
     Nmos pd
 
-To demonstrate how the ORD context works and how the conversion from ORD to Python looks, consider the following two examples. Every time a node statement (viewgen, port, or a schematic instance) is encountered, the element is saved as a local variable and a `with` context is opened. The dotted
-access is converted into `ctx.root`. If multiple dots are written prior to the identifier, the dots are
-converted to `ctx.root(.parent)*`. Accesses outside the context are still possible through the local variable. An access like this is visible in the for loop of the example.
+To demonstrate how the ORD context works and how the conversion from ORD to Python looks, consider the following example:
 
 **ORD code**
 
@@ -87,68 +85,75 @@ converted to `ctx.root(.parent)*`. Accesses outside the context are still possib
             for instance in pu, pd:
                 instance.g -- a
 
-
 **Compiled Python code**
 
+.. note::
+
+    The actual compiled code uses ``__ord_context__`` instead of ``context`` to avoid name collisions with user code. Here we use ``import ordec.ord2.context as context`` for readability.
+
+Every time a node statement (viewgen, port, or a schematic instance) is encountered, the element is saved as a local variable and a ``with`` context is opened. The dotted access is converted into ``context.root()``. If multiple dots are written prior to the identifier, the dots are converted to ``context.root()(.parent)*``. Accesses outside the context are still possible through the local variable. An access like this is visible in the for loop of the example.
+
 .. code-block:: python
+
+    import ordec.ord2.context as context
 
     class Inv(Cell):
         @generate
         def symbol(self) -> Symbol:
-            with OrdContext(Symbol(cell=self)):
-                vdd = ctx.add(('vdd',), Pin(pintype=PinType.Inout))
-                with OrdContext(vdd):
-                    ctx.root.align = North
-                vss = ctx.add(('vss',), Pin(pintype=PinType.Inout))
-                with OrdContext(vss):
-                    ctx.root.align = South
-                a = ctx.add(('a',), Pin(pintype=PinType.In))
-                with OrdContext(a):
-                    ctx.root.align = West
-                y = ctx.add(('y',), Pin(pintype=PinType.Out))
-                with OrdContext(y):
-                    ctx.root.align = East
-                return ctx.symbol_postprocess()
+            with context.Context(Symbol(cell=self)):
+                vdd = context.add(('vdd',), Pin(pintype=PinType.Inout))
+                with context.Context(vdd):
+                    context.root().align = North
+                vss = context.add(('vss',), Pin(pintype=PinType.Inout))
+                with context.Context(vss):
+                    context.root().align = South
+                a = context.add(('a',), Pin(pintype=PinType.In))
+                with context.Context(a):
+                    context.root().align = West
+                y = context.add(('y',), Pin(pintype=PinType.Out))
+                with context.Context(y):
+                    context.root().align = East
+                return context.root().postprocess()
 
         @generate
         def schematic(self) -> Schematic:
-            with OrdContext(Schematic(cell=self, symbol=self.symbol)):
-                vss = ctx.add_port(('vss',))
-                with OrdContext(vss):
-                    ctx.root.pos = (2,1)
-                    ctx.root.align = South
-                vdd = ctx.add_port(('vdd',))
-                with OrdContext(vdd):
-                    ctx.root.pos = (2,13)
-                    ctx.root.align = North
-                y = ctx.add_port(('y',))
-                with OrdContext(y):
-                    ctx.root.pos = (9,7)
-                    ctx.root.align = West
-                a = ctx.add_port(('a',))
-                with OrdContext(a):
-                    ctx.root.pos = (1,7)
-                    ctx.root.align = East
-          
-                pd = ctx.add(('pd',), SchemInstanceUnresolved(resolver = lambda **params: Nmos(**params).symbol))
-                with OrdContext(pd):
-                    ctx.root.s.__wire_op__(vss.ref)
-                    ctx.root.b.__wire_op__(vss.ref)
-                    ctx.root.d.__wire_op__(y.ref)
-                    ctx.root.pos = (3,2)
-                    ctx.root.params.l = R('400n')
+            with context.Context(Schematic(cell=self, symbol=self.symbol)):
+                vss = context.add_port(('vss',))
+                with context.Context(vss):
+                    context.root().pos = (2,1)
+                    context.root().align = South
+                vdd = context.add_port(('vdd',))
+                with context.Context(vdd):
+                    context.root().pos = (2,13)
+                    context.root().align = North
+                y = context.add_port(('y',))
+                with context.Context(y):
+                    context.root().pos = (9,7)
+                    context.root().align = West
+                a = context.add_port(('a',))
+                with context.Context(a):
+                    context.root().pos = (1,7)
+                    context.root().align = East
 
-                pu = ctx.add(('pu',), SchemInstanceUnresolved(resolver = lambda **params: Pmos(**params).symbol))
-                with OrdContext(pu):
-                    ctx.root.s.__wire_op__(vdd.ref)
-                    ctx.root.b.__wire_op__(vdd.ref)
-                    ctx.root.d.__wire_op__(y.ref)
-                    ctx.root.pos = (3,8)
-                    ctx.root.params.l = R('400n')
-                    
+                pd = context.add(('pd',), SchemInstanceUnresolved(resolver = lambda **params: Nmos(**params).symbol))
+                with context.Context(pd):
+                    context.root().s.__wire_op__(vss.ref)
+                    context.root().b.__wire_op__(vss.ref)
+                    context.root().d.__wire_op__(y.ref)
+                    context.root().pos = (3,2)
+                    context.root().params.l = R('400n')
+
+                pu = context.add(('pu',), SchemInstanceUnresolved(resolver = lambda **params: Pmos(**params).symbol))
+                with context.Context(pu):
+                    context.root().s.__wire_op__(vdd.ref)
+                    context.root().b.__wire_op__(vdd.ref)
+                    context.root().d.__wire_op__(y.ref)
+                    context.root().pos = (3,8)
+                    context.root().params.l = R('400n')
+
                 for instance in pu, pd:
                     instance.g.__wire_op__(a.ref)
-                return ctx.schematic_postprocess()
+                return context.root().postprocess()
 
 
 The following summary shows the most important functions and classes of ORD2. Please refer to the Python codebase for more background information and details.
@@ -162,10 +167,10 @@ Parser
 .. autofunction:: ordec.ord2.parser.parse_with_errors
 .. autofunction:: ordec.ord2.parser.ord2_to_py
 
-OrdContext
-----------
+Context
+-------
 
-.. autoclass:: ordec.ord2.context.OrdContext
+.. autoclass:: ordec.ord2.context.Context
     :members:
 
 OrdTransformer

--- a/docs/ref/ord2.rst
+++ b/docs/ref/ord2.rst
@@ -22,11 +22,11 @@ The dotted syntax of ORD, which accesses the parent element, requires having a r
 
 .. code-block::
 
-	# Type 1
-	port xyz:
-		.pos=(1,2)
-	# Type 2
-	port xyz(.pos=(1,2))
+    # Type 1
+    port xyz:
+        .pos=(1,2)
+    # Type 2
+    port xyz(.pos=(1,2))
 
 Node Statements
 ^^^^^^^^^^^^^^^
@@ -41,14 +41,14 @@ A node statement may have an optional body (indented block after ``:``) for sett
 
 .. code-block::
 
-	Nmos pd:
-		.$l = 400n
+    Nmos pd:
+        .$l = 400n
 
 Or it can be bodyless:
 
 .. code-block::
 
-	Nmos pd
+    Nmos pd
 
 To demonstrate how the ORD context works and how the conversion from ORD to Python looks, consider the following two examples. Every time a node statement (viewgen, port, or a schematic instance) is encountered, the element is saved as a local variable and a `with` context is opened. The dotted
 access is converted into `ctx.root`. If multiple dots are written prior to the identifier, the dots are
@@ -58,97 +58,97 @@ converted to `ctx.root(.parent)*`. Accesses outside the context are still possib
 
 .. code-block:: 
 
-	cell Inv:
-	    viewgen symbol:
-	        inout vdd(.align=North)
-	        inout vss(.align=South)
-	        input a(.align=West)
-	        output y(.align=East)
+    cell Inv:
+        viewgen symbol:
+            inout vdd(.align=North)
+            inout vss(.align=South)
+            input a(.align=West)
+            output y(.align=East)
 
-	    viewgen schematic:
-	        port vdd(.pos=(2,13); .align=North)
-	        port vss(.pos=(2,1); .align=South)
-	        port y (.pos=(9,7); .align=West)
-	        port a (.pos=(1,7); .align=East)
+        viewgen schematic:
+            port vdd(.pos=(2,13); .align=North)
+            port vss(.pos=(2,1); .align=South)
+            port y (.pos=(9,7); .align=West)
+            port a (.pos=(1,7); .align=East)
 
-	        Nmos pd:
-	            .s -- vss
-	            .b -- vss
-	            .d -- y
-	            .pos = (3,2)
-	            .$l = 400n
-	        Pmos pu:
-	            .s -- vdd
-	            .b -- vdd
-	            .d -- y
-	            .pos = (3,8)
-	            .$l = 400n
+            Nmos pd:
+                .s -- vss
+                .b -- vss
+                .d -- y
+                .pos = (3,2)
+                .$l = 400n
+            Pmos pu:
+                .s -- vdd
+                .b -- vdd
+                .d -- y
+                .pos = (3,8)
+                .$l = 400n
 
-	        for instance in pu, pd:
-	            instance.g -- a
+            for instance in pu, pd:
+                instance.g -- a
 
 
 **Compiled Python code**
 
 .. code-block:: python
 
-	class Inv(Cell):
-	    @generate
-	    def symbol(self) -> Symbol:
-	        with OrdContext(Symbol(cell=self)):
-	            vdd = ctx.add(('vdd',), Pin(pintype=PinType.Inout))
-	            with OrdContext(vdd):
-	                ctx.root.align = North
-	            vss = ctx.add(('vss',), Pin(pintype=PinType.Inout))
-	            with OrdContext(vss):
-	                ctx.root.align = South
-	            a = ctx.add(('a',), Pin(pintype=PinType.In))
-	            with OrdContext(a):
-	                ctx.root.align = West
-	            y = ctx.add(('y',), Pin(pintype=PinType.Out))
-	            with OrdContext(y):
-	                ctx.root.align = East
-	            return ctx.symbol_postprocess()
+    class Inv(Cell):
+        @generate
+        def symbol(self) -> Symbol:
+            with OrdContext(Symbol(cell=self)):
+                vdd = ctx.add(('vdd',), Pin(pintype=PinType.Inout))
+                with OrdContext(vdd):
+                    ctx.root.align = North
+                vss = ctx.add(('vss',), Pin(pintype=PinType.Inout))
+                with OrdContext(vss):
+                    ctx.root.align = South
+                a = ctx.add(('a',), Pin(pintype=PinType.In))
+                with OrdContext(a):
+                    ctx.root.align = West
+                y = ctx.add(('y',), Pin(pintype=PinType.Out))
+                with OrdContext(y):
+                    ctx.root.align = East
+                return ctx.symbol_postprocess()
 
-	    @generate
-	    def schematic(self) -> Schematic:
-	        with OrdContext(Schematic(cell=self, symbol=self.symbol)):
-	            vss = ctx.add_port(('vss',))
-	            with OrdContext(vss):
-	                ctx.root.pos = (2,1)
-	                ctx.root.align = South
-	            vdd = ctx.add_port(('vdd',))
-	            with OrdContext(vdd):
-	                ctx.root.pos = (2,13)
-	                ctx.root.align = North
-	            y = ctx.add_port(('y',))
-	            with OrdContext(y):
-	                ctx.root.pos = (9,7)
-	                ctx.root.align = West
-	            a = ctx.add_port(('a',))
-	            with OrdContext(a):
-	                ctx.root.pos = (1,7)
-	                ctx.root.align = East
-	      
-	            pd = ctx.add(('pd',), SchemInstanceUnresolved(resolver = lambda **params: Nmos(**params).symbol))
-	            with OrdContext(pd):
-	                ctx.root.s.__wire_op__(vss.ref)
-	                ctx.root.b.__wire_op__(vss.ref)
-	                ctx.root.d.__wire_op__(y.ref)
-	                ctx.root.pos = (3,2)
-	                ctx.root.params.l = R('400n')
+        @generate
+        def schematic(self) -> Schematic:
+            with OrdContext(Schematic(cell=self, symbol=self.symbol)):
+                vss = ctx.add_port(('vss',))
+                with OrdContext(vss):
+                    ctx.root.pos = (2,1)
+                    ctx.root.align = South
+                vdd = ctx.add_port(('vdd',))
+                with OrdContext(vdd):
+                    ctx.root.pos = (2,13)
+                    ctx.root.align = North
+                y = ctx.add_port(('y',))
+                with OrdContext(y):
+                    ctx.root.pos = (9,7)
+                    ctx.root.align = West
+                a = ctx.add_port(('a',))
+                with OrdContext(a):
+                    ctx.root.pos = (1,7)
+                    ctx.root.align = East
+          
+                pd = ctx.add(('pd',), SchemInstanceUnresolved(resolver = lambda **params: Nmos(**params).symbol))
+                with OrdContext(pd):
+                    ctx.root.s.__wire_op__(vss.ref)
+                    ctx.root.b.__wire_op__(vss.ref)
+                    ctx.root.d.__wire_op__(y.ref)
+                    ctx.root.pos = (3,2)
+                    ctx.root.params.l = R('400n')
 
-	            pu = ctx.add(('pu',), SchemInstanceUnresolved(resolver = lambda **params: Pmos(**params).symbol))
-	            with OrdContext(pu):
-	                ctx.root.s.__wire_op__(vdd.ref)
-	                ctx.root.b.__wire_op__(vdd.ref)
-	                ctx.root.d.__wire_op__(y.ref)
-	                ctx.root.pos = (3,8)
-	                ctx.root.params.l = R('400n')
-	                
-	            for instance in pu, pd:
-	                instance.g.__wire_op__(a.ref)
-	            return ctx.schematic_postprocess()
+                pu = ctx.add(('pu',), SchemInstanceUnresolved(resolver = lambda **params: Pmos(**params).symbol))
+                with OrdContext(pu):
+                    ctx.root.s.__wire_op__(vdd.ref)
+                    ctx.root.b.__wire_op__(vdd.ref)
+                    ctx.root.d.__wire_op__(y.ref)
+                    ctx.root.pos = (3,8)
+                    ctx.root.params.l = R('400n')
+                    
+                for instance in pu, pd:
+                    instance.g.__wire_op__(a.ref)
+                return ctx.schematic_postprocess()
 
 
 The following summary shows the most important functions and classes of ORD2. Please refer to the Python codebase for more background information and details.
@@ -159,23 +159,23 @@ Parser
 
 .. automodule:: ordec.ord2
 
-.. autofunction:: parse_with_errors
-.. autofunction:: ord2_to_py
+.. autofunction:: ordec.ord2.parser.parse_with_errors
+.. autofunction:: ordec.ord2.parser.ord2_to_py
 
 OrdContext
 ----------
 
-.. autoclass:: OrdContext
-	:members: 
+.. autoclass:: ordec.ord2.context.OrdContext
+    :members:
 
 OrdTransformer
 --------------
 
-.. autoclass:: Ord2Transformer
-	:members:
-	:show-inheritance:
+.. autoclass:: ordec.ord2.ord2_transformer.Ord2Transformer
+    :members:
+    :show-inheritance:
 
 PythonTransformer
 -----------------
 
-.. autoclass:: PythonTransformer
+.. autoclass:: ordec.ord2.python_transformer.PythonTransformer

--- a/ordec/core/context.py
+++ b/ordec/core/context.py
@@ -1,10 +1,39 @@
 # SPDX-FileCopyrightText: 2026 ORDeC contributors
 # SPDX-License-Identifier: Apache-2.0
 
+# standard imports
+from contextvars import ContextVar, Token
+
+
+_ctx_var = ContextVar("ctx", default=None)
+_view_ctx_var = ContextVar("view_ctx", default=None)
+
+
+class NodeContext:
+    """
+    Class which represents the context where a specific
+    ORDB element is alive and accessible via relative
+    accesses (dotted notation)
+    """
+
+    def __init__(self, root):
+        self.root = root
+
+    def __enter__(self):
+        """Enter context, set context variable and save parent"""
+        self._token = _ctx_var.set(self)
+        old = self._token.old_value
+        self.parent = old if old is not Token.MISSING else None
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Exit context and reset context variable"""
+        _ctx_var.reset(self._token)
+
 
 class ViewContext:
     """
-    Base view context. Subclasses override to add capabilities(e.g.constraint
+    Base view context. Subclasses override to add capabilities (e.g. constraint
     solving).
 
     ViewContext is a separate context from the NodeContext but its __enter__
@@ -15,14 +44,12 @@ class ViewContext:
         self.root = root
 
     def __enter__(self):
-        from ordec.ord2.context import _view_ctx_var
         self._node_ctx = self.root.ctx()
         self._node_ctx.__enter__()
         self._token = _view_ctx_var.set(self)
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        from ordec.ord2.context import _view_ctx_var
         _view_ctx_var.reset(self._token)
         self._node_ctx.__exit__(exc_type, exc_val, exc_tb)
 

--- a/ordec/core/ordb.py
+++ b/ordec/core/ordb.py
@@ -937,8 +937,8 @@ class Node(tuple, metaclass=NodeMeta, build_node=False):
 
     def ctx(self):
         """Return a Context for use as a context manager: ``with node.ctx(): ...``"""
-        from ordec.ord2.context import Context
-        return Context(self)
+        from ordec.ord2.context import NodeContext
+        return NodeContext(self)
 
     def __copy__(self) -> 'Self':
         return self # tuple is immutable (at shallow level), thus no copy needed.

--- a/ordec/core/ordb.py
+++ b/ordec/core/ordb.py
@@ -935,6 +935,11 @@ class Node(tuple, metaclass=NodeMeta, build_node=False):
         """Returns whether the selected subgraph is mutable."""
         raise TypeError("n.mutable is unavailable where n is not subclass of MutableNode or FrozenNode.")
 
+    def ctx(self):
+        """Return a Context for use as a context manager: ``with node.ctx(): ...``"""
+        from ordec.ord2.context import Context
+        return Context(self)
+
     def __copy__(self) -> 'Self':
         return self # tuple is immutable (at shallow level), thus no copy needed.
 

--- a/ordec/core/ordb.py
+++ b/ordec/core/ordb.py
@@ -937,7 +937,7 @@ class Node(tuple, metaclass=NodeMeta, build_node=False):
 
     def ctx(self):
         """Return a Context for use as a context manager: ``with node.ctx(): ...``"""
-        from ordec.ord2.context import NodeContext
+        from .context import NodeContext
         return NodeContext(self)
 
     def __copy__(self) -> 'Self':

--- a/ordec/core/schema.py
+++ b/ordec/core/schema.py
@@ -344,6 +344,25 @@ class Schematic(SubgraphRoot):
         from ..render import render
         return render(self).webdata()
 
+class NegatedWireOperand:
+    """Wrapper enabling the ``--`` pseudo-operator for schematic wiring.
+
+    The ``--`` connection operator (e.g. ``inst.d -- vss``) is not a dedicated
+    grammar rule but a combination of Python's subtraction and negation:
+    ``a -- b`` is parsed as ``a.__sub__(b.__neg__())``.  Both operand orders
+    are supported (pin -- net *and* net -- pin) so the operator is commutative.
+    """
+    __slots__ = ('wrapped',)
+    def __init__(self, wrapped):
+        self.wrapped = wrapped
+
+    def __rsub__(self, other):
+        # Supports net -- pin (i.e. net - (-pin))
+        wire_op = getattr(self.wrapped, '__wire_op__', None)
+        if wire_op is not None:
+            return wire_op(other)
+        return NotImplemented
+
 @public
 class Net(Node):
     in_subgraphs = [Schematic]
@@ -351,6 +370,9 @@ class Net(Node):
     auto_wire = Attr(bool, default=True) #: Controls whether the Net is auto-wired
 
     pin_idx = Index(pin)
+
+    def __neg__(self):
+        return NegatedWireOperand(self)
 
     @property
     def port(self):
@@ -419,9 +441,17 @@ class SchemInstanceSubcursor(tuple):
         """Support indexing into pin hierarchies (e.g., inst['d'][0].pos)."""
         return SchemInstanceSubcursor((self.inst(), self.node()[key]))
 
+    def __neg__(self):
+        return NegatedWireOperand(self)
+
     def __wire_op__(self, here):
         conn = self.inst() % SchemInstanceConn(here=here, there=self.node())
         return conn
+
+    def __sub__(self, other):
+        if isinstance(other, NegatedWireOperand):
+            return self.__wire_op__(other.wrapped)
+        return NotImplemented
 
     def __getattr__(self, name):
         inner_ret = getattr(self.node(), name)
@@ -527,10 +557,18 @@ class SchemInstanceUnresolvedSubcursor(tuple):
         # self[1:], but without calling SchemInstanceUnresolvedCursor.__getitem__
         return tuple.__getitem__(self, slice(1,None))
 
+    def __neg__(self):
+        return NegatedWireOperand(self)
+
     def __wire_op__(self, here):
         conn = self.instanceunresolved % \
             SchemInstanceUnresolvedConn(here=here, there=self.instancepath)
         return conn
+
+    def __sub__(self, other):
+        if isinstance(other, NegatedWireOperand):
+            return self.__wire_op__(other.wrapped)
+        return NotImplemented
     
 @public
 class SchemInstanceUnresolved(Node):

--- a/ordec/core/schema.py
+++ b/ordec/core/schema.py
@@ -416,6 +416,10 @@ class SchemInstanceSubcursor(tuple):
         """Support indexing into pin hierarchies (e.g., inst['d'][0].pos)."""
         return SchemInstanceSubcursor((self.inst(), self.node()[key]))
 
+    def __wire_op__(self, here):
+        conn = self.inst() % SchemInstanceConn(here=here, there=self.node())
+        return conn
+
     def __getattr__(self, name):
         inner_ret = getattr(self.node(), name)
         if isinstance(inner_ret, (Rect4R, Vec2R)):

--- a/ordec/core/schema.py
+++ b/ordec/core/schema.py
@@ -991,7 +991,7 @@ class Layout(SubgraphRoot):
 
     cell = Attr(Cell)
     symbol = SubgraphRef(Symbol) #: All LayoutPins in this subgraph reference this symbol.
-    ref_layers = SubgraphRef(LayerStack, optional=False) #: All .layer attributes of nodes in this subgraph reference this LayerStack.
+    ref_layers = SubgraphRef(LayerStack) #: All .layer attributes of nodes in this subgraph reference this LayerStack.
 
     def postprocess(self):
         return self

--- a/ordec/core/schema.py
+++ b/ordec/core/schema.py
@@ -1010,7 +1010,7 @@ class LayoutLabel(Node):
     """
     in_subgraphs = [Layout]
 
-    layer = ExternalRef(Layer, of_subgraph=lambda c: c.root.ref_layers, optional=False)
+    layer = ExternalRef(Layer, of_subgraph=lambda c: c.root.ref_layers)
     pos = ConstrainableAttr(Vec2I, factory=coerce_tuple(Vec2I, 2),
         placeholder=Vec2LinearTerm)
     text = Attr(str)
@@ -1027,7 +1027,7 @@ class LayoutPoly(GenericPolyI, MixinClosedPolygon):
     """
     in_subgraphs = [Layout]
 
-    layer = ExternalRef(Layer, of_subgraph=lambda c: c.root.ref_layers, optional=False)
+    layer = ExternalRef(Layer, of_subgraph=lambda c: c.root.ref_layers)
 
 class LayoutPathBase(GenericPolyI):
     endtype = Attr(PathEndType, default=PathEndType.Flush, optional=False)
@@ -1071,7 +1071,7 @@ class LayoutRectPoly(GenericPolyI):
     in_subgraphs = [Layout]
 
     start_direction = Attr(RectDirection, default=RectDirection.Horizontal)
-    layer = ExternalRef(Layer, of_subgraph=lambda c: c.root.ref_layers, optional=False)
+    layer = ExternalRef(Layer, of_subgraph=lambda c: c.root.ref_layers)
 
 @public
 class LayoutRectPath(LayoutPathBase):
@@ -1094,7 +1094,7 @@ class LayoutRect(Node):
     """Layout rectangle."""
     in_subgraphs = [Layout]
 
-    layer = ExternalRef(Layer, of_subgraph=lambda c: c.root.ref_layers, optional=False)
+    layer = ExternalRef(Layer, of_subgraph=lambda c: c.root.ref_layers)
     rect = ConstrainableAttr(Rect4I, factory=coerce_tuple(Rect4I, 4),
         placeholder=Rect4LinearTerm)
 

--- a/ordec/core/schema.py
+++ b/ordec/core/schema.py
@@ -13,6 +13,7 @@ from .geoprim import *
 from .ordb import *
 from .cell import Cell
 from .constraints import *
+from .viewctx import ViewContext, LayoutViewContext
 from .simarray import SimArray
 
 # Enums
@@ -132,6 +133,7 @@ def coerce_tuple(target_type, tuple_length):
 @public
 class Symbol(SubgraphRoot):
     """A symbol of an individual cell."""
+    view_context = ViewContext
     outline = Attr(Rect4R, factory=coerce_tuple(Rect4R, 4))
     caption = Attr(str)
     cell = Attr(Cell)
@@ -306,6 +308,7 @@ class SymbolArc(Node):
 @public
 class Schematic(SubgraphRoot):
     """A schematic of an individual cell."""
+    view_context = ViewContext
     symbol = SubgraphRef(Symbol)
     outline = Attr(Rect4R, factory=coerce_tuple(Rect4R, 4))
     cell = Attr(Cell)
@@ -1013,6 +1016,7 @@ class Layout(SubgraphRoot):
     Subgraph containing integrated circuit layout elements, possibly including
     hierarchical instances of other Layout subgraphs.
     """
+    view_context = LayoutViewContext
 
     cell = Attr(Cell)
     symbol = SubgraphRef(Symbol) #: All LayoutPins in this subgraph reference this symbol.

--- a/ordec/core/schema.py
+++ b/ordec/core/schema.py
@@ -70,6 +70,27 @@ class SchemErrorType(Enum):
     def __repr__(self):
         return f'{self.__class__.__name__}.{self.name}'
 
+# Attribute proxy
+# ---------------
+
+class AttrProxy:
+    """Descriptor that delegates reads to a sub-attribute of another attribute.
+
+    Carries metadata (source_attr, name) so that LayoutInstanceSubcursor
+    can retrieve the full source object for coordinate transformation
+    before extracting the sub-attribute.
+    """
+    def __init__(self, source_attr, name):
+        self.source_attr = source_attr
+        self.name = name
+
+    def __get__(self, obj, objtype=None):
+        if obj is None:
+            return self
+        return getattr(getattr(obj, self.source_attr), self.name)
+
+def _rect_proxy(name):
+    return AttrProxy('rect', name)
 
 # NamedTuples
 # -----------
@@ -1098,6 +1119,33 @@ class LayoutRect(Node):
     rect = ConstrainableAttr(Rect4I, factory=coerce_tuple(Rect4I, 4),
         placeholder=Rect4LinearTerm)
 
+    # Delegate Rect4Generic properties:
+    lx = _rect_proxy('lx')
+    ly = _rect_proxy('ly')
+    ux = _rect_proxy('ux')
+    uy = _rect_proxy('uy')
+    cx = _rect_proxy('cx')
+    cy = _rect_proxy('cy')
+    width = _rect_proxy('width')
+    height = _rect_proxy('height')
+    size = _rect_proxy('size')
+    center = _rect_proxy('center')
+    north = _rect_proxy('north')
+    south = _rect_proxy('south')
+    east = _rect_proxy('east')
+    west = _rect_proxy('west')
+    northwest = _rect_proxy('northwest')
+    northeast = _rect_proxy('northeast')
+    southwest = _rect_proxy('southwest')
+    southeast = _rect_proxy('southeast')
+    x_extent = _rect_proxy('x_extent')
+    y_extent = _rect_proxy('y_extent')
+
+    def contains(self, other):
+        if isinstance(other, LayoutRect):
+            return self.rect.contains(other.rect)
+        return self.rect.contains(other)
+
 class LayoutInstanceSubcursor(tuple):
     """Cursor to go through layout instances, transforming coordinates."""
     def __repr__(self):
@@ -1200,9 +1248,15 @@ class LayoutInstanceSubcursor(tuple):
             return self.__getattr('parent')
 
     def __getattr__(self, name):
-        inner_ret = getattr(self.node(), name)
+        node = self.node()
         if self.needs_instancearray_index():
             raise AttributeError("Missing index [] for LayoutInstanceArray.")
+        # Detect AttrProxy descriptors: delegate through self so transformation
+        # happens automatically via the existing __getattr__ path.
+        descriptor = getattr(type(node), name, None)
+        if isinstance(descriptor, AttrProxy):
+            return getattr(getattr(self, descriptor.source_attr), descriptor.name)
+        inner_ret = getattr(node, name)
         if isinstance(inner_ret, (Rect4I, Vec2I)):
             return self.transform_stack() * inner_ret
         elif isinstance(inner_ret, Node):

--- a/ordec/core/schema.py
+++ b/ordec/core/schema.py
@@ -13,7 +13,7 @@ from .geoprim import *
 from .ordb import *
 from .cell import Cell
 from .constraints import *
-from .viewctx import ViewContext, LayoutViewContext
+from .context import ViewContext, LayoutViewContext
 from .simarray import SimArray
 
 # Enums

--- a/ordec/core/viewctx.py
+++ b/ordec/core/viewctx.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2026 ORDeC contributors
+# SPDX-License-Identifier: Apache-2.0
+
+
+class ViewContext:
+    """
+    Base view context. Subclasses override to add capabilities(e.g.constraint
+    solving).
+
+    ViewContext is a separate context from the NodeContext but its __enter__
+    and __exit__ methods also automatically enter and exit a corresponding
+    NodeContext.
+    """
+    def __init__(self, root):
+        self.root = root
+
+    def __enter__(self):
+        from ordec.ord2.context import _view_ctx_var
+        self._node_ctx = self.root.ctx()
+        self._node_ctx.__enter__()
+        self._token = _view_ctx_var.set(self)
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        from ordec.ord2.context import _view_ctx_var
+        _view_ctx_var.reset(self._token)
+        self._node_ctx.__exit__(exc_type, exc_val, exc_tb)
+
+    def constrain(self, constraint):
+        raise TypeError(f"Constraints not supported in {type(self.root).__name__} views.")
+
+
+class LayoutViewContext(ViewContext):
+    def __enter__(self):
+        super().__enter__()
+        from .constraints import Solver
+        self.solver = Solver(self.root)
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if exc_type is None:
+            self.solver.solve()
+        super().__exit__(exc_type, exc_val, exc_tb)
+
+    def constrain(self, constraint):
+        self.solver.constrain(constraint)

--- a/ordec/language.py
+++ b/ordec/language.py
@@ -21,7 +21,12 @@ def prepare_ord_globals(g: dict):
 def compile_ord(source_data: str, g: dict, filename: str = "<string>"):
     """Compile ORD source, prepare globals, return compiled code object."""
     prepare_ord_globals(g)
-    module = ord_to_py(source_data)
+    try:
+        module = ord_to_py(source_data)
+    except SyntaxError as e:
+        if e.filename is None:
+            e.msg = f"In {filename}:\n{e.msg}"
+        raise
     g["__ord_py_source__"] = ast.unparse(module)
     return compile(module, filename, "exec")
 

--- a/ordec/layout/makevias.py
+++ b/ordec/layout/makevias.py
@@ -52,4 +52,4 @@ def makevias(layout: Layout,
             y = y_start + (size.y+spacing.y)*row
             via = layout % LayoutRect(layer=layer, rect=Rect4I(x, y, x+size.x, y+size.y))
 
-    return Rect4I(x_start, y_start, via.rect.ux, via.rect.uy)
+    return Rect4I(x_start, y_start, via.ux, via.uy)

--- a/ordec/layout/srouter.py
+++ b/ordec/layout/srouter.py
@@ -8,8 +8,20 @@ class SRouterException(Exception):
 
 class SRouter:
     """Stack router"""
-    def __init__(self, layout: Layout, solver: Solver,
-        routing_spec: RoutingSpec):
+    def __init__(self, routing_spec: RoutingSpec,
+        layout: Layout = None, solver: Solver = None):
+        """Create a stack router.
+
+        If layout or solver are not provided, they are obtained from the
+        current LayoutViewContext.
+        """
+        if layout is None or solver is None:
+            from ordec.ord2.context import view_context
+            vc = view_context()
+            if layout is None:
+                layout = vc.root
+            if solver is None:
+                solver = vc.solver
         self.layout = layout
         self.solver = solver
         self.routing_spec = routing_spec

--- a/ordec/layout/srouter.py
+++ b/ordec/layout/srouter.py
@@ -87,8 +87,8 @@ class SRouter:
                     raise SRouterException("Cannot draw via-like rect on layer wher"
                         " route_via_width or route_via_height is None.")
                 r = self.layout % LayoutRect(layer=self.cur_layer)
-                self.solver.constrain(r.rect.center == self.cur_pos)
-                self.solver.constrain(r.rect.size ==
+                self.solver.constrain(r.center == self.cur_pos)
+                self.solver.constrain(r.size ==
                     (rsl.route_via_width, rsl.route_via_height))
         else:
             self.path = None

--- a/ordec/lib/examples/vco_pseudodiff.ord
+++ b/ordec/lib/examples/vco_pseudodiff.ord
@@ -73,14 +73,8 @@ cell VcoHalfStage:
             ! .poly[0].cx == m1.poly[0].cx
             ! .activ.uy + 1500 == m1.activ.ly
 
-        nmos m3
-        pmos m4
-
-        nmos m5
-        pmos m6
-
-        nmos m7
-        pmos m8
+        nmos m3, m5, m7
+        pmos m4, m6, m8
 
         grid = ((m2, m1), (m3, m4), (m5, m6), (m7, m8))
 

--- a/ordec/lib/examples/vco_pseudodiff.ord
+++ b/ordec/lib/examples/vco_pseudodiff.ord
@@ -67,8 +67,11 @@ cell VcoHalfStage:
         pmos = self.schematic.m1.symbol.cell
         nmos = self.schematic.m2.symbol.cell
 
-        pmos m1
-        nmos m2
+        pmos m1:
+            ! .pos == (0, 0)
+        nmos m2:
+            ! .poly[0].rect.cx == m1.poly[0].rect.cx
+            ! .activ.rect.uy + 1500 == m1.activ.rect.ly
 
         nmos m3
         pmos m4
@@ -79,12 +82,7 @@ cell VcoHalfStage:
         nmos m7
         pmos m8
 
-        grid = ((.m2, .m1), (.m3, .m4), (.m5, .m6), (.m7, .m8))
-
-        ! .m1.pos == (0, 0)
-        ! .m1.poly[0].rect.cx == .m2.poly[0].rect.cx
-
-        ! .m1.activ.rect.ly == .m2.activ.rect.uy + 1500
+        grid = ((m2, m1), (m3, m4), (m5, m6), (m7, m8))
 
         for left, right in pairwise(grid):
             left_nmos, left_pmos = left
@@ -94,9 +92,10 @@ cell VcoHalfStage:
 
         path poly
         for idx, insts in enumerate(grid):
-            LayoutRect poly[idx]: .layer=layers.GatPoly
-            for inst in insts:
-                ! poly[idx].rect.contains(inst.poly[0].rect)
+            LayoutRect poly[idx]: 
+                .layer=layers.GatPoly
+                for inst in insts:
+                    ! .rect.contains(inst.poly[0].rect)
 
         polycont_spec = (
             ('south', 'west', 'rst_n'),
@@ -110,51 +109,55 @@ cell VcoHalfStage:
             polyext = . % LayoutRect(layer=layers.GatPoly)
             ! polyext.rect.size == (300, 300)
             if horiz_spec == 'west':
-                ! polyext.rect.ux == .poly[idx].rect.ux
+                ! polyext.rect.ux == poly[idx].rect.ux
             else:
                 assert horiz_spec == 'east'
-                ! polyext.rect.lx == .poly[idx].rect.lx
+                ! polyext.rect.lx == poly[idx].rect.lx
             if vert_spec == 'north':
-                ! polyext.rect.uy == .m1.activ.rect.ly - 200
+                ! polyext.rect.uy == m1.activ.rect.ly - 200
             else:
                 assert vert_spec == 'south'
-                ! polyext.rect.ly == .m2.activ.rect.uy + 200
+                ! polyext.rect.ly == m2.activ.rect.uy + 200
             LayoutRect polycont[idx]: .layer=layers.Cont
             ! polycont[idx].rect.size == (160, 160)
             ! polycont[idx].rect.center == polyext.rect.center
             if add_m1:
                 setattr(., add_m1, LayoutRect(layer=layers.Metal1))
-                m1 = getattr(., add_m1)
-                ! m1.rect.cx == .polycont[idx].rect.cx + (-25 if horiz_spec=='west' else 25)
-                ! m1.rect.width == 210
-                ! m1.rect.ly == .m2.sd[0].rect.uy + 200
-                ! m1.rect.height == 600
+                m1_ = getattr(., add_m1)
+                ! m1_.rect.cx == .polycont[idx].rect.cx + (-25 if horiz_spec=='west' else 25)
+                ! m1_.rect.width == 210
+                ! m1_.rect.ly == .m2.sd[0].rect.uy + 200
+                ! m1_.rect.height == 600
 
         .rst_n % LayoutPin(pin=self.symbol.rst_n)
         .inp % LayoutPin(pin=self.symbol.inp)
         .fb % LayoutPin(pin=self.symbol.fb)
 
-        LayoutRect outbar_h: .layer=layers.Metal1
-        .outbar_h % LayoutPin(pin=self.symbol.out)
-        ! .outbar_h.rect.cy == .polycont[3].rect.cy
-        ! .outbar_h.rect.height == 210
-        ! .outbar_h.rect.lx == .m1.sd[0].rect.lx
-        ! .outbar_h.rect.ux == .polycont[3].rect.ux + 500
+        LayoutRect outbar_h:
+            .layer=layers.Metal1
+            . % LayoutPin(pin=self.symbol.out)
+            ! .rect.cy == polycont[3].rect.cy
+            ! .rect.height == 210
+            ! .rect.lx == m1.sd[0].rect.lx
+            ! .rect.ux == polycont[3].rect.ux + 500
 
-        LayoutRect outbar_vmain: .layer=layers.Metal1
-        ! .outbar_vmain.rect.contains(.m3.sd[1].rect)
-        ! .outbar_vmain.rect.contains(.m4.sd[1].rect)
+        LayoutRect outbar_vmain:
+            .layer=layers.Metal1
+            ! .rect.contains(m3.sd[1].rect)
+            ! .rect.contains(m4.sd[1].rect)
 
-        LayoutRect outbar_vrst: .layer=layers.Metal1
-        ! .outbar_vrst.rect.contains(.m1.sd[0].rect)
-        ! .outbar_vrst.rect.ly == .outbar_h.rect.ly
+        LayoutRect outbar_vrst:
+            .layer=layers.Metal1
+            ! .rect.contains(m1.sd[0].rect)
+            ! .rect.ly == outbar_h.rect.ly
 
-        LayoutRect outbar_outn: .layer=layers.Metal1
-        ! .outbar_outn.rect.uy == .m8.sd[1].rect.uy
-        ! .outbar_outn.rect.ly == .m7.sd[1].rect.ly
-        ! .outbar_outn.rect.lx >= .m7.sd[1].rect.ux
-        ! .outbar_outn.rect.lx >= .outbar_h.rect.ux + 200
-        ! .outbar_outn.rect.width == 210
+        LayoutRect outbar_outn:
+            .layer=layers.Metal1
+            ! .rect.uy == m8.sd[1].rect.uy
+            ! .rect.ly == m7.sd[1].rect.ly
+            ! .rect.lx >= m7.sd[1].rect.ux
+            ! .rect.lx >= outbar_h.rect.ux + 200
+            ! .rect.width == 210
 
         .outbar_outn % LayoutPin(pin=self.symbol.out_n)
 
@@ -163,36 +166,39 @@ cell VcoHalfStage:
             ! r.rect.contains(sd.rect)
             ! r.rect.ux >= .outbar_outn.rect.lx
 
-        LayoutRect vddbar: .layer=layers.Metal1
-        .vddbar % LayoutPin(pin=self.symbol.vdd)
-        ! .vddbar.rect.southwest == .m1.sd[0].rect.northwest + (-500,400)
-        ! .vddbar.rect.height == 400
-        ! .vddbar.rect.ux == .m7.sd[1].rect.ux + 500
+        LayoutRect vddbar:
+            .layer=layers.Metal1
+            . % LayoutPin(pin=self.symbol.vdd)
+            ! .rect.southwest == m1.sd[0].rect.northwest + (-500,400)
+            ! .rect.height == 400
+            ! .rect.ux == m7.sd[1].rect.ux + 500
 
         for sd in (.m4.sd[0], .m8.sd[0]):
             r = . % LayoutRect(layer=layers.Metal1)
             ! r.rect.contains(sd.rect)
             ! r.rect.uy == .vddbar.rect.ly
 
-        LayoutRect vssbar: .layer=layers.Metal1
-        .vssbar % LayoutPin(pin=self.symbol.vss)
-        ! .vssbar.rect.width == .vddbar.rect.width
-        ! .vssbar.rect.height == 400
-        ! .vssbar.rect.northwest == .m2.sd[0].rect.southwest - (500,500)
+        LayoutRect vssbar:
+            .layer=layers.Metal1
+            . % LayoutPin(pin=self.symbol.vss)
+            ! .rect.width == vddbar.rect.width
+            ! .rect.height == 400
+            ! .rect.northwest == m2.sd[0].rect.southwest - (500,500)
 
         for sd in (.m2.sd[0], .m7.sd[0]):
             r = . % LayoutRect(layer=layers.Metal1)
             ! r.rect.contains(sd.rect)
-            ! r.rect.ly == .vssbar.rect.uy
+            ! r.rect.ly == vssbar.rect.uy
 
         r = . % LayoutRect(layer=layers.Metal1)
-        ! r.rect.contains(.m2.sd[1].rect)
+        ! r.rect.contains(m2.sd[1].rect)
         ! r.rect.height == 600
-        ! r.rect.uy == .m2.sd[1].rect.uy
+        ! r.rect.uy == m2.sd[1].rect.uy
 
-        LayoutRect nwell: .layer=layers.NWell
-        for m in (.m1, .m4, .m6, .m8):
-            ! .nwell.rect.contains(m.nwell.rect)
+        LayoutRect nwell:
+            .layer=layers.NWell
+            for m in (m1, m4, m6, m8):
+                ! .rect.contains(m.nwell.rect)
 
 cell VcoRing:
     viewgen symbol -> Symbol:
@@ -266,46 +272,53 @@ cell VcoRing:
         sr = SRouter(__ordec_solver__.subgraph, __ordec_solver__,
             routing_spec=SG13G2().default_routing_spec)
 
-        LayoutRect nwell: .layer=layers.NWell
+        LayoutRect nwell:
+             .layer=layers.NWell
 
-        LayoutRect vdd_st_bar: .layer=layers.Metal1
-        vdd_st_bar % LayoutPin(pin=self.symbol.vdd_st)
+        LayoutRect vdd_st_bar:
+            .layer=layers.Metal1
+            . % LayoutPin(pin=self.symbol.vdd_st)
 
-        LayoutRect vss_st_bar_n: .layer=layers.Metal1
-        vss_st_bar_n % LayoutPin(pin=self.symbol.vss_st)
+        LayoutRect vss_st_bar_n:
+            .layer=layers.Metal1
+            . % LayoutPin(pin=self.symbol.vss_st)
 
-        LayoutRect vss_st_bar_p: .layer=layers.Metal1
-        vss_st_bar_p % LayoutPin(pin=self.symbol.vss_st)
+        LayoutRect vss_st_bar_p:
+            .layer=layers.Metal1
+            . % LayoutPin(pin=self.symbol.vss_st)
 
         for i in range(2):
-            VcoHalfStage() stage_p[i]: .orientation=MX
-            VcoHalfStage() stage_n[i]
-            if i == 0:
-                .stage_p[i].orientation *= MY
-                .stage_n[i].orientation *= MY
-            ! .stage_n[i].vddbar.rect.southwest == .stage_p[i].vddbar.rect.southwest
+            VcoHalfStage() stage_p[i]:
+                .orientation=MX
+                if i == 0:
+                    .orientation *= MY
+                ! vdd_st_bar.rect.contains(.vddbar.rect)
+                ! nwell.rect.contains(.nwell.rect)
+                ! vss_st_bar_p.rect.contains(.vssbar.rect)
+            
+            VcoHalfStage() stage_n[i]:
+                if i == 0:
+                    .orientation *= MY
+                ! vdd_st_bar.rect.contains(.vddbar.rect)
+                ! vss_st_bar_n.rect.contains(.vssbar.rect)
+                ! nwell.rect.contains(.nwell.rect)
+
+            ! stage_n[i].vddbar.rect.southwest == stage_p[i].vddbar.rect.southwest
 
             if i > 0:
-                ! .stage_n[i].vddbar.rect.west == .stage_n[i-1].vddbar.rect.east
+                ! stage_n[i].vddbar.rect.west == stage_n[i-1].vddbar.rect.east
 
-            ! .nwell.rect.contains(.stage_p[i].nwell.rect)
-            ! .nwell.rect.contains(.stage_n[i].nwell.rect)
-
-            outbar_n = .stage_n[i].outbar_outn
-            LayoutRect out_n[i]: .layer=outbar_n.layer.nid
-            ! out_n[i].rect == outbar_n.rect
-            out_n[i] % LayoutPin(pin=self.symbol.out_n[i])
+            outbar_n = stage_n[i].outbar_outn
+            LayoutRect out_n[i]:
+                .layer=outbar_n.layer.nid
+                ! .rect == outbar_n.rect
+                . % LayoutPin(pin=self.symbol.out_n[i])
 
             outbar_p = .stage_p[i].outbar_outn
-            LayoutRect out_p[i]: .layer=outbar_p.layer.nid
-            ! out_p[i].rect == outbar_p.rect
-            out_p[i] % LayoutPin(pin=self.symbol.out_p[i])
-
-            ! vdd_st_bar.rect.contains(.stage_p[i].vddbar.rect)
-            ! vdd_st_bar.rect.contains(.stage_n[i].vddbar.rect)
-
-            ! vss_st_bar_n.rect.contains(.stage_n[i].vssbar.rect)
-            ! vss_st_bar_p.rect.contains(.stage_p[i].vssbar.rect)
+            LayoutRect out_p[i]:
+                .layer=outbar_p.layer.nid
+                ! .rect == outbar_p.rect
+                . % LayoutPin(pin=self.symbol.out_p[i])
 
         ! .stage_p[0].pos == (0,0)
 
@@ -318,69 +331,69 @@ cell VcoRing:
 
         # Connect rst_n of stage_n[1] and stage_p[0] to own rst_n:
 
-        sr.move(layers.Metal1, .stage_n[1].rst_n.rect.center)
+        sr.move(layers.Metal1, stage_n[1].rst_n.rect.center)
         sr.layer(layers.Metal2)
-        sr.wire_x(0.5*.stage_p[0].rst_n.rect.cx + 0.5*.stage_n[1].rst_n.rect.cx)
-        sr.wire_y(.stage_p[0].rst_n.rect.cy)
+        sr.wire_x(0.5*stage_p[0].rst_n.rect.cx + 0.5*stage_n[1].rst_n.rect.cx)
+        sr.wire_y(stage_p[0].rst_n.rect.cy)
         sr.push()
-        sr.wire_x(.stage_p[0].rst_n.rect.cx)
+        sr.wire_x(stage_p[0].rst_n.rect.cx)
         sr.layer(layers.Metal1)
         sr.pop()
-        sr.wire_y(.stage_p[0].rst_n.rect.cy+2500)
+        sr.wire_y(stage_p[0].rst_n.rect.cy+2500)
         sr.path % LayoutPin(pin=self.symbol.rst_n)
 
         # Connect matching fb -- out -- inp pins:
 
-        sr.move(layers.Metal1, .stage_n[0].fb.rect.center)
+        sr.move(layers.Metal1, stage_n[0].fb.rect.center)
         sr.layer(layers.Metal2)
-        sr.wire_y(.stage_p[0].outbar_h.rect.cy)
+        sr.wire_y(stage_p[0].outbar_h.rect.cy)
         sr.push()
         sr.layer(layers.Metal1)
         sr.pop()
         sr.layer(layers.Metal3)
-        sr.wire_x(.stage_p[1].inp.rect.cx)
+        sr.wire_x(stage_p[1].inp.rect.cx)
         sr.layer(layers.Metal2)
-        sr.wire_y(.stage_p[1].inp.rect.cy)
+        sr.wire_y(stage_p[1].inp.rect.cy)
         sr.layer(layers.Metal1)
 
-        sr.move(layers.Metal1, .stage_n[1].fb.rect.center)
+        sr.move(layers.Metal1, stage_n[1].fb.rect.center)
         sr.layer(layers.Metal2)
-        sr.wire_y(.stage_n[1].outbar_h.rect.cy + 500)
+        sr.wire_y(stage_n[1].outbar_h.rect.cy + 500)
         sr.push()
-        sr.wire_y(.stage_p[1].outbar_h.rect.cy)
+        sr.wire_y(stage_p[1].outbar_h.rect.cy)
         sr.layer(layers.Metal1)
         sr.pop()
         sr.layer(layers.Metal3)
-        sr.wire_x(.stage_n[0].inp.rect.cx)
+        sr.wire_x(stage_n[0].inp.rect.cx)
         sr.layer(layers.Metal2)
-        sr.wire_y(.stage_n[0].inp.rect.cy)
+        sr.wire_y(stage_n[0].inp.rect.cy)
         sr.layer(layers.Metal1)
 
-        sr.move(layers.Metal1, .stage_p[0].fb.rect.center)
+        sr.move(layers.Metal1, stage_p[0].fb.rect.center)
         sr.layer(layers.Metal2)
-        sr.wire_x(.stage_n[0].outbar_h.rect.lx + 150)
-        sr.wire_y(.stage_n[0].outbar_h.rect.cy)
+        sr.wire_x(stage_n[0].outbar_h.rect.lx + 150)
+        sr.wire_y(stage_n[0].outbar_h.rect.cy)
         sr.push()
         sr.layer(layers.Metal1)
         sr.pop()
         sr.layer(layers.Metal3)
-        sr.wire_x(.stage_n[1].inp.rect.cx)
+        sr.wire_x(stage_n[1].inp.rect.cx)
         sr.layer(layers.Metal2)
-        sr.wire_y(.stage_n[1].inp.rect.cy)
+        sr.wire_y(stage_n[1].inp.rect.cy)
         sr.layer(layers.Metal1)
 
-        sr.move(layers.Metal1, .stage_p[1].fb.rect.center)
+        sr.move(layers.Metal1, stage_p[1].fb.rect.center)
         sr.layer(layers.Metal2)
-        sr.wire_x(.stage_n[1].outbar_h.rect.ux - 150)
-        sr.wire_y(.stage_p[i].outbar_h.rect.cy - 500)
+        sr.wire_x(stage_n[1].outbar_h.rect.ux - 150)
+        sr.wire_y(stage_p[i].outbar_h.rect.cy - 500)
         sr.push()
-        sr.wire_y(.stage_n[1].outbar_h.rect.cy)
+        sr.wire_y(stage_n[1].outbar_h.rect.cy)
         sr.layer(layers.Metal1)
         sr.pop()
         sr.layer(layers.Metal3)
-        sr.wire_x(.stage_p[0].inp.rect.cx)
+        sr.wire_x(stage_p[0].inp.rect.cx)
         sr.layer(layers.Metal2)
-        sr.wire_y(.stage_p[0].inp.rect.cy)
+        sr.wire_y(stage_p[0].inp.rect.cy)
         sr.layer(layers.Metal1)
 
 cell Vco:

--- a/ordec/lib/examples/vco_pseudodiff.ord
+++ b/ordec/lib/examples/vco_pseudodiff.ord
@@ -70,8 +70,8 @@ cell VcoHalfStage:
         pmos m1:
             ! .pos == (0, 0)
         nmos m2:
-            ! .poly[0].rect.cx == m1.poly[0].rect.cx
-            ! .activ.rect.uy + 1500 == m1.activ.rect.ly
+            ! .poly[0].cx == m1.poly[0].cx
+            ! .activ.uy + 1500 == m1.activ.ly
 
         nmos m3
         pmos m4
@@ -87,15 +87,15 @@ cell VcoHalfStage:
         for left, right in pairwise(grid):
             left_nmos, left_pmos = left
             right_nmos, right_pmos = right
-            ! right_nmos.sd[0].rect.center == left_nmos.sd[1].rect.center
-            ! right_pmos.sd[0].rect.center == left_pmos.sd[1].rect.center
+            ! right_nmos.sd[0].center == left_nmos.sd[1].center
+            ! right_pmos.sd[0].center == left_pmos.sd[1].center
 
         path poly
         for idx, insts in enumerate(grid):
             LayoutRect poly[idx]: 
                 .layer=layers.GatPoly
                 for inst in insts:
-                    ! .rect.contains(inst.poly[0].rect)
+                    ! .contains(inst.poly[0].rect)
 
         polycont_spec = (
             ('south', 'west', 'rst_n'),
@@ -107,27 +107,27 @@ cell VcoHalfStage:
         polycont_m1={}
         for idx, (vert_spec, horiz_spec, add_m1) in enumerate(polycont_spec):
             polyext = . % LayoutRect(layer=layers.GatPoly)
-            ! polyext.rect.size == (300, 300)
+            ! polyext.size == (300, 300)
             if horiz_spec == 'west':
-                ! polyext.rect.ux == poly[idx].rect.ux
+                ! polyext.ux == poly[idx].ux
             else:
                 assert horiz_spec == 'east'
-                ! polyext.rect.lx == poly[idx].rect.lx
+                ! polyext.lx == poly[idx].lx
             if vert_spec == 'north':
-                ! polyext.rect.uy == m1.activ.rect.ly - 200
+                ! polyext.uy == m1.activ.ly - 200
             else:
                 assert vert_spec == 'south'
-                ! polyext.rect.ly == m2.activ.rect.uy + 200
+                ! polyext.ly == m2.activ.uy + 200
             LayoutRect polycont[idx]: .layer=layers.Cont
-            ! polycont[idx].rect.size == (160, 160)
-            ! polycont[idx].rect.center == polyext.rect.center
+            ! polycont[idx].size == (160, 160)
+            ! polycont[idx].center == polyext.center
             if add_m1:
                 setattr(., add_m1, LayoutRect(layer=layers.Metal1))
                 m1_ = getattr(., add_m1)
-                ! m1_.rect.cx == .polycont[idx].rect.cx + (-25 if horiz_spec=='west' else 25)
-                ! m1_.rect.width == 210
-                ! m1_.rect.ly == .m2.sd[0].rect.uy + 200
-                ! m1_.rect.height == 600
+                ! m1_.cx == .polycont[idx].cx + (-25 if horiz_spec=='west' else 25)
+                ! m1_.width == 210
+                ! m1_.ly == .m2.sd[0].uy + 200
+                ! m1_.height == 600
 
         .rst_n % LayoutPin(pin=self.symbol.rst_n)
         .inp % LayoutPin(pin=self.symbol.inp)
@@ -136,69 +136,69 @@ cell VcoHalfStage:
         LayoutRect outbar_h:
             .layer=layers.Metal1
             . % LayoutPin(pin=self.symbol.out)
-            ! .rect.cy == polycont[3].rect.cy
-            ! .rect.height == 210
-            ! .rect.lx == m1.sd[0].rect.lx
-            ! .rect.ux == polycont[3].rect.ux + 500
+            ! .cy == polycont[3].cy
+            ! .height == 210
+            ! .lx == m1.sd[0].lx
+            ! .ux == polycont[3].ux + 500
 
         LayoutRect outbar_vmain:
             .layer=layers.Metal1
-            ! .rect.contains(m3.sd[1].rect)
-            ! .rect.contains(m4.sd[1].rect)
+            ! .contains(m3.sd[1].rect)
+            ! .contains(m4.sd[1].rect)
 
         LayoutRect outbar_vrst:
             .layer=layers.Metal1
-            ! .rect.contains(m1.sd[0].rect)
-            ! .rect.ly == outbar_h.rect.ly
+            ! .contains(m1.sd[0].rect)
+            ! .ly == outbar_h.ly
 
         LayoutRect outbar_outn:
             .layer=layers.Metal1
-            ! .rect.uy == m8.sd[1].rect.uy
-            ! .rect.ly == m7.sd[1].rect.ly
-            ! .rect.lx >= m7.sd[1].rect.ux
-            ! .rect.lx >= outbar_h.rect.ux + 200
-            ! .rect.width == 210
+            ! .uy == m8.sd[1].uy
+            ! .ly == m7.sd[1].ly
+            ! .lx >= m7.sd[1].ux
+            ! .lx >= outbar_h.ux + 200
+            ! .width == 210
 
         .outbar_outn % LayoutPin(pin=self.symbol.out_n)
 
         for sd in (.m8.sd[1], .m7.sd[1]):
             r = . % LayoutRect(layer=layers.Metal1)
-            ! r.rect.contains(sd.rect)
-            ! r.rect.ux >= .outbar_outn.rect.lx
+            ! r.contains(sd.rect)
+            ! r.ux >= .outbar_outn.lx
 
         LayoutRect vddbar:
             .layer=layers.Metal1
             . % LayoutPin(pin=self.symbol.vdd)
-            ! .rect.southwest == m1.sd[0].rect.northwest + (-500,400)
-            ! .rect.height == 400
-            ! .rect.ux == m7.sd[1].rect.ux + 500
+            ! .southwest == m1.sd[0].northwest + (-500,400)
+            ! .height == 400
+            ! .ux == m7.sd[1].ux + 500
 
         for sd in (.m4.sd[0], .m8.sd[0]):
             r = . % LayoutRect(layer=layers.Metal1)
-            ! r.rect.contains(sd.rect)
-            ! r.rect.uy == .vddbar.rect.ly
+            ! r.contains(sd.rect)
+            ! r.uy == .vddbar.ly
 
         LayoutRect vssbar:
             .layer=layers.Metal1
             . % LayoutPin(pin=self.symbol.vss)
-            ! .rect.width == vddbar.rect.width
-            ! .rect.height == 400
-            ! .rect.northwest == m2.sd[0].rect.southwest - (500,500)
+            ! .width == vddbar.width
+            ! .height == 400
+            ! .northwest == m2.sd[0].southwest - (500,500)
 
         for sd in (.m2.sd[0], .m7.sd[0]):
             r = . % LayoutRect(layer=layers.Metal1)
-            ! r.rect.contains(sd.rect)
-            ! r.rect.ly == vssbar.rect.uy
+            ! r.contains(sd.rect)
+            ! r.ly == vssbar.uy
 
         r = . % LayoutRect(layer=layers.Metal1)
-        ! r.rect.contains(m2.sd[1].rect)
-        ! r.rect.height == 600
-        ! r.rect.uy == m2.sd[1].rect.uy
+        ! r.contains(m2.sd[1].rect)
+        ! r.height == 600
+        ! r.uy == m2.sd[1].uy
 
         LayoutRect nwell:
             .layer=layers.NWell
             for m in (m1, m4, m6, m8):
-                ! .rect.contains(m.nwell.rect)
+                ! .contains(m.nwell.rect)
 
 cell VcoRing:
     viewgen symbol -> Symbol:
@@ -292,21 +292,21 @@ cell VcoRing:
                 .orientation=MX
                 if i == 0:
                     .orientation *= MY
-                ! vdd_st_bar.rect.contains(.vddbar.rect)
-                ! nwell.rect.contains(.nwell.rect)
-                ! vss_st_bar_p.rect.contains(.vssbar.rect)
+                ! vdd_st_bar.contains(.vddbar.rect)
+                ! nwell.contains(.nwell.rect)
+                ! vss_st_bar_p.contains(.vssbar.rect)
             
             VcoHalfStage() stage_n[i]:
                 if i == 0:
                     .orientation *= MY
-                ! vdd_st_bar.rect.contains(.vddbar.rect)
-                ! vss_st_bar_n.rect.contains(.vssbar.rect)
-                ! nwell.rect.contains(.nwell.rect)
+                ! vdd_st_bar.contains(.vddbar.rect)
+                ! vss_st_bar_n.contains(.vssbar.rect)
+                ! nwell.contains(.nwell.rect)
 
-            ! stage_n[i].vddbar.rect.southwest == stage_p[i].vddbar.rect.southwest
+            ! stage_n[i].vddbar.southwest == stage_p[i].vddbar.southwest
 
             if i > 0:
-                ! stage_n[i].vddbar.rect.west == stage_n[i-1].vddbar.rect.east
+                ! stage_n[i].vddbar.west == stage_n[i-1].vddbar.east
 
             outbar_n = stage_n[i].outbar_outn
             LayoutRect out_n[i]:
@@ -324,76 +324,76 @@ cell VcoRing:
 
         # Connect rst_n of stage_n[0] and stage_p[1] to VDD:
         for stage in [.stage_n[0], .stage_p[1]]:
-            sr.move(layers.Metal1, stage.rst_n.rect.center)
+            sr.move(layers.Metal1, stage.rst_n.center)
             sr.layer(layers.Metal2)
-            sr.wire_y(stage.vddbar.rect.cy)
+            sr.wire_y(stage.vddbar.cy)
             sr.layer(layers.Metal1)
 
         # Connect rst_n of stage_n[1] and stage_p[0] to own rst_n:
 
-        sr.move(layers.Metal1, stage_n[1].rst_n.rect.center)
+        sr.move(layers.Metal1, stage_n[1].rst_n.center)
         sr.layer(layers.Metal2)
-        sr.wire_x(0.5*stage_p[0].rst_n.rect.cx + 0.5*stage_n[1].rst_n.rect.cx)
-        sr.wire_y(stage_p[0].rst_n.rect.cy)
+        sr.wire_x(0.5*stage_p[0].rst_n.cx + 0.5*stage_n[1].rst_n.cx)
+        sr.wire_y(stage_p[0].rst_n.cy)
         sr.push()
-        sr.wire_x(stage_p[0].rst_n.rect.cx)
+        sr.wire_x(stage_p[0].rst_n.cx)
         sr.layer(layers.Metal1)
         sr.pop()
-        sr.wire_y(stage_p[0].rst_n.rect.cy+2500)
+        sr.wire_y(stage_p[0].rst_n.cy+2500)
         sr.path % LayoutPin(pin=self.symbol.rst_n)
 
         # Connect matching fb -- out -- inp pins:
 
-        sr.move(layers.Metal1, stage_n[0].fb.rect.center)
+        sr.move(layers.Metal1, stage_n[0].fb.center)
         sr.layer(layers.Metal2)
-        sr.wire_y(stage_p[0].outbar_h.rect.cy)
+        sr.wire_y(stage_p[0].outbar_h.cy)
         sr.push()
         sr.layer(layers.Metal1)
         sr.pop()
         sr.layer(layers.Metal3)
-        sr.wire_x(stage_p[1].inp.rect.cx)
+        sr.wire_x(stage_p[1].inp.cx)
         sr.layer(layers.Metal2)
-        sr.wire_y(stage_p[1].inp.rect.cy)
+        sr.wire_y(stage_p[1].inp.cy)
         sr.layer(layers.Metal1)
 
-        sr.move(layers.Metal1, stage_n[1].fb.rect.center)
+        sr.move(layers.Metal1, stage_n[1].fb.center)
         sr.layer(layers.Metal2)
-        sr.wire_y(stage_n[1].outbar_h.rect.cy + 500)
+        sr.wire_y(stage_n[1].outbar_h.cy + 500)
         sr.push()
-        sr.wire_y(stage_p[1].outbar_h.rect.cy)
+        sr.wire_y(stage_p[1].outbar_h.cy)
         sr.layer(layers.Metal1)
         sr.pop()
         sr.layer(layers.Metal3)
-        sr.wire_x(stage_n[0].inp.rect.cx)
+        sr.wire_x(stage_n[0].inp.cx)
         sr.layer(layers.Metal2)
-        sr.wire_y(stage_n[0].inp.rect.cy)
+        sr.wire_y(stage_n[0].inp.cy)
         sr.layer(layers.Metal1)
 
-        sr.move(layers.Metal1, stage_p[0].fb.rect.center)
+        sr.move(layers.Metal1, stage_p[0].fb.center)
         sr.layer(layers.Metal2)
-        sr.wire_x(stage_n[0].outbar_h.rect.lx + 150)
-        sr.wire_y(stage_n[0].outbar_h.rect.cy)
+        sr.wire_x(stage_n[0].outbar_h.lx + 150)
+        sr.wire_y(stage_n[0].outbar_h.cy)
         sr.push()
         sr.layer(layers.Metal1)
         sr.pop()
         sr.layer(layers.Metal3)
-        sr.wire_x(stage_n[1].inp.rect.cx)
+        sr.wire_x(stage_n[1].inp.cx)
         sr.layer(layers.Metal2)
-        sr.wire_y(stage_n[1].inp.rect.cy)
+        sr.wire_y(stage_n[1].inp.cy)
         sr.layer(layers.Metal1)
 
-        sr.move(layers.Metal1, stage_p[1].fb.rect.center)
+        sr.move(layers.Metal1, stage_p[1].fb.center)
         sr.layer(layers.Metal2)
-        sr.wire_x(stage_n[1].outbar_h.rect.ux - 150)
-        sr.wire_y(stage_p[i].outbar_h.rect.cy - 500)
+        sr.wire_x(stage_n[1].outbar_h.ux - 150)
+        sr.wire_y(stage_p[i].outbar_h.cy - 500)
         sr.push()
-        sr.wire_y(stage_n[1].outbar_h.rect.cy)
+        sr.wire_y(stage_n[1].outbar_h.cy)
         sr.layer(layers.Metal1)
         sr.pop()
         sr.layer(layers.Metal3)
-        sr.wire_x(stage_p[0].inp.rect.cx)
+        sr.wire_x(stage_p[0].inp.cx)
         sr.layer(layers.Metal2)
-        sr.wire_y(stage_p[0].inp.rect.cy)
+        sr.wire_y(stage_p[0].inp.cy)
         sr.layer(layers.Metal1)
 
 cell Vco:

--- a/ordec/lib/examples/vco_pseudodiff.ord
+++ b/ordec/lib/examples/vco_pseudodiff.ord
@@ -263,8 +263,8 @@ cell VcoRing:
         .ref_layers = SG13G2().layers
         layers = .ref_layers
         path stage_n, stage_p, out_n, out_p
-        sr = SRouter(__ordec_solver__.subgraph, __ordec_solver__,
-            routing_spec=SG13G2().default_routing_spec)
+        vc = __ord_context__.view_context()
+        sr = SRouter(vc.root, vc.solver, routing_spec=SG13G2().default_routing_spec)
 
         LayoutRect nwell:
              .layer=layers.NWell

--- a/ordec/lib/examples/vco_pseudodiff.ord
+++ b/ordec/lib/examples/vco_pseudodiff.ord
@@ -67,17 +67,17 @@ cell VcoHalfStage:
         pmos = self.schematic.m1.symbol.cell
         nmos = self.schematic.m2.symbol.cell
 
-        .m1 = LayoutInstance(ref=pmos.layout)
-        .m2 = LayoutInstance(ref=nmos.layout)
+        pmos m1
+        nmos m2
 
-        .m3 = LayoutInstance(ref=nmos.layout)
-        .m4 = LayoutInstance(ref=pmos.layout)
+        nmos m3
+        pmos m4
 
-        .m5 = LayoutInstance(ref=nmos.layout)
-        .m6 = LayoutInstance(ref=pmos.layout)
+        nmos m5
+        pmos m6
 
-        .m7 = LayoutInstance(ref=nmos.layout)
-        .m8 = LayoutInstance(ref=pmos.layout)
+        nmos m7
+        pmos m8
 
         grid = ((.m2, .m1), (.m3, .m4), (.m5, .m6), (.m7, .m8))
 
@@ -94,9 +94,9 @@ cell VcoHalfStage:
 
         path poly
         for idx, insts in enumerate(grid):
-            .poly[idx] = LayoutRect(layer=layers.GatPoly)
+            LayoutRect poly[idx]: .layer=layers.GatPoly
             for inst in insts:
-                ! .poly[idx].rect.contains(inst.poly[0].rect)
+                ! poly[idx].rect.contains(inst.poly[0].rect)
 
         polycont_spec = (
             ('south', 'west', 'rst_n'),
@@ -119,9 +119,9 @@ cell VcoHalfStage:
             else:
                 assert vert_spec == 'south'
                 ! polyext.rect.ly == .m2.activ.rect.uy + 200
-            .polycont[idx] = LayoutRect(layer=layers.Cont)
-            ! .polycont[idx].rect.size == (160, 160)
-            ! .polycont[idx].rect.center == polyext.rect.center
+            LayoutRect polycont[idx]: .layer=layers.Cont
+            ! polycont[idx].rect.size == (160, 160)
+            ! polycont[idx].rect.center == polyext.rect.center
             if add_m1:
                 setattr(., add_m1, LayoutRect(layer=layers.Metal1))
                 m1 = getattr(., add_m1)
@@ -134,22 +134,22 @@ cell VcoHalfStage:
         .inp % LayoutPin(pin=self.symbol.inp)
         .fb % LayoutPin(pin=self.symbol.fb)
 
-        .outbar_h = LayoutRect(layer=layers.Metal1)
+        LayoutRect outbar_h: .layer=layers.Metal1
         .outbar_h % LayoutPin(pin=self.symbol.out)
         ! .outbar_h.rect.cy == .polycont[3].rect.cy
         ! .outbar_h.rect.height == 210
         ! .outbar_h.rect.lx == .m1.sd[0].rect.lx
         ! .outbar_h.rect.ux == .polycont[3].rect.ux + 500
 
-        .outbar_vmain = LayoutRect(layer=layers.Metal1)
+        LayoutRect outbar_vmain: .layer=layers.Metal1
         ! .outbar_vmain.rect.contains(.m3.sd[1].rect)
         ! .outbar_vmain.rect.contains(.m4.sd[1].rect)
 
-        .outbar_vrst = LayoutRect(layer=layers.Metal1)
+        LayoutRect outbar_vrst: .layer=layers.Metal1
         ! .outbar_vrst.rect.contains(.m1.sd[0].rect)
         ! .outbar_vrst.rect.ly == .outbar_h.rect.ly
 
-        .outbar_outn = LayoutRect(layer=layers.Metal1)
+        LayoutRect outbar_outn: .layer=layers.Metal1
         ! .outbar_outn.rect.uy == .m8.sd[1].rect.uy
         ! .outbar_outn.rect.ly == .m7.sd[1].rect.ly
         ! .outbar_outn.rect.lx >= .m7.sd[1].rect.ux
@@ -163,7 +163,7 @@ cell VcoHalfStage:
             ! r.rect.contains(sd.rect)
             ! r.rect.ux >= .outbar_outn.rect.lx
 
-        .vddbar = LayoutRect(layer=layers.Metal1)
+        LayoutRect vddbar: .layer=layers.Metal1
         .vddbar % LayoutPin(pin=self.symbol.vdd)
         ! .vddbar.rect.southwest == .m1.sd[0].rect.northwest + (-500,400)
         ! .vddbar.rect.height == 400
@@ -174,7 +174,7 @@ cell VcoHalfStage:
             ! r.rect.contains(sd.rect)
             ! r.rect.uy == .vddbar.rect.ly
 
-        .vssbar = LayoutRect(layer=layers.Metal1)
+        LayoutRect vssbar: .layer=layers.Metal1
         .vssbar % LayoutPin(pin=self.symbol.vss)
         ! .vssbar.rect.width == .vddbar.rect.width
         ! .vssbar.rect.height == 400
@@ -190,7 +190,7 @@ cell VcoHalfStage:
         ! r.rect.height == 600
         ! r.rect.uy == .m2.sd[1].rect.uy
 
-        .nwell = LayoutRect(layer=layers.NWell)
+        LayoutRect nwell: .layer=layers.NWell
         for m in (.m1, .m4, .m6, .m8):
             ! .nwell.rect.contains(m.nwell.rect)
 
@@ -266,20 +266,20 @@ cell VcoRing:
         sr = SRouter(__ordec_solver__.subgraph, __ordec_solver__,
             routing_spec=SG13G2().default_routing_spec)
 
-        .nwell = LayoutRect(layer=layers.NWell)
+        LayoutRect nwell: .layer=layers.NWell
 
-        .vdd_st_bar = LayoutRect(layer=layers.Metal1)
-        .vdd_st_bar % LayoutPin(pin=self.symbol.vdd_st)
+        LayoutRect vdd_st_bar: .layer=layers.Metal1
+        vdd_st_bar % LayoutPin(pin=self.symbol.vdd_st)
 
-        .vss_st_bar_n = LayoutRect(layer=layers.Metal1)
-        .vss_st_bar_n % LayoutPin(pin=self.symbol.vss_st)
+        LayoutRect vss_st_bar_n: .layer=layers.Metal1
+        vss_st_bar_n % LayoutPin(pin=self.symbol.vss_st)
 
-        .vss_st_bar_p = LayoutRect(layer=layers.Metal1)
-        .vss_st_bar_p % LayoutPin(pin=self.symbol.vss_st)
+        LayoutRect vss_st_bar_p: .layer=layers.Metal1
+        vss_st_bar_p % LayoutPin(pin=self.symbol.vss_st)
 
         for i in range(2):
-            .stage_p[i] = LayoutInstance(ref=VcoHalfStage().layout, orientation=MX)
-            .stage_n[i] = LayoutInstance(ref=VcoHalfStage().layout)
+            VcoHalfStage() stage_p[i]: .orientation=MX
+            VcoHalfStage() stage_n[i]
             if i == 0:
                 .stage_p[i].orientation *= MY
                 .stage_n[i].orientation *= MY
@@ -292,20 +292,20 @@ cell VcoRing:
             ! .nwell.rect.contains(.stage_n[i].nwell.rect)
 
             outbar_n = .stage_n[i].outbar_outn
-            .out_n[i] = LayoutRect(layer=outbar_n.layer.nid)
-            ! .out_n[i].rect == outbar_n.rect
-            .out_n[i] % LayoutPin(pin=self.symbol.out_n[i])
+            LayoutRect out_n[i]: .layer=outbar_n.layer.nid
+            ! out_n[i].rect == outbar_n.rect
+            out_n[i] % LayoutPin(pin=self.symbol.out_n[i])
 
             outbar_p = .stage_p[i].outbar_outn
-            .out_p[i] = LayoutRect(layer=outbar_p.layer.nid)
-            ! .out_p[i].rect == outbar_p.rect
-            .out_p[i] % LayoutPin(pin=self.symbol.out_p[i])
+            LayoutRect out_p[i]: .layer=outbar_p.layer.nid
+            ! out_p[i].rect == outbar_p.rect
+            out_p[i] % LayoutPin(pin=self.symbol.out_p[i])
 
-            ! .vdd_st_bar.rect.contains(.stage_p[i].vddbar.rect)
-            ! .vdd_st_bar.rect.contains(.stage_n[i].vddbar.rect)
+            ! vdd_st_bar.rect.contains(.stage_p[i].vddbar.rect)
+            ! vdd_st_bar.rect.contains(.stage_n[i].vddbar.rect)
 
-            ! .vss_st_bar_n.rect.contains(.stage_n[i].vssbar.rect)
-            ! .vss_st_bar_p.rect.contains(.stage_p[i].vssbar.rect)
+            ! vss_st_bar_n.rect.contains(.stage_n[i].vssbar.rect)
+            ! vss_st_bar_p.rect.contains(.stage_p[i].vssbar.rect)
 
         ! .stage_p[0].pos == (0,0)
 

--- a/ordec/lib/examples/vco_pseudodiff.ord
+++ b/ordec/lib/examples/vco_pseudodiff.ord
@@ -61,7 +61,9 @@ cell VcoHalfStage:
             mos.$l = self.length
 
 
-    viewgen layout(layers=SG13G2().layers) -> Layout:
+    viewgen layout -> Layout:
+        .ref_layers = SG13G2().layers
+        layers = .ref_layers
         pmos = self.schematic.m1.symbol.cell
         nmos = self.schematic.m2.symbol.cell
 
@@ -257,7 +259,9 @@ cell VcoRing:
                 .pos = (5 + xoffset, 3)
 
 
-    viewgen layout(layers=SG13G2().layers) -> Layout:
+    viewgen layout -> Layout:
+        .ref_layers = SG13G2().layers
+        layers = .ref_layers
         path stage_n, stage_p, out_n, out_p
         sr = SRouter(__ordec_solver__.subgraph, __ordec_solver__,
             routing_spec=SG13G2().default_routing_spec)

--- a/ordec/lib/examples/vco_pseudodiff.ord
+++ b/ordec/lib/examples/vco_pseudodiff.ord
@@ -263,8 +263,6 @@ cell VcoRing:
         .ref_layers = SG13G2().layers
         layers = .ref_layers
         path stage_n, stage_p, out_n, out_p
-        vc = __ord_context__.view_context()
-        sr = SRouter(vc.root, vc.solver, routing_spec=SG13G2().default_routing_spec)
 
         LayoutRect nwell:
              .layer=layers.NWell
@@ -316,6 +314,8 @@ cell VcoRing:
 
         ! .stage_p[0].pos == (0,0)
 
+        sr = SRouter(SG13G2().default_routing_spec)
+        
         # Connect rst_n of stage_n[0] and stage_p[1] to VDD:
         for stage in [.stage_n[0], .stage_p[1]]:
             sr.move(layers.Metal1, stage.rst_n.center)

--- a/ordec/lib/examples/vco_pseudodiff.ord
+++ b/ordec/lib/examples/vco_pseudodiff.ord
@@ -100,21 +100,23 @@ cell VcoHalfStage:
         path polycont
         polycont_m1={}
         for idx, (vert_spec, horiz_spec, add_m1) in enumerate(polycont_spec):
-            polyext = . % LayoutRect(layer=layers.GatPoly)
-            ! polyext.size == (300, 300)
-            if horiz_spec == 'west':
-                ! polyext.ux == poly[idx].ux
-            else:
-                assert horiz_spec == 'east'
-                ! polyext.lx == poly[idx].lx
-            if vert_spec == 'north':
-                ! polyext.uy == m1.activ.ly - 200
-            else:
-                assert vert_spec == 'south'
-                ! polyext.ly == m2.activ.uy + 200
-            LayoutRect polycont[idx]: .layer=layers.Cont
-            ! polycont[idx].size == (160, 160)
-            ! polycont[idx].center == polyext.center
+            anonymous LayoutRect polyext:
+                .layer=layers.GatPoly
+                ! .size == (300, 300)
+                if horiz_spec == 'west':
+                    ! .ux == poly[idx].ux
+                else:
+                    assert horiz_spec == 'east'
+                    ! .lx == poly[idx].lx
+                if vert_spec == 'north':
+                    ! .uy == m1.activ.ly - 200
+                else:
+                    assert vert_spec == 'south'
+                    ! .ly == m2.activ.uy + 200
+            LayoutRect polycont[idx]:
+                .layer=layers.Cont
+                ! .size == (160, 160)
+                ! .center == polyext.center
             if add_m1:
                 setattr(., add_m1, LayoutRect(layer=layers.Metal1))
                 m1_ = getattr(., add_m1)
@@ -156,9 +158,10 @@ cell VcoHalfStage:
         .outbar_outn % LayoutPin(pin=self.symbol.out_n)
 
         for sd in (.m8.sd[1], .m7.sd[1]):
-            r = . % LayoutRect(layer=layers.Metal1)
-            ! r.contains(sd.rect)
-            ! r.ux >= .outbar_outn.lx
+            anonymous LayoutRect r:
+                .layer=layers.Metal1
+                ! .contains(sd.rect)
+                ! .ux >= outbar_outn.lx
 
         LayoutRect vddbar:
             .layer=layers.Metal1
@@ -168,9 +171,10 @@ cell VcoHalfStage:
             ! .ux == m7.sd[1].ux + 500
 
         for sd in (.m4.sd[0], .m8.sd[0]):
-            r = . % LayoutRect(layer=layers.Metal1)
-            ! r.contains(sd.rect)
-            ! r.uy == .vddbar.ly
+            anonymous LayoutRect r:
+                .layer=layers.Metal1
+                ! .contains(sd.rect)
+                ! .uy == vddbar.ly
 
         LayoutRect vssbar:
             .layer=layers.Metal1

--- a/ordec/lib/ihp130.py
+++ b/ordec/lib/ihp130.py
@@ -259,53 +259,53 @@ def layoutgen_mos(cell: Cell, length: R, width: R, num_gates: int, nwell: bool) 
         nonlocal l, s, x_cur, activ_ext
         l.sd[i] = LayoutRect(layer=layers.Metal1)
         sd = l.sd[i]
-        s.constrain(sd.rect.west == (x_cur, l.activ.rect.cy))
-        s.constrain(sd.rect.width == 160)
+        s.constrain(sd.west == (x_cur, l.activ.cy))
+        s.constrain(sd.width == 160)
         if W >= 300:
-            s.constrain(sd.rect.height == W)
+            s.constrain(sd.height == W)
         else:
-            s.constrain(sd.rect.height == 260)
+            s.constrain(sd.height == 260)
 
             activ_ext = l % LayoutRect(layer=layers.Activ)
-            s.constrain(activ_ext.rect.center == sd.rect.center)
-            s.constrain(activ_ext.rect.size == (300, 300))
-        x_cur = sd.rect.ux    
+            s.constrain(activ_ext.center == sd.center)
+            s.constrain(activ_ext.size == (300, 300))
+        x_cur = sd.ux
 
     def add_poly(i):
         nonlocal l, s, x_cur
         x_cur += 110
         l.poly[i] = LayoutRect(layer=layers.GatPoly)
         poly = l.poly[i]
-        s.constrain(poly.rect.west == (x_cur, l.activ.rect.cy))
-        s.constrain(poly.rect.size == (L, l.activ.rect.height + 360))
-        s.constrain(poly.rect.ly == 0)
-        x_cur = poly.rect.ux + 110
+        s.constrain(poly.west == (x_cur, l.activ.cy))
+        s.constrain(poly.size == (L, l.activ.height + 360))
+        s.constrain(poly.ly == 0)
+        x_cur = poly.ux + 110
 
     l.activ = LayoutRect(layer=layers.Activ)
-    s.constrain(l.activ.rect.height == W)
-    s.constrain(l.activ.rect.lx == 0)
-    x_cur = l.activ.rect.lx + 70
+    s.constrain(l.activ.height == W)
+    s.constrain(l.activ.lx == 0)
+    x_cur = l.activ.lx + 70
 
     add_sd(0)
     for i in range(num_gates):
         add_poly(i)
         add_sd(i+1)
 
-    s.constrain(l.activ.rect.ux == x_cur + 70)
+    s.constrain(l.activ.ux == x_cur + 70)
 
     if nwell:
         l.psd = LayoutRect(layer=layers.pSD)
-        s.constrain(l.psd.rect.center == l.activ.rect.center)
-        s.constrain(l.psd.rect.size == l.activ.rect.size + Vec2I(360, 600))
+        s.constrain(l.psd.center == l.activ.center)
+        s.constrain(l.psd.size == l.activ.size + Vec2I(360, 600))
 
         if activ_ext is None:
             max_activ = l.activ
         else:
             max_activ = activ_ext
         l.nwell = LayoutRect(layer=layers.NWell)
-        s.constrain(l.nwell.rect.center == l.activ.rect.center)
-        s.constrain(l.nwell.rect.ux == l.activ.rect.ux + 310)
-        s.constrain(l.nwell.rect.uy == max_activ.rect.uy + 310)
+        s.constrain(l.nwell.center == l.activ.center)
+        s.constrain(l.nwell.ux == l.activ.ux + 310)
+        s.constrain(l.nwell.uy == max_activ.uy + 310)
 
     s.solve()
 
@@ -373,8 +373,8 @@ def layoutgen_tap(cell: Cell, length: R, width: R, nwell: bool):
     W = int(width/R("1n"))
 
     l.activ = LayoutRect(layer=layers.Activ)
-    s.constrain(l.activ.rect.size == (L, W))
-    s.constrain(l.activ.rect.southwest == (0, 0))
+    s.constrain(l.activ.size == (L, W))
+    s.constrain(l.activ.southwest == (0, 0))
 
     l.m1 = LayoutRect(layer=layers.Metal1)
 
@@ -382,15 +382,15 @@ def layoutgen_tap(cell: Cell, length: R, width: R, nwell: bool):
 
     if nwell:
         l.nwell = LayoutRect(layer=layers.NWell)
-        s.constrain(l.nwell.rect.center == l.activ.rect.center)
-        s.constrain(l.nwell.rect.size == l.activ.rect.size + Vec2I(480, 480))
+        s.constrain(l.nwell.center == l.activ.center)
+        s.constrain(l.nwell.size == l.activ.size + Vec2I(480, 480))
 
         l.nbulay = LayoutRect(layer=layers.nBuLay)
         s.constrain(l.nbulay.rect == l.nwell.rect)
     else:
         l.psd = LayoutRect(layer=layers.pSD)
-        s.constrain(l.psd.rect.center == l.activ.rect.center)
-        s.constrain(l.psd.rect.size == l.activ.rect.size + Vec2I(60, 60))
+        s.constrain(l.psd.center == l.activ.center)
+        s.constrain(l.psd.size == l.activ.size + Vec2I(60, 60))
 
     s.solve()
 

--- a/ordec/ord2/context.py
+++ b/ordec/ord2/context.py
@@ -9,8 +9,9 @@ from ..core import *
 from ..schematic.helpers import recursive_setitem, recursive_getitem
 
 _ctx_var = ContextVar("ctx", default=None)
+_view_ctx_var = ContextVar("view_ctx", default=None)
 
-class Context:
+class NodeContext:
     """
     Class which represents the context where a specific
     ORDB element is alive and accessible via relative
@@ -54,6 +55,14 @@ def add_port(name_tuple):
     net = add(name_tuple, Net(pin=pin))
     subgraph_root % SchemPort(ref=net)
     return net
+
+
+def view_context():
+    return _view_ctx_var.get()
+
+
+def constrain(constraint):
+    return _view_ctx_var.get().constrain(constraint)
 
 
 def add_element(name_tuple, element):

--- a/ordec/ord2/context.py
+++ b/ordec/ord2/context.py
@@ -58,3 +58,39 @@ class OrdContext:
         net = self.add(name_tuple, Net(pin=pin))
         subgraph_root % SchemPort(ref=net)
         return net
+
+    def add_element(self, name_tuple, element):
+        """
+        Add a context element, dispatching based on element type.
+
+        Args:
+            name_tuple: path components for naming the element.
+            element: Cell class, Cell instance, Node subclass,
+                or NodeTuple instance.
+        """
+        if isinstance(element, type) and issubclass(element, Cell):
+            # Cell class: deferred resolution with parameters
+            ref = SchemInstanceUnresolved(
+                resolver=lambda **params: element(**params).symbol
+            )
+            return self.add(name_tuple, ref)
+
+        if isinstance(element, Cell):
+            # Cell instance: symbol already determined, params are fixed
+            ref = SchemInstanceUnresolved(
+                resolver=lambda: element.symbol
+            )
+            return self.add(name_tuple, ref)
+
+        if isinstance(element, type) and issubclass(element, Node):
+            # Node subclass: instantiate with defaults
+            return self.add(name_tuple, element())
+
+        if isinstance(element, NodeTuple):
+            # Node instance: add directly
+            return self.add(name_tuple, element)
+
+        raise TypeError(
+            f"Cannot use {element!r} as context element. "
+            f"Expected Cell class/instance or Node class/instance."
+        )

--- a/ordec/ord2/context.py
+++ b/ordec/ord2/context.py
@@ -25,19 +25,14 @@ class OrdContext:
     """
     ctx = _CtxWrapper()
 
-    def __init__(self, root=None, parent=None):
+    def __init__(self, root):
         self.root = root
-        self._explicit_parent = parent
-        self.parent = None
 
     def __enter__(self):
         """Enter context, set context variable and save parent"""
         self._token = _ctx_var.set(self)
-        if self._token.old_value is not Token.MISSING:
-            self.parent = self._token.old_value
-        else:
-            # Case for the top-level context
-            self.parent = self._explicit_parent
+        old = self._token.old_value
+        self.parent = old if old is not Token.MISSING else None
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):

--- a/ordec/ord2/context.py
+++ b/ordec/ord2/context.py
@@ -41,6 +41,10 @@ def root():
 def add(name_tuple, ref):
     """ Add a value to the current context"""
     ctx = _ctx_var.get()
+    if name_tuple is None:
+        # Anonymous: add to subgraph without NPath
+        nid_new = ctx.root.subgraph.add(ref)
+        return ctx.root.subgraph.cursor_at(nid_new, lookup_npath=False)
     recursive_setitem(ctx.root, name_tuple, ref)
     return recursive_getitem(ctx.root, name_tuple)
 

--- a/ordec/ord2/context.py
+++ b/ordec/ord2/context.py
@@ -1,36 +1,10 @@
 # SPDX-FileCopyrightText: 2025 ORDeC contributors
 # SPDX-License-Identifier: Apache-2.0
 
-# standard imports
-from contextvars import ContextVar, Token
-
 # ordec imports
 from ..core import *
+from ..core.context import _ctx_var, _view_ctx_var
 from ..schematic.helpers import recursive_setitem, recursive_getitem
-
-_ctx_var = ContextVar("ctx", default=None)
-_view_ctx_var = ContextVar("view_ctx", default=None)
-
-class NodeContext:
-    """
-    Class which represents the context where a specific
-    ORDB element is alive and accessible via relative
-    accesses (dotted notation)
-    """
-
-    def __init__(self, root):
-        self.root = root
-
-    def __enter__(self):
-        """Enter context, set context variable and save parent"""
-        self._token = _ctx_var.set(self)
-        old = self._token.old_value
-        self.parent = old if old is not Token.MISSING else None
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        """Exit context and reset context variable"""
-        _ctx_var.reset(self._token)
 
 
 def root():

--- a/ordec/ord2/context.py
+++ b/ordec/ord2/context.py
@@ -56,7 +56,12 @@ class OrdContext:
 
     def add_element(self, name_tuple, element):
         """
-        Add a context element, dispatching based on element type.
+        Add an element from a node statement, dispatching based on type.
+
+        Handles the three types of node statements:
+        - Node class statements (e.g., LayoutRect x)
+        - Node instance statements (e.g., Nmos x)
+        - Cell class/instance statements (e.g., Inv x)
 
         Args:
             name_tuple: path components for naming the element.
@@ -92,6 +97,6 @@ class OrdContext:
             return self.add(name_tuple, element)
 
         raise TypeError(
-            f"Cannot use {element!r} as context element. "
+            f"Cannot use {element!r} in node statement. "
             f"Expected Cell class/instance or Node class/instance."
         )

--- a/ordec/ord2/context.py
+++ b/ordec/ord2/context.py
@@ -9,21 +9,13 @@ from ..core import *
 from ..schematic.helpers import recursive_setitem, recursive_getitem
 
 _ctx_var = ContextVar("ctx", default=None)
-class _CtxWrapper:
-    """Wrapper for the context variable"""
-    def __getattr__(self, item):
-        return getattr(_ctx_var.get(), item)
 
-    def __call__(self):
-        return _ctx_var.get()
-
-class OrdContext:
+class Context:
     """
     Class which represents the context where a specific
     ORDB element is alive and accessible via relative
     accesses (dotted notation)
     """
-    ctx = _CtxWrapper()
 
     def __init__(self, root):
         self.root = root
@@ -39,62 +31,73 @@ class OrdContext:
         """Exit context and reset context variable"""
         _ctx_var.reset(self._token)
 
-    def add(self, name_tuple, ref):
-        """ Add a value to the current context"""
-        recursive_setitem(self.root, name_tuple, ref)
-        return recursive_getitem(self.root, name_tuple)
 
-    def add_port(self, name_tuple):
-        """ Add a port to the current context"""
-        pin = recursive_getitem(self.root.symbol, name_tuple)
-        subgraph_root = self.root
-        while not isinstance(subgraph_root, SubgraphRoot):
-            subgraph_root = subgraph_root.parent
-        net = self.add(name_tuple, Net(pin=pin))
-        subgraph_root % SchemPort(ref=net)
-        return net
+def root():
+    """Return the root of the current context"""
+    return _ctx_var.get().root
 
-    def add_element(self, name_tuple, element):
-        """
-        Add an element from a node statement, dispatching based on type.
 
-        Handles the three types of node statements:
-        - Node class statements (e.g., LayoutRect x)
-        - Node instance statements (e.g., Nmos x)
-        - Cell class/instance statements (e.g., Inv x)
+def add(name_tuple, ref):
+    """ Add a value to the current context"""
+    ctx = _ctx_var.get()
+    recursive_setitem(ctx.root, name_tuple, ref)
+    return recursive_getitem(ctx.root, name_tuple)
 
-        Args:
-            name_tuple: path components for naming the element.
-            element: Cell class, Cell instance, Node subclass,
-                or NodeTuple instance.
-        """
-        # Layout context: create LayoutInstance from Cell instances
-        if isinstance(self.root, Layout):
-            if isinstance(element, Cell):
-                ref = LayoutInstance(ref=element.layout)
-                return self.add(name_tuple, ref)
 
-        if isinstance(element, type) and issubclass(element, Cell):
-            # Cell class: deferred resolution with parameters
-            ref = SchemInstanceUnresolved(
-                resolver=lambda **params: element(**params).symbol
-            )
-            return self.add(name_tuple, ref)
+def add_port(name_tuple):
+    """ Add a port to the current context"""
+    ctx = _ctx_var.get()
+    pin = recursive_getitem(ctx.root.symbol, name_tuple)
+    subgraph_root = ctx.root
+    while not isinstance(subgraph_root, SubgraphRoot):
+        subgraph_root = subgraph_root.parent
+    net = add(name_tuple, Net(pin=pin))
+    subgraph_root % SchemPort(ref=net)
+    return net
 
+
+def add_element(name_tuple, element):
+    """
+    Add an element from a node statement, dispatching based on type.
+
+    Handles the three types of node statements:
+    - Node class statements (e.g., LayoutRect x)
+    - Node instance statements (e.g., Nmos x)
+    - Cell class/instance statements (e.g., Inv x)
+
+    Args:
+        name_tuple: path components for naming the element.
+        element: Cell class, Cell instance, Node subclass,
+            or NodeTuple instance.
+    """
+    ctx = _ctx_var.get()
+    # Layout context: create LayoutInstance from Cell instances
+    if isinstance(ctx.root, Layout):
         if isinstance(element, Cell):
-            # Cell instance: symbol already determined, create SchemInstance directly
-            ref = SchemInstance(symbol=element.symbol)
-            return self.add(name_tuple, ref)
+            ref = LayoutInstance(ref=element.layout)
+            return add(name_tuple, ref)
 
-        if isinstance(element, type) and issubclass(element, Node):
-            # Node subclass: instantiate with defaults
-            return self.add(name_tuple, element())
-
-        if isinstance(element, NodeTuple):
-            # Node instance: add directly
-            return self.add(name_tuple, element)
-
-        raise TypeError(
-            f"Cannot use {element!r} in node statement. "
-            f"Expected Cell class/instance or Node class/instance."
+    if isinstance(element, type) and issubclass(element, Cell):
+        # Cell class: deferred resolution with parameters
+        ref = SchemInstanceUnresolved(
+            resolver=lambda **params: element(**params).symbol
         )
+        return add(name_tuple, ref)
+
+    if isinstance(element, Cell):
+        # Cell instance: symbol already determined, create SchemInstance directly
+        ref = SchemInstance(symbol=element.symbol)
+        return add(name_tuple, ref)
+
+    if isinstance(element, type) and issubclass(element, Node):
+        # Node subclass: instantiate with defaults
+        return add(name_tuple, element())
+
+    if isinstance(element, NodeTuple):
+        # Node instance: add directly
+        return add(name_tuple, element)
+
+    raise TypeError(
+        f"Cannot use {element!r} in node statement. "
+        f"Expected Cell class/instance or Node class/instance."
+    )

--- a/ordec/ord2/context.py
+++ b/ordec/ord2/context.py
@@ -63,6 +63,12 @@ class OrdContext:
             element: Cell class, Cell instance, Node subclass,
                 or NodeTuple instance.
         """
+        # Layout context: create LayoutInstance from Cell instances
+        if isinstance(self.root, Layout):
+            if isinstance(element, Cell):
+                ref = LayoutInstance(ref=element.layout)
+                return self.add(name_tuple, ref)
+
         if isinstance(element, type) and issubclass(element, Cell):
             # Cell class: deferred resolution with parameters
             ref = SchemInstanceUnresolved(

--- a/ordec/ord2/context.py
+++ b/ordec/ord2/context.py
@@ -82,10 +82,8 @@ class OrdContext:
             return self.add(name_tuple, ref)
 
         if isinstance(element, Cell):
-            # Cell instance: symbol already determined, params are fixed
-            ref = SchemInstanceUnresolved(
-                resolver=lambda: element.symbol
-            )
+            # Cell instance: symbol already determined, create SchemInstance directly
+            ref = SchemInstance(symbol=element.symbol)
             return self.add(name_tuple, ref)
 
         if isinstance(element, type) and issubclass(element, Node):

--- a/ordec/ord2/ord2.lark
+++ b/ordec/ord2/ord2.lark
@@ -93,7 +93,6 @@ lambda_kwparams: "**" name ","?
             | global_stmt
             | nonlocal_stmt
             | assert_stmt
-            | connect_stmt
             | path_stmt
             | net_stmt
             | constrain_stmt
@@ -380,7 +379,6 @@ RATIONAL: DEC_NUMBER SLASH DEC_NUMBER
         | DEC_NUMBER SI?
         | FLOAT_NUMBER SI?
 
-connect_stmt: testlist_star_expr "--" testlist_star_expr
 celldef: "cell" name ":" suite
 viewgen: "viewgen" name ["(" [arguments] ")"] "->" name ":" suite
 constrain_stmt: "!" test

--- a/ordec/ord2/ord2.lark
+++ b/ordec/ord2/ord2.lark
@@ -386,7 +386,7 @@ viewgen: "viewgen" name ["(" [arguments] ")"] "->" name ":" suite
 constrain_stmt: "!" test
 context_body: ":" suite
 node_stmt: atom_expr context_target context_body
-node_stmt_nobody: atom_expr context_target
+node_stmt_nobody: atom_expr context_target ("," context_target)*
 
 ?context_target: context_target "." name -> getattr
 		       | context_target "[" subscriptlist "]" -> getitem

--- a/ordec/ord2/ord2.lark
+++ b/ordec/ord2/ord2.lark
@@ -97,7 +97,7 @@ lambda_kwparams: "**" name ","?
             | path_stmt
             | net_stmt
             | constrain_stmt
-            | context_element_nobody)
+            | node_stmt_nobody)
 
 expr_stmt: testlist_star_expr
 assign_stmt: annassign | augassign | assign
@@ -135,7 +135,7 @@ assert_stmt: "assert" test ["," test]
 
 ?compound_stmt: if_stmt | while_stmt | for_stmt | try_stmt | match_stmt
               | with_stmt | funcdef | classdef | celldef | decorated | async_stmt | viewgen
-              | context_element
+              | node_stmt
 async_stmt: "async" (funcdef | with_stmt | for_stmt)
 if_stmt: "if" test ":" suite elifs ["else" ":" suite]
 elifs: elif_*
@@ -385,8 +385,8 @@ celldef: "cell" name ":" suite
 viewgen: "viewgen" name ["(" [arguments] ")"] "->" name ":" suite
 constrain_stmt: "!" test
 context_body: ":" suite
-context_element: atom_expr context_target context_body
-context_element_nobody: atom_expr context_target
+node_stmt: atom_expr context_target context_body
+node_stmt_nobody: atom_expr context_target
 
 ?context_target: context_target "." name -> getattr
 		       | context_target "[" subscriptlist "]" -> getitem

--- a/ordec/ord2/ord2.lark
+++ b/ordec/ord2/ord2.lark
@@ -96,7 +96,8 @@ lambda_kwparams: "**" name ","?
             | connect_stmt
             | path_stmt
             | net_stmt
-            | constrain_stmt)
+            | constrain_stmt
+            | context_element_nobody)
 
 expr_stmt: testlist_star_expr
 assign_stmt: annassign | augassign | assign
@@ -385,6 +386,7 @@ viewgen: "viewgen" name ["(" [arguments] ")"] "->" name ":" suite
 constrain_stmt: "!" test
 context_body: ":" suite
 context_element: atom_expr context_target context_body
+context_element_nobody: atom_expr context_target
 
 ?context_target: context_target "." name -> getattr
 		       | context_target "[" subscriptlist "]" -> getitem

--- a/ordec/ord2/ord2.lark
+++ b/ordec/ord2/ord2.lark
@@ -96,7 +96,7 @@ lambda_kwparams: "**" name ","?
             | path_stmt
             | net_stmt
             | constrain_stmt
-            | node_stmt_nobody)
+            | node_stmt_nobody | anon_node_stmt_nobody)
 
 expr_stmt: testlist_star_expr
 assign_stmt: annassign | augassign | assign
@@ -134,7 +134,7 @@ assert_stmt: "assert" test ["," test]
 
 ?compound_stmt: if_stmt | while_stmt | for_stmt | try_stmt | match_stmt
               | with_stmt | funcdef | classdef | celldef | decorated | async_stmt | viewgen
-              | node_stmt
+              | node_stmt | anon_node_stmt
 async_stmt: "async" (funcdef | with_stmt | for_stmt)
 if_stmt: "if" test ":" suite elifs ["else" ":" suite]
 elifs: elif_*
@@ -357,7 +357,7 @@ _NEWLINE: ( /\r?\n[\t ]*/ | COMMENT )+
 %declare _INDENT _DEDENT
 
 // Python terminals
-!name: NAME | "match" | "case"
+!name: NAME | "match" | "case" | "anonymous"
 NAME: /[^\W\d]\w*(?!['"])/
 COMMENT: /#[^\n]*/
 
@@ -385,6 +385,8 @@ constrain_stmt: "!" test
 context_body: ":" suite
 node_stmt: atom_expr context_target context_body
 node_stmt_nobody: atom_expr context_target ("," context_target)*
+anon_node_stmt: "anonymous" atom_expr context_target context_body
+anon_node_stmt_nobody: "anonymous" atom_expr context_target ("," context_target)*
 
 ?context_target: context_target "." name -> getattr
 		       | context_target "[" subscriptlist "]" -> getitem

--- a/ordec/ord2/ord2_transformer.py
+++ b/ordec/ord2/ord2_transformer.py
@@ -215,8 +215,14 @@ class Ord2Transformer(PythonTransformer):
         else:
             raise Exception(f"Incompatible path type: {nodes!r}")
 
-    def context_element(self, nodes):
-        """ context_element (context_type context_target:\n    suite)"""
+    def node_stmt(self, nodes):
+        """Node statement: 'Type name' with optional body.
+
+        There are three types of node statements:
+        - Node class statements: e.g., LayoutRect x
+        - Node instance statements: e.g., Nmos x
+        - Node keyword statements: e.g., input x, port x
+        """
         context_type = nodes[0]
         context_name = nodes[1]
         context_body = nodes[2] if len(nodes) > 2 else None
@@ -306,9 +312,9 @@ class Ord2Transformer(PythonTransformer):
         )
         return [assignment, with_stmt]
 
-    def context_element_nobody(self, nodes):
-        """context_element without body (e.g., 'port x' or 'Pmos m1')"""
-        return self.context_element(nodes)
+    def node_stmt_nobody(self, nodes):
+        """Node statement without body (e.g., 'port x' or 'Pmos m1')"""
+        return self.node_stmt(nodes)
 
     def depth_helper(self, value, depth=1):
         """ Access parent attributes depending on the dotted depth"""
@@ -394,7 +400,7 @@ class Ord2Transformer(PythonTransformer):
         return self.net_and_path_stmt_helper(nodes, "PathNode")
 
     def _flatten(self, items):
-        """ Flatten the body of the context element suite"""
+        """ Flatten the body of a node statement suite"""
         flat = []
         for item in items:
             if isinstance(item, list):

--- a/ordec/ord2/ord2_transformer.py
+++ b/ordec/ord2/ord2_transformer.py
@@ -117,17 +117,8 @@ class Ord2Transformer(PythonTransformer):
         # Build the ORD context call
         ord_context_call = ast.Call(
             func=self.ast_ord_context("OrdContext"),
-            args=[],
-            keywords=[
-                ast.keyword(
-                    arg='root',
-                    value=viewgen_call
-                ),
-                ast.keyword(
-                    arg='parent',
-                    value=self.ast_name('self')
-                )
-            ]
+            args=[viewgen_call],
+            keywords=[]
         )
         # Solver must be added to layout viewgen
         if viewgen_type_lower == "layout":
@@ -313,13 +304,8 @@ class Ord2Transformer(PythonTransformer):
                 ast.withitem(
                     context_expr=ast.Call(
                         func=self.ast_ord_context("OrdContext"),
-                        args=[],
-                        keywords=[
-                            ast.keyword(
-                                arg="root",
-                                value=context_name
-                            )
-                        ]
+                        args=[context_name],
+                        keywords=[]
                     )
                 )
             ],

--- a/ordec/ord2/ord2_transformer.py
+++ b/ordec/ord2/ord2_transformer.py
@@ -29,9 +29,6 @@ class Ord2Transformer(PythonTransformer):
     def ast_ord_context(self, attr):
         return self.ast_attribute(self.ast_name("__ord_context__"), attr)
 
-    def ast_ctx(self):
-        return self.ast_attribute(self.ast_ord_context("OrdContext"), "ctx")
-
     def celldef(self, nodes):
         """ Definition of a ORDeC cell class"""
         cell_name = nodes[0]
@@ -109,7 +106,7 @@ class Ord2Transformer(PythonTransformer):
         )
         # Build the ORD context call
         ord_context_call = ast.Call(
-            func=self.ast_ord_context("OrdContext"),
+            func=self.ast_ord_context("Context"),
             args=[viewgen_call],
             keywords=[]
         )
@@ -119,7 +116,7 @@ class Ord2Transformer(PythonTransformer):
                 targets=[self.ast_name("__ordec_solver__", ctx=ast.Store())],
                 value=ast.Call(
                     func=self.ast_core("Solver"),
-                    args=[self.ast_attribute(self.ast_ctx(), "root")],
+                    args=[ast.Call(self.ast_ord_context("root"), args=[], keywords=[])],
                     keywords=[]
                 )
             )
@@ -138,7 +135,7 @@ class Ord2Transformer(PythonTransformer):
         return_value = ast.Return(
                 ast.Call(
                 func=self.ast_attribute(
-                    self.ast_attribute(self.ast_ctx(), "root"),
+                    ast.Call(self.ast_ord_context("root"), args=[], keywords=[]),
                     "postprocess",
                 ),
                 args=[],
@@ -254,7 +251,7 @@ class Ord2Transformer(PythonTransformer):
                     inout = "Out"
 
             args = []
-            func = self.ast_attribute(self.ast_ctx(), "add")
+            func = self.ast_ord_context("add")
 
             args.append(ast.Tuple(elts=context_name_tuple, ctx=ast.Load()))
             args.append(ast.Call(
@@ -276,7 +273,7 @@ class Ord2Transformer(PythonTransformer):
         elif context_type_name == "port":
  
             args = [ast.Tuple(elts=context_name_tuple, ctx=ast.Load())]
-            func = self.ast_attribute(self.ast_ctx(),"add_port")
+            func = self.ast_ord_context("add_port")
             rhs = ast.Call(func=func, args=args, keywords=[])
 
         # Case for any other element type (Cell class/instance, Node class/instance)
@@ -285,7 +282,7 @@ class Ord2Transformer(PythonTransformer):
                 ast.Tuple(elts=context_name_tuple, ctx=ast.Load()),
                 context_type_expr
             ]
-            func = self.ast_attribute(self.ast_ctx(), "add_element")
+            func = self.ast_ord_context("add_element")
             rhs = ast.Call(func=func, args=args, keywords=[])
 
         # Path accesses must not be assigned
@@ -302,7 +299,7 @@ class Ord2Transformer(PythonTransformer):
             items=[
                 ast.withitem(
                     context_expr=ast.Call(
-                        func=self.ast_ord_context("OrdContext"),
+                        func=self.ast_ord_context("Context"),
                         args=[context_name],
                         keywords=[]
                     )
@@ -321,7 +318,7 @@ class Ord2Transformer(PythonTransformer):
 
     def depth_helper(self, value, depth=1):
         """ Access parent attributes depending on the dotted depth"""
-        node = self.ast_attribute(self.ast_ctx(), "root")
+        node = ast.Call(self.ast_ord_context("root"), args=[], keywords=[])
 
         for _ in range(depth - 1):
             node = self.ast_attribute(node,"parent")
@@ -353,10 +350,7 @@ class Ord2Transformer(PythonTransformer):
             # only dotted access
             attr = nodes[0]
             ctx = ast.Store()
-            target = self.ast_attribute(
-                self.ast_ctx(),
-                "root"
-            )
+            target = ast.Call(self.ast_ord_context("root"), args=[], keywords=[])
         return self.ast_attribute(
             self.ast_attribute(
                 target,
@@ -372,9 +366,7 @@ class Ord2Transformer(PythonTransformer):
             context_name_tuple = self.extract_path(name)
             name_length = len(context_name_tuple)
             rhs = ast.Call(
-                func=self.ast_attribute(
-                    self.ast_ctx(),
-                    "add"),
+                func=self.ast_ord_context("add"),
                 args=[
                     ast.Tuple(elts=context_name_tuple, ctx=ast.Load()),
                     ast.Call(

--- a/ordec/ord2/ord2_transformer.py
+++ b/ordec/ord2/ord2_transformer.py
@@ -99,62 +99,46 @@ class Ord2Transformer(PythonTransformer):
                 )
             )
 
+        ord_root = self.ast_name("__ord_root__")
+        ord_root_store = self.ast_name("__ord_root__", ctx=ast.Store())
+
         viewgen_call = ast.Call(
             func=self.ast_core(viewgen_type.title()),
             args=[],
             keywords=keywords
         )
-        # Build the ORD context call
-        ord_context_call = ast.Call(
-            func=self.ast_ord_context("Context"),
-            args=[viewgen_call],
+
+        # __ord_root__ = Type(cell=self, symbol=self.symbol)
+        root_assign = ast.Assign(
+            targets=[ord_root_store],
+            value=viewgen_call
+        )
+
+        # __ord_root__.view_context(__ord_root__) — access class attr, instantiate
+        view_context_call = ast.Call(
+            func=self.ast_attribute(ord_root, "view_context"),
+            args=[ord_root],
             keywords=[]
         )
-        # Solver must be added to layout viewgen
-        if viewgen_type_lower == "layout":
-            solver_create = ast.Assign(
-                targets=[self.ast_name("__ordec_solver__", ctx=ast.Store())],
-                value=ast.Call(
-                    func=self.ast_core("Solver"),
-                    args=[ast.Call(self.ast_ord_context("root"), args=[], keywords=[])],
-                    keywords=[]
-                )
-            )
-            solver_solve = ast.Expr(
-                ast.Call(
-                    func=self.ast_attribute(
-                        self.ast_name("__ordec_solver__"), "solve"
-                    ),
-                    args=[],
-                    keywords=[]
-                )
-            )
-            suite = [solver_create] + suite + [solver_solve]
 
-        # Call postprocess on the subgraph root
+        # return __ord_root__.postprocess()
         return_value = ast.Return(
-                ast.Call(
-                func=self.ast_attribute(
-                    ast.Call(self.ast_ord_context("root"), args=[], keywords=[]),
-                    "postprocess",
-                ),
+            ast.Call(
+                func=self.ast_attribute(ord_root, "postprocess"),
                 args=[],
                 keywords=[]
             )
         )
 
-        suite.append(return_value)
         with_context = ast.With(
             items=[
-                ast.withitem(
-                    context_expr=ord_context_call
-                )
+                ast.withitem(context_expr=view_context_call),
             ],
             body=suite
         )
         # Wrap with statement with context in a decorated function call
         # --> See Python implementation
-        func_body = kwarg_assignments + [with_context]
+        func_body = kwarg_assignments + [root_assign, with_context, return_value]
         func_def = ast.FunctionDef(
             name=func_name,
             args=ast.arguments(
@@ -185,9 +169,7 @@ class Ord2Transformer(PythonTransformer):
         """ ! x >= 200 """
         return ast.Expr(
             ast.Call(
-                func=self.ast_attribute(
-                    self.ast_name("__ordec_solver__"), "constrain"
-                ),
+                func=self.ast_ord_context("constrain"),
                 args=[nodes[0]],
                 keywords=[]
             )
@@ -299,8 +281,8 @@ class Ord2Transformer(PythonTransformer):
             items=[
                 ast.withitem(
                     context_expr=ast.Call(
-                        func=self.ast_ord_context("Context"),
-                        args=[context_name],
+                        func=self.ast_attribute(context_name, "ctx"),
+                        args=[],
                         keywords=[]
                     )
                 )

--- a/ordec/ord2/ord2_transformer.py
+++ b/ordec/ord2/ord2_transformer.py
@@ -101,13 +101,6 @@ class Ord2Transformer(PythonTransformer):
                     value=self.ast_attribute(self.ast_name("self"), attr="symbol")
                 )
             )
-        # For layout viewgens, map layers kwarg to ref_layers
-        if viewgen_type_lower == "layout":
-            for arg in viewgen_args:
-                if isinstance(arg, tuple) and arg[0] == "argvalue" and arg[1].id == "layers":
-                    keywords.append(
-                        ast.keyword(arg="ref_layers", value=self.ast_name("layers"))
-                    )
 
         viewgen_call = ast.Call(
             func=self.ast_core(viewgen_type.title()),

--- a/ordec/ord2/ord2_transformer.py
+++ b/ordec/ord2/ord2_transformer.py
@@ -156,15 +156,6 @@ class Ord2Transformer(PythonTransformer):
         )
         return func_def
 
-    def connect_stmt(self, nodes):
-        """ connect stmt x -- b"""
-        connect_lhs = nodes[0]
-        connect_rhs = nodes[1]
-        call = ast.Call(func=self.ast_attribute(connect_lhs, attr="__wire_op__"),
-                        args=[connect_rhs],
-                        keywords=[])
-        return ast.Expr(value=call)
-
     def constrain_stmt(self, nodes):
         """ ! x >= 200 """
         return ast.Expr(

--- a/ordec/ord2/ord2_transformer.py
+++ b/ordec/ord2/ord2_transformer.py
@@ -313,8 +313,11 @@ class Ord2Transformer(PythonTransformer):
         return [assignment, with_stmt]
 
     def node_stmt_nobody(self, nodes):
-        """Node statement without body (e.g., 'port x' or 'Pmos m1')"""
-        return self.node_stmt(nodes)
+        """Node statement without body, supports multiple names (e.g., 'Nmos a, b, c')"""
+        result = []
+        for context_target in nodes[1:]:
+            result.extend(self.node_stmt([nodes[0], context_target]))
+        return result
 
     def depth_helper(self, value, depth=1):
         """ Access parent attributes depending on the dotted depth"""

--- a/ordec/ord2/ord2_transformer.py
+++ b/ordec/ord2/ord2_transformer.py
@@ -289,53 +289,23 @@ class Ord2Transformer(PythonTransformer):
             func = self.ast_attribute(self.ast_ctx(),"add_port")
             rhs = ast.Call(func=func, args=args, keywords=[])
 
-        # Case for instantiating sub-cells
+        # Case for any other element type (Cell class/instance, Node class/instance)
         else:
-            resolver_lambda = ast.Lambda(
-                        args=ast.arguments(
-                            posonlyargs=[],
-                            args=[],
-                            kwonlyargs=[],
-                            kw_defaults=[],
-                            kwarg=ast.arg(
-                                arg="params"
-                            ),
-                            defaults=[]
-                        ),
-                        body=self.ast_attribute(
-                            ast.Call(
-                                func=context_type_expr,
-                                args=[],
-                                keywords=[
-                                    ast.keyword(
-                                        value=self.ast_name("params"),
-                                    )
-                                ]
-                            ),
-                            "symbol"
-                        )
-                    )
-
-            args = []
-            func=self.ast_attribute(self.ast_ctx(), "add")
-            args.append(ast.Tuple(elts=context_name_tuple, ctx=ast.Load()))
-            args.append(ast.Call(
-                        func=self.ast_core("SchemInstanceUnresolved"),
-                        keywords=[
-                            ast.keyword(
-                                arg="resolver",
-                                value=resolver_lambda
-                            )
-                        ],
-                        args=[]
-                )
-            )
+            args = [
+                ast.Tuple(elts=context_name_tuple, ctx=ast.Load()),
+                context_type_expr
+            ]
+            func = self.ast_attribute(self.ast_ctx(), "add_element")
             rhs = ast.Call(func=func, args=args, keywords=[])
+
         # Path accesses must not be assigned
         if path_node:
             assignment = ast.Expr(rhs)
         else:
             assignment = ast.Assign([lhs], rhs)
+
+        if context_body is None:
+            return [assignment]
 
         # Combine to context-with stmt
         with_stmt = ast.With(
@@ -356,6 +326,10 @@ class Ord2Transformer(PythonTransformer):
             body=context_body if isinstance(context_body, list) else [context_body]
         )
         return [assignment, with_stmt]
+
+    def context_element_nobody(self, nodes):
+        """context_element without body (e.g., 'port x' or 'Pmos m1')"""
+        return self.context_element(nodes)
 
     def depth_helper(self, value, depth=1):
         """ Access parent attributes depending on the dotted depth"""

--- a/ordec/ord2/ord2_transformer.py
+++ b/ordec/ord2/ord2_transformer.py
@@ -282,6 +282,49 @@ class Ord2Transformer(PythonTransformer):
         )
         return [assignment, with_stmt]
 
+    def anon_node_stmt(self, nodes):
+        """Anonymous node statement: 'anonymous Type name' with optional body.
+
+        Like node_stmt but passes None as name_tuple, so no NPath is created.
+        """
+        context_type = nodes[0]
+        context_name = nodes[1]
+        context_body = nodes[2] if len(nodes) > 2 else None
+
+        rhs = ast.Call(
+            func=self.ast_ord_context("add_element"),
+            args=[ast.Constant(value=None), context_type],
+            keywords=[]
+        )
+
+        target = copy.copy(context_name)
+        self._set_ctx(target, ast.Store())
+        assignment = ast.Assign([target], rhs)
+
+        if context_body is None:
+            return [assignment]
+
+        with_stmt = ast.With(
+            items=[
+                ast.withitem(
+                    context_expr=ast.Call(
+                        func=self.ast_attribute(context_name, "ctx"),
+                        args=[],
+                        keywords=[]
+                    )
+                )
+            ],
+            body=context_body if isinstance(context_body, list) else [context_body]
+        )
+        return [assignment, with_stmt]
+
+    def anon_node_stmt_nobody(self, nodes):
+        """Anonymous node statement without body, supports multiple names."""
+        result = []
+        for context_target in nodes[1:]:
+            result.extend(self.anon_node_stmt([nodes[0], context_target]))
+        return result
+
     def node_stmt_nobody(self, nodes):
         """Node statement without body, supports multiple names (e.g., 'Nmos a, b, c')"""
         result = []

--- a/ordec/ord2/python_transformer.py
+++ b/ordec/ord2/python_transformer.py
@@ -13,6 +13,18 @@ class PythonTransformer(Transformer):
     This Class represents the base of the ORD language
     """
 
+    def _call_userfunc(self, tree, new_children=None):
+        result = super()._call_userfunc(tree, new_children)
+        if isinstance(result, ast.AST) and hasattr(tree, 'meta'):
+            meta = tree.meta
+            if meta.line is not None:
+                result.lineno = meta.line
+                result.col_offset = (meta.column or 1) - 1
+            if meta.end_line is not None:
+                result.end_lineno = meta.end_line
+                result.end_col_offset = (meta.end_column or 1) - 1
+        return result
+
     # Variables
     # ---------
 

--- a/ordec/ord2/python_transformer.py
+++ b/ordec/ord2/python_transformer.py
@@ -206,6 +206,8 @@ class PythonTransformer(Transformer):
     SLASH = lambda self, token: token.value
     STRING_OTHER_PREFIX = lambda self, token: token.value
     MATCH = lambda self, token: token.value
+    CASE = lambda self, token: token.value
+    ANONYMOUS = lambda self, token: token.value
 
     # Statements
     # ----------

--- a/ordec/server.py
+++ b/ordec/server.py
@@ -57,6 +57,8 @@ import argparse
 import http
 import json
 import traceback
+import linecache
+import itertools
 import queue
 from pathlib import Path
 from types import ModuleType
@@ -85,9 +87,9 @@ from websockets.http11 import Request, Response
 from websockets.datastructures import Headers
 from websockets.exceptions import ConnectionClosedOK
 
-from . import importer
+from . import importer, language
 from .version import version
-from .core import Cell, generate, generate_func, SubgraphRoot 
+from .core import Cell, generate, generate_func, SubgraphRoot
 from .language import compile_ord
 from .extlibrary import ExtLibrary
 
@@ -293,6 +295,30 @@ class ImportTracker:
                 return spec
         return None
 
+def is_internal_frame(filename):
+    from .ord2 import parser as ord2_parser
+    internal_files = {
+        __file__,
+        importer.__file__,
+        language.__file__,
+        ord2_parser.__file__
+        }
+    return (filename in internal_files
+        or (filename.startswith('<') and filename != '<webeditor>')
+        or 'importlib' in filename)
+
+def format_user_exception(exc):
+    """Format exception for the web UI, keeping only user-relevant frames."""
+    all_frames = traceback.extract_tb(exc.__traceback__)
+    frames = list(itertools.dropwhile(
+        lambda f: is_internal_frame(f.filename), all_frames
+    ))
+    parts = ['Traceback (most recent call last):\n']
+    if frames:
+        parts += traceback.format_list(frames)
+    parts += traceback.format_exception_only(type(exc), exc)
+    return ''.join(parts)
+
 class ConnectionHandler:
     def __init__(self, key, sysmodules_orig):
         self.sysmodules_orig = set(sysmodules_orig.keys())
@@ -320,18 +346,25 @@ class ConnectionHandler:
                 viewtype, data = view.webdata()
             msg_ret['type'] = viewtype
             msg_ret['data'] = data
-        except:    
-            msg_ret['exception'] = traceback.format_exc()
+        except Exception as e:
+            msg_ret['exception'] = format_user_exception(e)
 
         return msg_ret
+
 
     def build_cells(self, source_type: str, source_data: str) -> (dict, dict):
         conn_globals = {}
         exc = None
+        filename = '<webeditor>'
+        # Populate linecache so tracebacks can display the original source lines.
+        source_lines = [line + '\n' for line in source_data.splitlines()]
+        linecache.cache[filename] = (
+            len(source_data), None, source_lines, filename
+        )
         if source_type == 'ord':
             # Having the import here enables auto-reloading of ord.
             try:
-                code = compile_ord(source_data, conn_globals)
+                code = compile_ord(source_data, conn_globals, filename=filename)
             except Exception as e:
                 exc = e
             else:
@@ -343,7 +376,8 @@ class ConnectionHandler:
         elif source_type == 'python':
             with self.import_lock.write():
                 try:
-                    exec(source_data, conn_globals, conn_globals)
+                    code = compile(source_data, filename, 'exec')
+                    exec(code, conn_globals, conn_globals)
                 except Exception as e:
                     exc = e
         else:
@@ -406,10 +440,9 @@ class ConnectionHandler:
             raise Exception("Excpected 'source' or 'localmodule' message.")
         
         if exc:
-            exc_str = ''.join(traceback.format_exception(exc))
             websocket.send(json.dumps({
                 'msg': 'exception',
-                'exception': exc_str,
+                'exception': format_user_exception(exc),
             }))
         else: 
             websocket.send(json.dumps({

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,51 @@
 # SPDX-FileCopyrightText: 2025 ORDeC contributors
 # SPDX-License-Identifier: Apache-2.0
 
+import types
 import pytest
 from ordec.core import Subgraph
+from ordec.language import compile_ord
+
+
+class OrdFile(pytest.File):
+    """Collect test_* functions from .ord files."""
+
+    def collect(self):
+        source = self.path.read_text()
+        mod = types.ModuleType(self.path.stem)
+        mod.__file__ = str(self.path)
+        try:
+            code = compile_ord(source, mod.__dict__, str(self.path))
+            exec(code, mod.__dict__)
+        except Exception as exc:
+            # Report compilation failure as a single failing test item
+            # so that other test files are still collected and run.
+            yield OrdCompileError.from_parent(self, name="compile", error=exc)
+            return
+        for name, obj in mod.__dict__.items():
+            if name.startswith("test_") and callable(obj):
+                yield pytest.Function.from_parent(self, name=name, callobj=obj)
+
+
+class OrdCompileError(pytest.Item):
+    """A test item that fails with the .ord file's compilation error."""
+
+    def __init__(self, name, parent, error):
+        super().__init__(name, parent)
+        self.error = error
+
+    def runtest(self):
+        raise self.error
+
+    def repr_failure(self, excinfo):
+        return str(excinfo.value)
+
+    def reportinfo(self):
+        return self.path, None, f"{self.path}::compile"
+
+def pytest_collect_file(file_path, parent):
+    if file_path.suffix == ".ord" and file_path.stem.startswith("test_"):
+        return OrdFile.from_parent(parent, path=file_path)
 
 # TODO: --upgrade-golden-files and --update-ord-files are currently not used.
 

--- a/tests/lib/ihp130_inv.py
+++ b/tests/lib/ihp130_inv.py
@@ -69,18 +69,18 @@ class Inv(Cell):
 
         # Example use of the new LayoutInstanceSubcursor:
         l.m1_vdd = LayoutRect(layer=layers.Metal1)
-        s.constrain(l.m1_vdd.rect.southwest == l.ntap.m1.rect.southeast)
-        s.constrain(l.m1_vdd.rect.southeast == l.pmos.sd[0].rect.southwest)
+        s.constrain(l.m1_vdd.southwest == l.ntap.m1.southeast)
+        s.constrain(l.m1_vdd.southeast == l.pmos.sd[0].southwest)
 
-        s.constrain(l.m1_vdd.rect.ux == l.pmos.sd[0].rect.lx)
-        s.constrain(l.m1_vdd.rect.height == (100 if self.variant=='thin_m1' else 160))
-        s.constrain(l.m1_vdd.rect.width == 800)
+        s.constrain(l.m1_vdd.ux == l.pmos.sd[0].lx)
+        s.constrain(l.m1_vdd.height == (100 if self.variant=='thin_m1' else 160))
+        s.constrain(l.m1_vdd.width == 800)
 
         l.m1_vss = LayoutRect(layer=layers.Metal1)
-        s.constrain(l.m1_vss.rect.southwest == l.ptap.m1.rect.southeast)
-        s.constrain(l.m1_vss.rect.southeast == l.nmos.sd[0].rect.southwest)
-        s.constrain(l.m1_vss.rect.height == (100 if self.variant=='thin_m1' else 160))
-        s.constrain(l.m1_vss.rect.width == 800)
+        s.constrain(l.m1_vss.southwest == l.ptap.m1.southeast)
+        s.constrain(l.m1_vss.southeast == l.nmos.sd[0].southwest)
+        s.constrain(l.m1_vss.height == (100 if self.variant=='thin_m1' else 160))
+        s.constrain(l.m1_vss.width == 800)
 
         if self.variant=="vss_vdd_pins_swapped":
             l.m1_vss % LayoutPin(pin=self.symbol.vdd)
@@ -91,32 +91,32 @@ class Inv(Cell):
 
         if self.variant!="missing_y":
             l.m1_y = LayoutRect(layer=layers.Metal1)
-            s.constrain(l.m1_y.rect.south == l.nmos.sd[1].rect.north)
-            s.constrain(l.m1_y.rect.north == l.pmos.sd[1].rect.south)
-            s.constrain(l.m1_y.rect.width == 160)
+            s.constrain(l.m1_y.south == l.nmos.sd[1].north)
+            s.constrain(l.m1_y.north == l.pmos.sd[1].south)
+            s.constrain(l.m1_y.width == 160)
             l.m1_y % LayoutPin(pin=self.symbol.y)
         
         l.nwell = LayoutRect(layer=layers.NWell)
-        s.constrain(l.nwell.rect.contains(l.ntap.nwell.rect))
-        s.constrain(l.nwell.rect.contains(l.pmos.nwell.rect))
+        s.constrain(l.nwell.contains(l.ntap.nwell.rect))
+        s.constrain(l.nwell.contains(l.pmos.nwell.rect))
 
         l.polybar = LayoutRect(layer=layers.GatPoly)
-        s.constrain(l.polybar.rect.south == l.nmos.poly[0].rect.north)
-        s.constrain(l.polybar.rect.north == l.pmos.poly[0].rect.south)
-        s.constrain(l.polybar.rect.width == l.pmos.poly[0].rect.width)
+        s.constrain(l.polybar.south == l.nmos.poly[0].north)
+        s.constrain(l.polybar.north == l.pmos.poly[0].south)
+        s.constrain(l.polybar.width == l.pmos.poly[0].width)
 
         l.polyext = LayoutRect(layer=layers.GatPoly)
-        s.constrain(l.polyext.rect.size == (500, 500))
-        s.constrain(l.polyext.rect.east == l.polybar.rect.west)
+        s.constrain(l.polyext.size == (500, 500))
+        s.constrain(l.polyext.east == l.polybar.west)
 
         l.polycont = LayoutRect(layer=layers.Cont)
-        s.constrain(l.polycont.rect.size == (160, 160))
-        s.constrain(l.polycont.rect.center == l.polyext.rect.center)
+        s.constrain(l.polycont.size == (160, 160))
+        s.constrain(l.polycont.center == l.polyext.center)
 
         l.m1_a = LayoutRect(layer=layers.Metal1)
-        s.constrain(l.m1_a.rect.y_extent == l.polycont.rect.y_extent)
-        s.constrain(l.m1_a.rect.ux == l.polycont.rect.ux + 200)
-        s.constrain(l.m1_a.rect.width == 1500)
+        s.constrain(l.m1_a.y_extent == l.polycont.y_extent)
+        s.constrain(l.m1_a.ux == l.polycont.ux + 200)
+        s.constrain(l.m1_a.width == 1500)
         l.m1_a % LayoutPin(pin=self.symbol.a)
 
         s.solve()

--- a/tests/lib/ord2/inverter_constraints.ord
+++ b/tests/lib/ord2/inverter_constraints.ord
@@ -29,7 +29,7 @@ cell Inv:
             .$l = 400n
         pu.$w = 200n
             
-        solver = Solver(__ord_context__.OrdContext.ctx.root)
+        solver = Solver(__ord_context__.root())
         solver.constrain(vss.pos == (2, 1))
         solver.constrain(vdd.pos == vss.pos + (0, 12))
         solver.constrain(y.pos.y == pd.d.pos.y + 1)

--- a/tests/test_layout_constraints.py
+++ b/tests/test_layout_constraints.py
@@ -16,15 +16,15 @@ def test_equalities():
 
     s = Solver(l)
 
-    s.constrain(l.activ.rect.width == 500)
-    s.constrain(l.activ.rect.height == 150)
-    s.constrain(l.activ.rect.lx == 100)
-    s.constrain(l.activ.rect.ly == -100)
+    s.constrain(l.activ.width == 500)
+    s.constrain(l.activ.height == 150)
+    s.constrain(l.activ.lx == 100)
+    s.constrain(l.activ.ly == -100)
 
-    s.constrain(l.activ.rect.cx == l.poly.rect.cx) # align x centers
-    s.constrain(l.activ.rect.cy == l.poly.rect.cy) # align y centers
-    s.constrain(l.poly.rect.height == 300)
-    s.constrain(l.poly.rect.width == 100)
+    s.constrain(l.activ.cx == l.poly.cx) # align x centers
+    s.constrain(l.activ.cy == l.poly.cy) # align y centers
+    s.constrain(l.poly.height == 300)
+    s.constrain(l.poly.width == 100)
 
     s.solve()
 
@@ -38,9 +38,9 @@ def test_underconstrained_1():
     l.activ = LayoutRect(layer=layers.Activ)
 
     s = Solver(l)
-    s.constrain(l.activ.rect.width == 500)
-    s.constrain(l.activ.rect.height == 150)
-    s.constrain(l.activ.rect.lx == 100)
+    s.constrain(l.activ.width == 500)
+    s.constrain(l.activ.height == 150)
+    s.constrain(l.activ.lx == 100)
     # Missing constraint for ly - system is underconstrained.
 
     with pytest.raises(UnderconstrainedError) as exc_info:
@@ -61,15 +61,15 @@ def test_underconstrained_2():
 
     s = Solver(l)
 
-    # l.r1.rect.lx not constrained.
-    s.constrain(l.r1.rect.ly == 0)
-    s.constrain(l.r1.rect.height >= 100)
-    s.constrain(l.r1.rect.width >= 200)
+    # l.r1.lx not constrained.
+    s.constrain(l.r1.ly == 0)
+    s.constrain(l.r1.height >= 100)
+    s.constrain(l.r1.width >= 200)
 
-    s.constrain(l.r2.rect.lx >= l.r1.rect.ux)
-    s.constrain(l.r2.rect.ly <= l.r1.rect.lx)
-    s.constrain(l.r2.rect.width == l.r2.rect.height)
-    # l.r2.rect.width and .height not properly constrained.
+    s.constrain(l.r2.lx >= l.r1.ux)
+    s.constrain(l.r2.ly <= l.r1.lx)
+    s.constrain(l.r2.width == l.r2.height)
+    # l.r2.width and .height not properly constrained.
 
     with pytest.raises(UnderconstrainedError) as exc_info:
         s.solve()
@@ -85,11 +85,11 @@ def test_missing_variables():
 
     l.activ = LayoutRect(layer=layers.Activ)
 
-    # For l.activ.rect, ly und uy have constraints, but lx and ux have non constraints.
+    # For l.activ, ly and uy have constraints, but lx and ux have no constraints.
 
     s = Solver(l)
-    s.constrain(l.activ.rect.ly == 100)
-    s.constrain(l.activ.rect.uy == 200)
+    s.constrain(l.activ.ly == 100)
+    s.constrain(l.activ.uy == 200)
 
     with pytest.raises(UnderconstrainedError) as exc_info:
         s.solve()
@@ -107,16 +107,16 @@ def test_inequalities():
     l.r2 = LayoutRect(layer=layers.Metal1)
 
     s = Solver(l)
-    s.constrain(l.r1.rect.height >= 500)
-    s.constrain(l.r1.rect.width >= 150)
-    s.constrain(l.r1.rect.southwest == (100, -100))
+    s.constrain(l.r1.height >= 500)
+    s.constrain(l.r1.width >= 150)
+    s.constrain(l.r1.southwest == (100, -100))
 
-    s.constrain(l.r2.rect.lx >= l.r1.rect.ux + 150)
-    s.constrain(l.r2.rect.width == -l.r1.rect.height + 800)
-    s.constrain(l.r2.rect.width <= 150) # Adjust this factor & see what happens.
+    s.constrain(l.r2.lx >= l.r1.ux + 150)
+    s.constrain(l.r2.width == -l.r1.height + 800)
+    s.constrain(l.r2.width <= 150) # Adjust this factor & see what happens.
 
-    s.constrain(l.r2.rect.height == 150)
-    s.constrain(l.r2.rect.cy == l.r1.rect.cy)
+    s.constrain(l.r2.height == 150)
+    s.constrain(l.r2.cy == l.r1.cy)
 
     s.solve()
 
@@ -134,8 +134,8 @@ def test_constraint_ops():
  
     l.r1 = LayoutRect(layer=layers.Metal1)
 
-    v1 = l.r1.rect.lx
-    v2 = l.r1.rect.ux
+    v1 = l.r1.lx
+    v2 = l.r1.ux
     assert isinstance(v1 == 100, Constraint)
     assert isinstance(100 == v1, Constraint)
     assert isinstance(v1 >= 100, Constraint)
@@ -161,11 +161,11 @@ def test_no_solution():
     l.activ = LayoutRect(layer=layers.Activ)
 
     s = Solver(l)
-    s.constrain(l.activ.rect.width == 500)
-    s.constrain(l.activ.rect.height == 150)
-    s.constrain(l.activ.rect.lx == 100)
-    s.constrain(l.activ.rect.ly == -100)
-    s.constrain(l.activ.rect.ux == 900) # conflicting with lx == 100 and width == 500
+    s.constrain(l.activ.width == 500)
+    s.constrain(l.activ.height == 150)
+    s.constrain(l.activ.lx == 100)
+    s.constrain(l.activ.ly == -100)
+    s.constrain(l.activ.ux == 900) # conflicting with lx == 100 and width == 500
 
     with pytest.raises(SolverError):
         s.solve()
@@ -179,12 +179,12 @@ def test_vec2():
     l.label = LayoutLabel(layer=layers.Metal1.pin)
 
     s = Solver(l)
-    s.constrain(l.m1.rect.width == 150)
-    s.constrain(l.m1.rect.height == 150)
-    s.constrain(l.m1.rect.lx == 0)
-    s.constrain(l.m1.rect.ly == 0)
-    s.constrain(l.label.pos.x == l.m1.rect.cx)
-    s.constrain(l.label.pos.y == l.m1.rect.cy)
+    s.constrain(l.m1.width == 150)
+    s.constrain(l.m1.height == 150)
+    s.constrain(l.m1.lx == 0)
+    s.constrain(l.m1.ly == 0)
+    s.constrain(l.label.pos.x == l.m1.cx)
+    s.constrain(l.label.pos.y == l.m1.cy)
     s.solve()
 
     assert l.m1.rect == Rect4I(lx=0, ly=0, ux=150, uy=150)
@@ -197,7 +197,7 @@ def test_multiconstraint():
     l.activ = LayoutRect(layer=layers.Activ)
 
     s = Solver(l)
-    s.constrain((l.activ.rect.lx == l.activ.rect.ly) & (l.activ.rect.ly == 100))
+    s.constrain((l.activ.lx == l.activ.ly) & (l.activ.ly == 100))
     s.constrain(l.activ.rect.is_square(150))
     s.solve()
 
@@ -225,15 +225,13 @@ def test_layoutinstance_subcursor_constraints():
 
         assert isinstance(layout2.layout1_inst.myrect.rect, Rect4LinearTerm)
         s = Solver(layout2)
-        s.constrain(layout2.layout1_inst.myrect.rect.lx == 1000)
-        s.constrain(layout2.layout1_inst.myrect.rect.ly == 900)
+        s.constrain(layout2.layout1_inst.myrect.lx == 1000)
+        s.constrain(layout2.layout1_inst.myrect.ly == 900)
 
         s.solve()
-        #print(layout2.layout1_inst.myrect.rect.lx, layout2.layout1_inst.myrect.rect.ly)
-        #print(layout2.layout1_inst.pos)
 
-        assert layout2.layout1_inst.myrect.rect.lx == 1000
-        assert layout2.layout1_inst.myrect.rect.ly == 900
+        assert layout2.layout1_inst.myrect.lx == 1000
+        assert layout2.layout1_inst.myrect.ly == 900
 
 def test_variable_on_frozen_subgraph():
     layers = SG13G2().layers
@@ -255,10 +253,10 @@ def test_solve_wrong_subgraph():
     layout2.myrect = LayoutRect(layer=layers.Metal1)
 
     s = Solver(layout2)
-    s.constrain(layout1.myrect.rect.lx == 1)
-    s.constrain(layout1.myrect.rect.ux == 2)
-    s.constrain(layout1.myrect.rect.ly == 3)
-    s.constrain(layout1.myrect.rect.uy == 4)
+    s.constrain(layout1.myrect.lx == 1)
+    s.constrain(layout1.myrect.ux == 2)
+    s.constrain(layout1.myrect.ly == 3)
+    s.constrain(layout1.myrect.uy == 4)
 
     with pytest.raises(SolverError, match="Solver found Variables of unexpected subgraph"):
         s.solve()
@@ -271,10 +269,10 @@ def test_vec2_constraints_eq():
     layout.r2 = LayoutRect(layer=layers.Metal2)
     
     s = Solver(layout)
-    s.constrain(layout.r1.rect.center == layout.r2.rect.center)
-    s.constrain(layout.r1.rect.size == (100, 100))
-    s.constrain(layout.r2.rect.size == (300, 400))
-    s.constrain(layout.r1.rect.southwest == (1000, -1000))
+    s.constrain(layout.r1.center == layout.r2.center)
+    s.constrain(layout.r1.size == (100, 100))
+    s.constrain(layout.r2.size == (300, 400))
+    s.constrain(layout.r1.southwest == (1000, -1000))
     s.solve()
 
     assert layout.r1.rect == Rect4I(lx=1000, ly=-1000, ux=1100, uy=-900)
@@ -289,10 +287,10 @@ def test_rect4_constraints_eq():
     layout.r3 = LayoutRect(layer=layers.Metal3)
 
     s = Solver(layout)
-    s.constrain(layout.r1.rect.lx == 100)
-    s.constrain(layout.r1.rect.ly == 200)
-    s.constrain(layout.r1.rect.ux == 300)
-    s.constrain(layout.r1.rect.uy == 400)
+    s.constrain(layout.r1.lx == 100)
+    s.constrain(layout.r1.ly == 200)
+    s.constrain(layout.r1.ux == 300)
+    s.constrain(layout.r1.uy == 400)
     s.constrain(layout.r2.rect == layout.r1.rect)
     s.constrain(layout.r3.rect == (10, 20, 30, 40))
     s.solve()
@@ -311,17 +309,17 @@ def test_rect4_constraints_contains():
     layout.r4 = LayoutRect(layer=layers.Metal2)
 
     s = Solver(layout)
-    s.constrain(layout.r1.rect.size == (100, 100))
-    s.constrain(layout.r2.rect.size == (100, 100))
-    s.constrain(layout.r3.rect.size == (100, 100))
+    s.constrain(layout.r1.size == (100, 100))
+    s.constrain(layout.r2.size == (100, 100))
+    s.constrain(layout.r3.size == (100, 100))
 
-    s.constrain(layout.r1.rect.southwest == (1000, -1000))
-    s.constrain(layout.r2.rect.southwest == (1600, -900))
-    s.constrain(layout.r3.rect.southwest == (1300, -500))
+    s.constrain(layout.r1.southwest == (1000, -1000))
+    s.constrain(layout.r2.southwest == (1600, -900))
+    s.constrain(layout.r3.southwest == (1300, -500))
 
-    s.constrain(layout.r4.rect.contains(layout.r1.rect))
-    s.constrain(layout.r4.rect.contains(layout.r2.rect))
-    s.constrain(layout.r4.rect.contains(layout.r3.rect))
+    s.constrain(layout.r4.contains(layout.r1))
+    s.constrain(layout.r4.contains(layout.r2))
+    s.constrain(layout.r4.contains(layout.r3))
 
     s.solve()
 

--- a/tests/test_ord2_compiler.py
+++ b/tests/test_ord2_compiler.py
@@ -711,3 +711,15 @@ def test_match_mapping_attr_key():
 def test_match_mapping_singleton_keys():
     ord_string = "match x:\n    case {True: y, None: z}:\n        pass"
     compare_asts(ord_string)
+
+def test_lineno_propagation():
+    code = "x = 1\ny = 2\nz = 3"
+    tree = ord2_to_py(code)
+    assert tree.body[0].lineno == 1
+    assert tree.body[1].lineno == 2
+    assert tree.body[2].lineno == 3
+
+def test_lineno_celldef():
+    code = "cell Foo:\n    pass"
+    tree = ord2_to_py(code)
+    assert tree.body[0].lineno == 1

--- a/tests/test_ord2_runtime.ord
+++ b/tests/test_ord2_runtime.ord
@@ -15,6 +15,19 @@ def test_symbol_dot():
         assert .outline == (0,1,2,3)
     assert root.outline == Rect4R(0,1,2,3)
 
+def test_dotdot():
+    root = Symbol()
+    with OrdContext(root):
+        assert . == root
+        PathNode x:
+            assert .. == root
+            assert . == root.x
+            PathNode z:
+                print(....)
+                #assert ... == root
+                assert .. == root.x
+                assert . == root.x.z
+
 def test_symbol_pin_creation():
     root = Symbol()
     with OrdContext(root):

--- a/tests/test_ord2_runtime.ord
+++ b/tests/test_ord2_runtime.ord
@@ -4,11 +4,10 @@
 from ordec.core import *
 from ordec.lib import Res
 from ordec.lib.ihp130 import SG13G2
-from ordec.ord2.context import Context
 
 def test_symbol_dot():
     root=Symbol()
-    with Context(root):
+    with root.ctx():
         # We can access our current context root via '.':
         assert . == __ord_context__.root() == root
         .outline = (0,1,2,3)
@@ -17,7 +16,7 @@ def test_symbol_dot():
 
 def test_dotdot():
     root = Symbol()
-    with Context(root):
+    with root.ctx():
         assert . == root
         PathNode x:
             assert .. == root
@@ -29,7 +28,7 @@ def test_dotdot():
 
 def test_symbol_pin_creation():
     root = Symbol()
-    with Context(root):
+    with root.ctx():
         sym = .
 
         # We can create a Pin using the special input/output/inout keywords...
@@ -64,10 +63,10 @@ def test_symbol_pin_creation():
 def test_nested_contexts():
     root1 = Symbol()
     root2 = Symbol()
-    with Context(root1):
+    with root1.ctx():
         input a
         assert .a == a
-        with Context(root2):
+        with root2.ctx():
             output a
             input c
         assert .a != a
@@ -86,7 +85,7 @@ def test_nested_contexts():
 
 def test_multi_name_bodyless_node_stmt():
     root = Symbol()
-    with Context(root):
+    with root.ctx():
         # Multiple pins with a keyword:
         input x1, x2, x3
         assert isinstance(root.x1, Pin)
@@ -105,7 +104,7 @@ def test_multi_name_bodyless_node_stmt():
 
 def test_scheminstance_creation():
     root = Schematic()
-    with Context(root):
+    with root.ctx():
         # Bodyless...
         # ...using a Cell subclass:
         Res a
@@ -130,7 +129,7 @@ def test_mixed_unresolved_resolved_instances():
     from ordec.lib import Vdc, Gnd
 
     root = Schematic()
-    with Context(root):
+    with root.ctx():
         net vss, mid
 
         # Cell instance -> SchemInstance directly
@@ -193,7 +192,7 @@ def test_minimal_layout():
 def test_layout_instance_shorthand():
     root = Layout()
     tc = LayoutTestCell()
-    with Context(root):
+    with root.ctx():
         tc a
         assert isinstance(a, LayoutInstance)
         assert a.ref == tc.layout

--- a/tests/test_ord2_runtime.ord
+++ b/tests/test_ord2_runtime.ord
@@ -3,6 +3,7 @@
 
 from ordec.core import *
 from ordec.lib import Res
+from ordec.lib.ihp130 import SG13G2
 from ordec.ord2.context import OrdContext
 
 def test_symbol_dot():
@@ -91,3 +92,24 @@ def test_scheminstance_creation():
             .pos=(1,2)
 
         assert c.pos == d.pos == Vec2R(1,2)
+
+cell LayoutTestCell:
+    viewgen symbol -> Symbol:
+        pass
+
+    viewgen layout -> Layout:
+        .ref_layers = SG13G2().layers
+        layers = .ref_layers
+        LayoutRect r:
+            .layer = layers.Metal1
+        ! .r.rect.width == 100
+        ! .r.rect.height == 100
+        ! .r.rect.lx == 0
+        ! .r.rect.ly == 0
+
+def test_minimal_layout():
+    c = LayoutTestCell()
+    layout = c.layout
+    layers = SG13G2().layers
+    assert layout.ref_layers == layers
+    assert layout.r.layer == layers.Metal1

--- a/tests/test_ord2_runtime.ord
+++ b/tests/test_ord2_runtime.ord
@@ -126,3 +126,16 @@ def test_minimal_layout():
     layers = SG13G2().layers
     assert layout.ref_layers == layers
     assert layout.r.layer == layers.Metal1
+
+def test_layout_instance_shorthand():
+    root = Layout()
+    tc = LayoutTestCell()
+    with OrdContext(root):
+        tc a
+        assert isinstance(a, LayoutInstance)
+        assert a.ref == tc.layout
+
+        tc b: .orientation = MX
+        assert isinstance(b, LayoutInstance)
+        assert b.ref == tc.layout
+        assert b.orientation == D4.MX

--- a/tests/test_ord2_runtime.ord
+++ b/tests/test_ord2_runtime.ord
@@ -23,7 +23,6 @@ def test_dotdot():
             assert .. == root
             assert . == root.x
             PathNode z:
-                print(....)
                 #assert ... == root
                 assert .. == root.x
                 assert . == root.x.z

--- a/tests/test_ord2_runtime.ord
+++ b/tests/test_ord2_runtime.ord
@@ -48,6 +48,29 @@ def test_symbol_pin_creation():
     assert root.d.pintype == PinType.Inout
     assert root.d.align == D4.R180
 
+def test_nested_contexts():
+    root1 = Symbol()
+    root2 = Symbol()
+    with OrdContext(root=root1):
+        input a
+        assert .a == a
+        with OrdContext(root=root2):
+            output a
+            input c
+        assert .a != a
+        output c
+
+    assert root1.a.pintype == PinType.In
+    assert root1.c.pintype == PinType.Out
+
+    assert root2.a.pintype == PinType.Out
+    assert root2.c.pintype == PinType.In
+
+    # Expect our local variables to be a bit messed up now:
+    assert a == root2.a
+    assert c == root1.c
+
+
 def test_scheminstance_creation():
     root = Schematic()
     with OrdContext(root=root):
@@ -68,4 +91,3 @@ def test_scheminstance_creation():
             .pos=(1,2)
 
         assert c.pos == d.pos == Vec2R(1,2)
-

--- a/tests/test_ord2_runtime.ord
+++ b/tests/test_ord2_runtime.ord
@@ -202,3 +202,11 @@ def test_layout_instance_shorthand():
         assert isinstance(b, LayoutInstance)
         assert b.ref == tc.layout
         assert b.orientation == D4.MX
+
+def test_node_as_context_manager():
+    root = Symbol()
+    with root.ctx():
+        input a
+        assert .a == a
+        assert .a.pintype == PinType.In
+    assert root.a.pintype == PinType.In

--- a/tests/test_ord2_runtime.ord
+++ b/tests/test_ord2_runtime.ord
@@ -84,6 +84,25 @@ def test_nested_contexts():
     assert c == root1.c
 
 
+def test_multi_name_bodyless_node_stmt():
+    root = Symbol()
+    with OrdContext(root):
+        # Multiple pins with a keyword:
+        input x1, x2, x3
+        assert isinstance(root.x1, Pin)
+        assert isinstance(root.x2, Pin)
+        assert isinstance(root.x3, Pin)
+        assert root.x1.pintype == PinType.In
+        assert root.x2.pintype == PinType.In
+        assert root.x3.pintype == PinType.In
+
+        # Multiple pins with a Node subclass:
+        Pin p1, p2, p3
+
+    assert isinstance(root.p1, Pin)
+    assert isinstance(root.p2, Pin)
+    assert isinstance(root.p3, Pin)
+
 def test_scheminstance_creation():
     root = Schematic()
     with OrdContext(root):

--- a/tests/test_ord2_runtime.ord
+++ b/tests/test_ord2_runtime.ord
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: 2026 ORDeC contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from ordec.core import *
+from ordec.lib import Res
+from ordec.ord2.context import OrdContext
+
+def test_symbol_dot():
+    root=Symbol()
+    with OrdContext(root=root):
+        # We can access our current context root via '.':
+        assert . == OrdContext.ctx.root == root
+        .outline = (0,1,2,3)
+        assert .outline == (0,1,2,3)
+    assert root.outline == Rect4R(0,1,2,3)
+
+def test_symbol_pin_creation():
+    root = Symbol()
+    with OrdContext(root=root):
+        sym = .
+
+        # We can create a Pin using the special input/output/inout keywords...
+        # ...either bodyless (no colon and subsequent body):
+        input a
+        # ...or with body (colon and subsequent body):
+        output b:
+            .pos = (5,5)
+            assert .parent == sym
+
+        # Alternatively, we can create a Pin using 'Pin', which is the Node subclass directly from the schema...
+        # ...again either bodyless:
+        Pin c
+        # ...or with body:
+        Pin d:
+            .pintype = PinType.Inout
+            .align = R180
+            assert .parent == sym
+
+    assert isinstance(root.a, Pin)
+    assert root.a.pintype == PinType.In
+    assert root.a.pos is None
+    assert isinstance(sym.b, Pin)
+    assert root.b.pintype == PinType.Out
+    assert root.b.pos == Vec2R(5,5)
+    assert isinstance(sym.c, Pin)
+    assert root.c.pos is None
+    assert isinstance(sym.d, Pin)
+    assert root.d.pintype == PinType.Inout
+    assert root.d.align == D4.R180
+
+def test_scheminstance_creation():
+    root = Schematic()
+    with OrdContext(root=root):
+        # Bodyless...
+        # ...using a Cell subclass:
+        Res a
+        assert isinstance(a, SchemInstanceUnresolved)
+        # ...or using a Cell subclass instance:
+        Res('1k') b
+        assert isinstance(b, SchemInstanceUnresolved)
+
+        # With body...
+        # ...using a Cell subclass:
+        Res c:
+            .pos=(1,2)
+        # ...or using a Cell subclass instance:
+        Res('1k') d:
+            .pos=(1,2)
+
+        assert c.pos == d.pos == Vec2R(1,2)
+

--- a/tests/test_ord2_runtime.ord
+++ b/tests/test_ord2_runtime.ord
@@ -168,6 +168,36 @@ def test_mixed_unresolved_resolved_instances():
     # No unresolved connections remain
     assert not list(root.all(SchemInstanceUnresolvedConn))
 
+def test_wire_op():
+    # The -- pseudo-operator is commutative: net -- pin and pin -- net should produce the same result.
+    from ordec.lib import Vdc, Gnd
+
+    root = Schematic()
+    with root.ctx():
+        net vss, mid
+
+        # pin -- net (normal order)
+        Vdc('1') v1: .p -- mid; .m -- vss; .pos = (0, 6)
+        # net -- pin (reversed order)
+        Res r1: .$r = '1k'; mid -- .p; vss -- .m; .pos = (5, 6)
+        # Also reversed for a Cell instance
+        Gnd() gnd: vss -- .p; .pos = (0, 0)
+
+    # All connections should be created regardless of operand order
+    v1_conns = list(root.all(SchemInstanceConn.ref_idx.query(v1)))
+    assert len(v1_conns) == 2
+
+    r1_conns = list(root.all(SchemInstanceUnresolvedConn.ref_idx.query(r1)))
+    assert len(r1_conns) == 2
+
+    gnd_conns = list(root.all(SchemInstanceConn.ref_idx.query(gnd)))
+    assert len(gnd_conns) == 1
+
+    # Postprocess should resolve everything normally
+    root.postprocess()
+    all_conns = list(root.all(SchemInstanceConn))
+    assert len(all_conns) == 5
+
 cell LayoutTestCell:
     viewgen symbol -> Symbol:
         pass

--- a/tests/test_ord2_runtime.ord
+++ b/tests/test_ord2_runtime.ord
@@ -256,3 +256,56 @@ def test_nodecontext_across_calls():
         add_pin_x()
         add_pin_y()
         assert count_pins() == 2
+
+def test_anonymous_node_stmt():
+    """Anonymous node statements create nodes without NPath entries."""
+    root = Symbol()
+    with root.ctx():
+        # Anonymous bodyless
+        anonymous Pin a
+        assert isinstance(a, Pin)
+
+        # Anonymous with body
+        anonymous Pin b:
+            .pintype = PinType.Out
+
+        assert isinstance(b, Pin)
+        assert b.pintype == PinType.Out
+
+        # Regular pin for comparison
+        Pin c
+
+        # c has an NPath, a and b don't
+        assert root.c == c
+        # a and b should not be accessible via path
+        import pytest
+        with pytest.raises(AttributeError):
+            root.a
+        with pytest.raises(AttributeError):
+            root.b
+
+def test_anonymous_in_loop():
+    """Anonymous nodes in loops don't clash on NPath names."""
+    root = Symbol()
+    pins = []
+    with root.ctx():
+        for i in range(3):
+            anonymous Pin p
+            pins.append(p)
+    assert len(pins) == 3
+    # All are distinct nodes
+    assert len(set(id(p) for p in pins)) == 3
+
+def test_anonymous_multi_target():
+    """Anonymous node statement with multiple targets."""
+    root = Symbol()
+    with root.ctx():
+        anonymous Pin x, y, z
+        assert isinstance(x, Pin)
+        assert isinstance(y, Pin)
+        assert isinstance(z, Pin)
+
+def test_anonymous_as_identifier():
+    """'anonymous' can still be used as a variable name."""
+    anonymous = 42
+    assert anonymous == 42

--- a/tests/test_ord2_runtime.ord
+++ b/tests/test_ord2_runtime.ord
@@ -133,10 +133,10 @@ cell LayoutTestCell:
         layers = .ref_layers
         LayoutRect r:
             .layer = layers.Metal1
-        ! .r.rect.width == 100
-        ! .r.rect.height == 100
-        ! .r.rect.lx == 0
-        ! .r.rect.ly == 0
+        ! .r.width == 100
+        ! .r.height == 100
+        ! .r.lx == 0
+        ! .r.ly == 0
 
 def test_minimal_layout():
     c = LayoutTestCell()

--- a/tests/test_ord2_runtime.ord
+++ b/tests/test_ord2_runtime.ord
@@ -209,3 +209,20 @@ def test_node_as_context_manager():
         assert .a == a
         assert .a.pintype == PinType.In
     assert root.a.pintype == PinType.In
+
+
+def add_pin_x():
+    Pin x
+
+def add_pin_y():
+    Pin y
+
+def count_pins():
+    return len(list(.all(Pin)))
+
+def test_nodecontext_across_calls():
+    """Checks that node context works across function calls"""
+    with Symbol().ctx():
+        add_pin_x()
+        add_pin_y()
+        assert count_pins() == 2

--- a/tests/test_ord2_runtime.ord
+++ b/tests/test_ord2_runtime.ord
@@ -4,20 +4,20 @@
 from ordec.core import *
 from ordec.lib import Res
 from ordec.lib.ihp130 import SG13G2
-from ordec.ord2.context import OrdContext
+from ordec.ord2.context import Context
 
 def test_symbol_dot():
     root=Symbol()
-    with OrdContext(root):
+    with Context(root):
         # We can access our current context root via '.':
-        assert . == OrdContext.ctx.root == root
+        assert . == __ord_context__.root() == root
         .outline = (0,1,2,3)
         assert .outline == (0,1,2,3)
     assert root.outline == Rect4R(0,1,2,3)
 
 def test_dotdot():
     root = Symbol()
-    with OrdContext(root):
+    with Context(root):
         assert . == root
         PathNode x:
             assert .. == root
@@ -29,7 +29,7 @@ def test_dotdot():
 
 def test_symbol_pin_creation():
     root = Symbol()
-    with OrdContext(root):
+    with Context(root):
         sym = .
 
         # We can create a Pin using the special input/output/inout keywords...
@@ -64,10 +64,10 @@ def test_symbol_pin_creation():
 def test_nested_contexts():
     root1 = Symbol()
     root2 = Symbol()
-    with OrdContext(root1):
+    with Context(root1):
         input a
         assert .a == a
-        with OrdContext(root2):
+        with Context(root2):
             output a
             input c
         assert .a != a
@@ -86,7 +86,7 @@ def test_nested_contexts():
 
 def test_multi_name_bodyless_node_stmt():
     root = Symbol()
-    with OrdContext(root):
+    with Context(root):
         # Multiple pins with a keyword:
         input x1, x2, x3
         assert isinstance(root.x1, Pin)
@@ -105,7 +105,7 @@ def test_multi_name_bodyless_node_stmt():
 
 def test_scheminstance_creation():
     root = Schematic()
-    with OrdContext(root):
+    with Context(root):
         # Bodyless...
         # ...using a Cell subclass:
         Res a
@@ -130,7 +130,7 @@ def test_mixed_unresolved_resolved_instances():
     from ordec.lib import Vdc, Gnd
 
     root = Schematic()
-    with OrdContext(root):
+    with Context(root):
         net vss, mid
 
         # Cell instance -> SchemInstance directly
@@ -193,7 +193,7 @@ def test_minimal_layout():
 def test_layout_instance_shorthand():
     root = Layout()
     tc = LayoutTestCell()
-    with OrdContext(root):
+    with Context(root):
         tc a
         assert isinstance(a, LayoutInstance)
         assert a.ref == tc.layout

--- a/tests/test_ord2_runtime.ord
+++ b/tests/test_ord2_runtime.ord
@@ -7,7 +7,7 @@ from ordec.ord2.context import OrdContext
 
 def test_symbol_dot():
     root=Symbol()
-    with OrdContext(root=root):
+    with OrdContext(root):
         # We can access our current context root via '.':
         assert . == OrdContext.ctx.root == root
         .outline = (0,1,2,3)
@@ -16,7 +16,7 @@ def test_symbol_dot():
 
 def test_symbol_pin_creation():
     root = Symbol()
-    with OrdContext(root=root):
+    with OrdContext(root):
         sym = .
 
         # We can create a Pin using the special input/output/inout keywords...
@@ -51,10 +51,10 @@ def test_symbol_pin_creation():
 def test_nested_contexts():
     root1 = Symbol()
     root2 = Symbol()
-    with OrdContext(root=root1):
+    with OrdContext(root1):
         input a
         assert .a == a
-        with OrdContext(root=root2):
+        with OrdContext(root2):
             output a
             input c
         assert .a != a
@@ -73,7 +73,7 @@ def test_nested_contexts():
 
 def test_scheminstance_creation():
     root = Schematic()
-    with OrdContext(root=root):
+    with OrdContext(root):
         # Bodyless...
         # ...using a Cell subclass:
         Res a

--- a/tests/test_ord2_runtime.ord
+++ b/tests/test_ord2_runtime.ord
@@ -110,9 +110,9 @@ def test_scheminstance_creation():
         # ...using a Cell subclass:
         Res a
         assert isinstance(a, SchemInstanceUnresolved)
-        # ...or using a Cell subclass instance:
+        # ...or using a Cell subclass instance (creates SchemInstance directly):
         Res('1k') b
-        assert isinstance(b, SchemInstanceUnresolved)
+        assert isinstance(b, SchemInstance)
 
         # With body...
         # ...using a Cell subclass:
@@ -123,6 +123,51 @@ def test_scheminstance_creation():
             .pos=(1,2)
 
         assert c.pos == d.pos == Vec2R(1,2)
+
+def test_mixed_unresolved_resolved_instances():
+    """A schematic with both SchemInstance (from Cell instance) and
+    SchemInstanceUnresolved (from Cell class), wired together and postprocessed."""
+    from ordec.lib import Vdc, Gnd
+
+    root = Schematic()
+    with OrdContext(root):
+        net vss, mid
+
+        # Cell instance -> SchemInstance directly
+        Vdc('1') v1: .p -- mid; .m -- vss; .pos = (0, 6)
+        # Cell class -> SchemInstanceUnresolved (params set via body)
+        Res r1: .$r = '1k'; .p -- mid; .m -- vss; .pos = (5, 6)
+        # Another Cell instance -> SchemInstance directly
+        Gnd() gnd: .p -- vss; .pos = (0, 0)
+
+    # Before postprocess: v1 and gnd are already SchemInstance,
+    # r1 is still SchemInstanceUnresolved
+    assert isinstance(v1, SchemInstance)
+    assert isinstance(gnd, SchemInstance)
+    assert isinstance(r1, SchemInstanceUnresolved)
+
+    # v1 already has SchemInstanceConn (direct wiring)
+    v1_conns = list(root.all(SchemInstanceConn.ref_idx.query(v1)))
+    assert len(v1_conns) == 2
+
+    # r1 still has SchemInstanceUnresolvedConn (deferred wiring)
+    r1_conns = list(root.all(SchemInstanceUnresolvedConn.ref_idx.query(r1)))
+    assert len(r1_conns) == 2
+
+    # Postprocess resolves r1 and runs auto_wire + check
+    root.postprocess()
+
+    # After postprocess: all instances are SchemInstance
+    all_instances = list(root.all(SchemInstance))
+    assert len(all_instances) == 3
+    assert not list(root.all(SchemInstanceUnresolved))
+
+    # All connections are now SchemInstanceConn
+    all_conns = list(root.all(SchemInstanceConn))
+    assert len(all_conns) == 5  # v1: 2, r1: 2, gnd: 1
+
+    # No unresolved connections remain
+    assert not list(root.all(SchemInstanceUnresolvedConn))
 
 cell LayoutTestCell:
     viewgen symbol -> Symbol:

--- a/tests/test_srouter.py
+++ b/tests/test_srouter.py
@@ -12,7 +12,7 @@ rs = ihp130.SG13G2().default_routing_spec
 def layout_basic():
     l = Layout(ref_layers=layers)
     s = Solver(l)
-    sr = SRouter(l, s, routing_spec=rs)
+    sr = SRouter(rs, layout=l, solver=s)
     sr.move(layers.Metal1, (0, 0))
     sr.wire((1000, 0))
     sr.wire((1000, 1000))
@@ -40,7 +40,7 @@ def layout_push_pop():
     """T-shaped route: go right, push, go up, pop, go down."""
     l = Layout(ref_layers=layers)
     s = Solver(l)
-    sr = SRouter(l, s, routing_spec=rs)
+    sr = SRouter(rs, layout=l, solver=s)
     sr.move(layers.Metal1, (0, 0))
     sr.wire((1000, 0))
     sr.push()
@@ -56,7 +56,7 @@ def layout_push_pop_layerchange():
     """T-shaped route: go right, push, go up, pop, change layer, go down."""
     l = Layout(ref_layers=layers)
     s = Solver(l)
-    sr = SRouter(l, s, routing_spec=rs)
+    sr = SRouter(rs, layout=l, solver=s)
     sr.move(layers.Metal1, (0, 0))
     sr.wire((1000, 0))
     sr.push()


### PR DESCRIPTION
In this branch, I have changed quite a few things in ORD2 and want your feedback and opinion.

I tried to simplify the context code generated by the ORD2 compiler, so for example this here:
```
vdd_st = __ord_context__.OrdContext.ctx.add(('vdd_st',), __ordec_core__.Pin(pintype=__ordec_core__.PinType.Inout))
with __ord_context__.OrdContext(root=vdd_st):
    __ord_context__.OrdContext.ctx.root.align = North
```
becomes this here:
```
vdd_st = __ord_context__.add(('vdd_st',), __ordec_core__.Pin(pintype=__ordec_core__.PinType.Inout))
with vdd_st.ctx():
    __ord_context__.root().align = North
```

I have renamed "context element" to "node statement" as discussed.

Also, in addition to the old `OrdContext`, which is now called `NodeContext` (see `core/context.py`), I have added a second context `ViewContext` which stays the same throughout the entire viewgen method (while the `NodeContext` varies when node statements are entered & exited). This `ViewContext` is used to collect constraints. Its __exit__ handler solves the constraints. `SRouter` also makes use of the new `ViewContext`.

Furthermore, I have removed connect_stmt from the grammar and now emulate its behavior using `__neg__`, `__sub__` and `__rsub__` (?). This gives better backwards compatibility to Python. `a -- b` is a correct Python statement and should have the same effect as `a.__sub__(b.__neg__())`.

I have added `_rect_proxy` in `core/schema.py` which makes it possible to access `myrect.rect.cx` directly as `myrect.cx`.

And lastly, I added an "anonymous" keyword that extends the node statements. You can see what it is good for in `vco_pseudodiff.ord`.