### PR TITLE
ord: drop support for dotted atom with more than one dot

### DIFF
--- a/docs/ord_tutorial.py
+++ b/docs/ord_tutorial.py
@@ -149,8 +149,7 @@ Inv().schematic
 # You might have already recognized a specific feature of the ORD language called **relative access**
 # or **dotted notation**. Whenever an ORD-specific element is defined, a **context** is opened.
 # This context can be defined with the Python-style block based notation `Nmos pd:`.
-# Every statement or expression inside this context can reference the parent object by using a leading `.`. The contexts 
-# are hierarchically structured, so even multiple leading dots are possible to access parent contexts.
+# Every statement or expression inside this context can reference the current context object by using a leading `.`.
 #
 # ```python
 # # Oneline definition

--- a/docs/ref/ord.rst
+++ b/docs/ref/ord.rst
@@ -35,8 +35,8 @@ Mastering the ORD language requires understanding two crucial parts. First, the 
 ORD Contexts
 ------------
 
-The dotted syntax of ORD, which accesses the parent element, requires having a
-reference to the parent element. This structure therefore necessitates that
+The dotted syntax of ORD, which accesses the current context element, requires
+having a reference to that element. This structure therefore necessitates that
 statements and expressions inside a context block have a reference to the
 parent even after transformation of ORD back to Python. This logic is
 implemented with :class:`~ordec.core.context.ViewContext` for the active view
@@ -125,9 +125,7 @@ At the start of a view generator, the compiler creates ``__ord_root__`` and
 opens the root view context with ``__ord_root__.view_context(__ord_root__)``.
 Every node statement then saves the created element as a local variable and, if
 the statement has a body, opens a nested node context with ``node.ctx()``. The
-dotted access is converted into ``context.root()``. If multiple dots are
-written prior to the identifier, the dots are converted to
-``context.root()(.parent)*``. Accesses outside the context are still possible
+dotted access is converted into ``context.root()``. Accesses outside the context are still possible
 through the local variable. An access like this is visible in the ``for`` loop
 of the example.
 

--- a/ordec/ord/ord.lark
+++ b/ordec/ord/ord.lark
@@ -263,7 +263,8 @@ AWAIT: "await"
      | number
      | string_concat
      | "(" test ")"
-     | dotted_atom // "..." -> ellipsis
+     | dotted_atom
+     | "..." -> ellipsis
      | "None"    -> const_none
      | "True"    -> const_true
      | "False"   -> const_false
@@ -392,7 +393,7 @@ anon_node_stmt_nobody: "anonymous" atom_expr context_target ("," context_target)
 		       | context_target "[" subscriptlist "]" -> getitem
    	           | name -> var
 		
-dotted_atom: dots name?
+dotted_atom: "." name?
 path_stmt: "path" context_target ("," context_target)*
 net_stmt: "net" context_target ("," context_target)*
 // END OF ORD DEFINITIONS

--- a/ordec/ord/ord_transformer.py
+++ b/ordec/ord/ord_transformer.py
@@ -332,28 +332,12 @@ class OrdTransformer(PythonTransformer):
             result.extend(self.node_stmt([nodes[0], context_target]))
         return result
 
-    def depth_helper(self, value, depth=1):
-        """ Access parent attributes depending on the dotted depth"""
-        node = ast.Call(self.ast_ord_context("root"), args=[], keywords=[])
-
-        for _ in range(depth - 1):
-            node = self.ast_attribute(node,"parent")
-
-        if value:
-            node = self.ast_attribute(node, value)
-        return node
-
     def dotted_atom(self, nodes):
-        """ Dotted name (..x) or ellipsis (...) """
-        if len(nodes) == 1:
-            depth = nodes[0]
-            if depth == 3:
-                return ast.Constant(value=Ellipsis)
-            return self.depth_helper(None, depth)
-        else:
-           depth = nodes[0]
-           value = nodes[1]
-           return self.depth_helper(value, depth)
+        """ Dotted name (.x) or bare dot (.) - access current context root """
+        root = ast.Call(self.ast_ord_context("root"), args=[], keywords=[])
+        if nodes:
+            return self.ast_attribute(root, nodes[0])
+        return root
 
     def getparam(self, nodes):
         """ get/set param (.$l = 100n) """

--- a/tests/test_ord_runtime.ord
+++ b/tests/test_ord_runtime.ord
@@ -14,18 +14,6 @@ def test_symbol_dot():
         assert .outline == (0,1,2,3)
     assert root.outline == Rect4R(0,1,2,3)
 
-def test_dotdot():
-    root = Symbol()
-    with root.ctx():
-        assert . == root
-        PathNode x:
-            assert .. == root
-            assert . == root.x
-            PathNode z:
-                #assert ... == root
-                assert .. == root.x
-                assert . == root.x.z
-
 def test_symbol_pin_creation():
     root = Symbol()
     with root.ctx():


### PR DESCRIPTION
As discussed, this drops the ".." support and so forth. Please let me know whether you see any issues here!