### PR TITLE
Drop LayoutRectPoly and LayoutRectPath

### DIFF
--- a/docs/ref/schema.rst
+++ b/docs/ref/schema.rst
@@ -117,15 +117,7 @@ Layout
    :undoc-members:
 
 .. autoclass:: LayoutPath
-   :members: 
-   :undoc-members:
-
-.. autoclass:: LayoutRectPoly
-   :members: 
-   :undoc-members:
-
-.. autoclass:: LayoutRectPath
-   :members: 
+   :members:
    :undoc-members:
 
 .. autoclass:: LayoutRect
@@ -145,9 +137,5 @@ Layout
    :undoc-members:
 
 .. autoclass:: PathEndType
-   :members: 
-   :undoc-members:
-
-.. autoclass:: RectDirection
-   :members: 
+   :members:
    :undoc-members:

--- a/examples/dev/layout.py
+++ b/examples/dev/layout.py
@@ -69,29 +69,6 @@ def layout_expand_geom() -> Layout:
         ],
     )
 
-    l % LayoutRectPoly(
-        layer=layers.Metal4,
-        vertices = [
-            Vec2I(0,0),
-            Vec2I(100,100),
-            Vec2I(50,50),
-            Vec2I(-100, 25),
-        ],
-    )
-
-    l % LayoutRectPath(
-        width=80,
-        endtype=PathEndType.Square,
-        layer=layers.Metal5,
-        vertices = [
-            Vec2I(0,0),
-            Vec2I(1400,1400),
-            Vec2I(-400,600),
-            Vec2I(100,100),
-        ],
-        start_direction=RectDirection.Horizontal,
-    )
-
     return l
 
 @generate_func

--- a/ordec/core/schema.py
+++ b/ordec/core/schema.py
@@ -41,15 +41,6 @@ class PathEndType(Enum):
         return f'{self.__class__.__name__}.{self.name}'
 
 @public
-class RectDirection(Enum):
-    """Used by :class:`LayoutRectPoly` and :class:`LayoutRectPath`."""
-    Vertical = 0 #: Indicates that shape is encoded with vertical edge first, horizontal edge second.
-    Horizontal = 1  #: Indicates that shape is encoded with horizontal edge first, vertical edge second.
-
-    def __repr__(self):
-        return f'{self.__class__.__name__}.{self.name}'
-
-@public
 class SchemErrorType(Enum):
     OverlappingTerminals = 'Overlapping terminals'
     MissingTerminalConnection = 'Missing terminal connection'
@@ -1128,42 +1119,6 @@ class LayoutPath(LayoutPathBase, MixinPolygonalChain, MixinLayoutPinnable):
 
 
 @public
-class LayoutRectPoly(GenericPolyI, MixinLayoutPinnable):
-    """
-    Compact rectilinear polygon. Each vertex is connected to its successor
-    through two segments. The first segment in start_direction, the second
-    segment perpendicular to the first. Each vertex has to differ in both x
-    and y coordiante from its successor. The successor of the last vertex is the
-    first vertex.
-
-    This representation of a rectilinear polygon requires half the vertices as
-    an equivalent LayoutPoly.
-
-    One use case is for rectangles, which this class can represent using just
-    two corner vertices.
-    """
-    in_subgraphs = [Layout]
-
-    start_direction = Attr(RectDirection, default=RectDirection.Horizontal)
-    layer = ExternalRef(Layer, of_subgraph=lambda c: c.root.ref_layers)
-
-@public
-class LayoutRectPath(LayoutPathBase, MixinLayoutPinnable):
-    """
-    Compact rectilinear path. Each vertex is connected to its successor
-    through two segments. The first segment in start_direction, the second
-    segment perpendicular to the first. Each vertex has to differ in both x
-    and y coordiante from its successor. The last vertex has no successor
-    (i.e. open path).
-
-    This representation of a rectilinear path requires half the vertices as
-    an equivalent LayoutPath.
-    """
-    in_subgraphs = [Layout]
-
-    start_direction = Attr(RectDirection, default=RectDirection.Horizontal)
-
-@public
 class LayoutRect(Node, MixinLayoutPinnable):
     """Layout rectangle."""
     in_subgraphs = [Layout]
@@ -1372,13 +1327,12 @@ class LayoutPin(Node):
     a non-pin layer, and a corresponding pin layer shape is created
     automatically by expand_pins (in write_gds or the web viewer).
 
-    The associated shape can be a LayoutPoly, LayoutRectPoly, LayoutRect,
-    LayoutPath or LayoutRectPath.
+    The associated shape can be a LayoutPoly, LayoutRect, or LayoutPath.
     """
     in_subgraphs = [Layout]
 
-    ref = LocalRef(LayoutPoly|LayoutRectPoly|LayoutPath,
-        refcheck_custom=lambda val: issubclass(val, (LayoutPoly, LayoutRectPoly, LayoutRect, LayoutPath, LayoutRectPath)),
+    ref = LocalRef(LayoutPoly|LayoutPath,
+        refcheck_custom=lambda val: issubclass(val, (LayoutPoly, LayoutRect, LayoutPath)),
         )
     pin = ExternalRef(Pin,
         of_subgraph=lambda c: c.root.symbol,

--- a/ordec/layout/__init__.py
+++ b/ordec/layout/__init__.py
@@ -11,8 +11,6 @@ __all__ = [
     'makevias',
     'poly_orientation',
     'expand_paths',
-    'expand_rectpolys',
-    'expand_rectpaths',
     'expand_rects',
     'expand_geom',
     'expand_pins',

--- a/ordec/layout/gds_out.py
+++ b/ordec/layout/gds_out.py
@@ -11,7 +11,7 @@ import gdsii.elements as elements
 from gdsii import types, tags
 
 from ..core import *
-from .helpers import expand_rectpolys, expand_rectpaths, expand_rects, expand_pins
+from .helpers import expand_rects, expand_pins
 
 def d4_to_gds(d4: D4) -> tuple[float,int]:
     return {
@@ -34,8 +34,6 @@ class GdsGenerator:
 
         layout = layout.mutable_copy()
         # Expand objects that are not supported by GDSII:
-        expand_rectpolys(layout)
-        expand_rectpaths(layout)
         expand_rects(layout)
         expand_pins(layout, directory=self.directory)
 

--- a/ordec/layout/helpers.py
+++ b/ordec/layout/helpers.py
@@ -130,62 +130,6 @@ def expand_paths(layout: Layout):
             vertices=path_to_poly_vertices(path),
             ))
 
-def rpoly_to_poly_vertices(rpoly: LayoutRectPoly) -> Iterable[Vec2I]:
-    start_direction = rpoly.start_direction
-    it = iter(rpoly.vertices())
-    last = next(it)
-    for pos in chain(it, (last,)):
-        if start_direction == RectDirection.Horizontal:
-            yield Vec2I(pos.x, last.y)
-        else:
-            yield Vec2I(last.x, pos.y)
-        yield pos
-        last = pos
-
-@public
-def expand_rectpolys(layout: Layout):
-    """
-    For the given Layout, replaces all LayoutRectPoly instances by geometrically
-    equivalent LayoutPoly instances.
-    """
-    for rpoly in layout.all(LayoutRectPoly):
-        rpoly.replace(LayoutPoly(
-            layer=rpoly.layer,
-            vertices=rpoly_to_poly_vertices(rpoly)
-            ))
-
-def rpath_to_path_vertices(rpath: LayoutRectPath) -> Iterable[Vec2I]:
-    start_direction = rpath.start_direction
-    it = iter(rpath.vertices())
-    pos0 = next(it)
-    yield pos0
-    last = pos0
-    for pos in it:
-        if start_direction == RectDirection.Horizontal:
-            intermediate = Vec2I(pos.x, last.y)
-        else:
-            intermediate = Vec2I(last.x, pos.y)
-        if intermediate != pos and intermediate != last:
-            yield intermediate
-        yield pos
-        last = pos
-
-@public
-def expand_rectpaths(layout: Layout):
-    """
-    For the given Layout, replaces all LayoutRectPath instances by geometrically
-    equivalent LayoutPath instances.
-    """
-    for rpath in layout.all(LayoutRectPath):
-        rpath.replace(LayoutPath(
-            layer=rpath.layer,
-            vertices=rpath_to_path_vertices(rpath),
-            endtype=rpath.endtype,
-            width=rpath.width,
-            ext_bgn=rpath.ext_bgn,
-            ext_end=rpath.ext_end,
-            ))
-
 @public
 def expand_rects(layout: Layout):
     """
@@ -208,11 +152,9 @@ def expand_rects(layout: Layout):
 @public
 def expand_geom(layout: Layout):
     """
-    Replaces all LayoutRectPath, LayoutRectPoly, LayoutRect and LayoutPath
-    instances by equivalent LayoutPoly instances.
+    Replaces all LayoutRect and LayoutPath instances by equivalent LayoutPoly
+    instances.
     """
-    expand_rectpolys(layout)
-    expand_rectpaths(layout)
     expand_rects(layout)
     expand_paths(layout)
 
@@ -263,24 +205,6 @@ def flatten_instance(dst: Layout, src: Layout, tran: TD4I, first_level: bool):
     for src_e in src.all(LayoutPath):
         dst % LayoutPath(
             layer=src_e.layer,
-            width=src_e.width,
-            endtype=src_e.endtype,
-            vertices=[tran * v for v in src_e.vertices()],
-            ext_bgn = src_e.ext_bgn,
-            ext_end = src_e.ext_end,
-        )
-
-    for src_e in src.all(LayoutRectPoly):
-        dst % LayoutRectPoly(
-            layer=src_e.layer,
-            start_direction=src_e.start_direction,
-            vertices=transform_vertex_loop(src_e.vertices()),
-        )
-    
-    for src_e in src.all(LayoutRectPath):
-        dst % LayoutRectPath(
-            layer=src_e.layer,
-            start_direction=src_e.start_direction,
             width=src_e.width,
             endtype=src_e.endtype,
             vertices=[tran * v for v in src_e.vertices()],
@@ -382,9 +306,8 @@ def expand_pins(layout: Layout, directory: Directory):
     For a given layout, removes LayoutPin objects and adds according LayoutPoly
     and LayoutLabel instances.
 
-    Handles LayoutPoly and LayoutPath refs directly. Expects that LayoutRect,
-    LayoutRectPoly and LayoutRectPath objects have already been expanded (e.g.
-    through expand_rects, expand_rectpolys, expand_rectpaths).
+    Handles LayoutPoly and LayoutPath refs directly. Expects that LayoutRect
+    objects have already been expanded (e.g. through expand_rects).
     """
     for pin in layout.all(LayoutPin):
         ref = pin.ref
@@ -395,7 +318,7 @@ def expand_pins(layout: Layout, directory: Directory):
         else:
             raise Exception(
                 f"expand_pins: unsupported ref type {type(ref)}. "
-                f"Run expand_rects/expand_rectpolys/expand_rectpaths first."
+                f"Run expand_rects first."
             )
 
         pinlayer = pin.ref.layer.pinlayer()

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -260,18 +260,6 @@ def test_flatten():
         width=150,
         vertices=[(0, 0), (1000, 0), (1000, 1000)],
     )
-    rpoly_orig = sublayout % LayoutRectPoly(
-        layer=layers.Metal3,
-        start_direction=RectDirection.Vertical,
-        vertices=[(0, 0), (250, 250), (500, 500)],
-    )
-    rpath_orig = sublayout % LayoutRectPath(
-        layer=layers.Metal4,
-        start_direction=RectDirection.Vertical,
-        endtype=PathEndType.Square,
-        width=200,
-        vertices=[(0, 0), (-1000, 1000), (500, 500)],
-    )
     rect_orig = sublayout % LayoutRect(
         layer=layers.Metal5,
         rect=(900, 900, 1100, 1100),
@@ -312,23 +300,6 @@ def test_flatten():
         assert path.endtype == path_orig.endtype
         assert path.width == path_orig.width
         assert path.vertices() == [tran * v for v in path_orig.vertices()]
-
-        # ...and the flattened LayoutRectPoly...
-        rpoly = layout.one(LayoutRectPoly)
-        assert rpoly.layer == rpoly_orig.layer
-        assert rpoly.start_direction == rpoly_orig.start_direction
-        expected_vertices = [tran * v for v in rpoly_orig.vertices()]
-        if orientation.det() < 0:
-            expected_vertices.reverse()
-        assert rpoly.vertices() == expected_vertices
-
-        # ...and the flattened LayoutRectPath...
-        rpath = layout.one(LayoutRectPath)
-        assert rpath.layer == rpath_orig.layer
-        assert rpath.endtype == rpath_orig.endtype
-        assert rpath.width == rpath_orig.width
-        assert rpath.start_direction == rpath_orig.start_direction
-        assert rpath.vertices() == [tran * v for v in rpath_orig.vertices()]
 
         # ...and the flattened LayoutRect...
         rect = layout.one(LayoutRect)
@@ -556,138 +527,6 @@ def test_expand_paths_invalid():
         with pytest.raises(ValueError):
             expand_paths(l)
 
-def test_expand_rectpoly():
-    layers = SG13G2().layers
-
-    l = Layout(ref_layers=layers)
-    l.rpoly_h = LayoutRectPoly(
-        layer=layers.Metal1,
-        vertices = [
-            Vec2I(0, 0),
-            Vec2I(100, 100),
-            Vec2I(50, 50),
-        ],
-        start_direction=RectDirection.Horizontal,
-    )
-    l.rpoly_v = LayoutRectPoly(
-        layer=layers.Metal1,
-        vertices = [
-            Vec2I(0, 0),
-            Vec2I(-100, 100),
-            Vec2I(-50, 50),
-        ],
-        start_direction=RectDirection.Vertical,
-    )
-
-    expand_rectpolys(l)
-
-    assert len(list(l.all(LayoutRectPoly))) == 0
-    assert isinstance(l.rpoly_h, LayoutPoly)
-    assert l.rpoly_h.vertices() == [
-        Vec2I(100, 0),
-        Vec2I(100, 100),
-        Vec2I(50, 100),
-        Vec2I(50, 50),
-        Vec2I(0, 50),
-        Vec2I(0, 0),
-    ]
-    assert isinstance(l.rpoly_v, LayoutPoly)
-    assert l.rpoly_v.vertices() == [
-        Vec2I(0, 100),
-        Vec2I(-100, 100),
-        Vec2I(-100, 50),
-        Vec2I(-50, 50),
-        Vec2I(-50, 0),
-        Vec2I(0, 0),
-    ]
-
-def test_expand_rectpath():
-    layers = SG13G2().layers
-
-    l = Layout(ref_layers=layers)
-    l.rpath_h = LayoutRectPath(
-        layer=layers.Metal1,
-        vertices = [
-            Vec2I(0, 0),
-            Vec2I(100, 100),
-            Vec2I(50, 50),
-        ],
-        width=10,
-        endtype=PathEndType.Square,
-        start_direction=RectDirection.Horizontal,
-    )
-    l.rpath_h2 = LayoutRectPath(
-        layer=layers.Metal1,
-        vertices = [
-            Vec2I(0, 0),
-            Vec2I(100, 100),
-            Vec2I(100, 50),
-        ],
-        width=10,
-        endtype=PathEndType.Square,
-        start_direction=RectDirection.Horizontal,
-    )
-    l.rpath_h3 = LayoutRectPath(
-        layer=layers.Metal1,
-        vertices = [
-            Vec2I(0, 0),
-            Vec2I(100, 100),
-            Vec2I(50, 100),
-        ],
-        width=10,
-        endtype=PathEndType.Square,
-        start_direction=RectDirection.Horizontal,
-    )
-    l.rpath_v = LayoutRectPath(
-        layer=layers.Metal1,
-        vertices = [
-            Vec2I(0, 0),
-            Vec2I(100, 100),
-            Vec2I(50, 50),
-        ],
-        width=10,
-        endtype=PathEndType.Square,
-        start_direction=RectDirection.Vertical,
-    )
-
-    expand_rectpaths(l)
-    assert len(list(l.all(LayoutRectPath))) == 0
-    assert isinstance(l.rpath_h, LayoutPath)
-    assert l.rpath_h.vertices() == [
-        Vec2I(0, 0),
-        Vec2I(100, 0),
-        Vec2I(100, 100),
-        Vec2I(50, 100),
-        Vec2I(50, 50),
-    ]
-    assert l.rpath_h.width == 10
-    assert l.rpath_h.endtype == PathEndType.Square
-
-    assert isinstance(l.rpath_h2, LayoutPath)
-    assert l.rpath_h2.vertices() == [
-        Vec2I(0, 0),
-        Vec2I(100, 0),
-        Vec2I(100, 100),
-        Vec2I(100, 50),
-    ]
-
-    assert isinstance(l.rpath_h3, LayoutPath)
-    assert l.rpath_h3.vertices() == [
-        Vec2I(0, 0),
-        Vec2I(100, 0),
-        Vec2I(100, 100),
-        Vec2I(50, 100),
-    ]
-
-    assert isinstance(l.rpath_v, LayoutPath)
-    assert l.rpath_v.vertices() == [
-        Vec2I(0, 0),
-        Vec2I(0, 100),
-        Vec2I(100, 100),
-        Vec2I(100, 50),
-        Vec2I(50, 50),
-    ]
-
 def test_expand_rect():
     layers = SG13G2().layers
 
@@ -715,14 +554,16 @@ def test_write_gds():
         @generate
         def layout(self) -> Layout:
             l = Layout(ref_layers=layers, cell=self)
-            l % LayoutRectPoly(layer=layers.Metal2.pin, vertices=[(0, 0), (200, 200), (100, 100)])
+            l % LayoutPoly(layer=layers.Metal2.pin, vertices=[
+                (200, 0), (200, 200), (100, 200), (100, 100), (0, 100), (0, 0)])
             return l
 
     class Sub2(Cell):
         @generate
         def layout(self) -> Layout:
             l = Layout(ref_layers=layers, cell=self)
-            l % LayoutRectPoly(layer=layers.Metal2.pin, vertices=[(0, 0), (100, 100), (200, 200)])
+            l % LayoutPoly(layer=layers.Metal2.pin, vertices=[
+                (100, 0), (100, 100), (200, 100), (200, 200), (0, 200), (0, 0)])
             return l
 
     class Top(Cell):
@@ -761,7 +602,8 @@ def test_write_gds_without_cell():
     layers = SG13G2().layers
 
     l = Layout(ref_layers=layers)
-    l % LayoutRectPoly(layer=layers.Metal2.pin, vertices=[(0, 0), (200, 200), (100, 100)])
+    l % LayoutPoly(layer=layers.Metal2.pin, vertices=[
+        (200, 0), (200, 200), (100, 200), (100, 100), (0, 100), (0, 0)])
     l = l.freeze()
 
     reference = gds_text_from_file(gds_dir / 'test_write_gds_without_cell.gds')


### PR DESCRIPTION
For now, it seems that those "compact storage" classes for rectilinear shapes are not really that useful in practice.