### PR TITLE
Python transformer edge cases

### DIFF
--- a/ordec/ord/ord.lark
+++ b/ordec/ord/ord.lark
@@ -57,15 +57,16 @@ decorated: decorators (classdef | celldef | funcdef | viewgen | async_funcdef)
 async_funcdef: "async" funcdef
 funcdef: "def" name [type_params] "(" [parameters] _rpar ["->" test] ":" suite
 
-parameters: paramvalue ("," paramvalue)* ["," SLASH ("," paramvalue)*] ["," [starparams | kwparams]]
+parameters: paramvalue ("," paramvalue)* ["," SLASH ("," paramvalue)*] ["," [starparams | kwparams_trailing]]
           | starparams
-          | kwparams ","?
+          | kwparams_trailing
 
 SLASH: "/" // Otherwise the it will completely disappear and it will be undisguisable in the result
 starparams: (starparam | starguard) poststarparams
 starparam: "*" typed_starparam
 starguard: "*"
 poststarparams: ("," paramvalue)* ["," kwparams] ","?
+?kwparams_trailing: kwparams ","?
 kwparams: "**" typedparam
 
 ?paramvalue: typedparam ("=" test)?
@@ -117,7 +118,7 @@ pass_stmt: "pass"
 ?flow_stmt: break_stmt | continue_stmt | return_stmt | raise_stmt | yield_stmt
 break_stmt: "break"
 continue_stmt: "continue"
-return_stmt: "return" [testlist]
+return_stmt: "return" [testlist_star_expr]
 yield_stmt: yield_expr
 raise_stmt: "raise" [test ["from" test]]
 import_stmt: import_name | import_from
@@ -142,7 +143,7 @@ if_stmt: "if" test ":" suite elifs ["else" ":" suite]
 elifs: elif_*
 elif_: "elif" test ":" suite
 while_stmt: "while" test ":" suite ["else" ":" suite]
-for_stmt: "for" exprlist "in" testlist ":" suite ["else" ":" suite]
+for_stmt: "for" for_target_list "in" testlist_star_expr ":" suite ["else" ":" suite]
 try_stmt: "try" ":" suite except_clauses ["else" ":" suite] [finally__]
         | "try" ":" suite finally__   -> try_finally
 finally__: "finally" ":" suite
@@ -166,17 +167,12 @@ with_paren_mixed_items: with_paren_as_item "," with_paren_item ("," with_paren_i
 with_paren_item: test ["as" with_target]
 with_item: test ["as" with_target]
 
-?with_target: with_target "." name -> getattr
-            | with_target "[" subscriptlist "]" -> getitem
-            | name -> var
-            | "(" with_target _rpar
-            | "(" _with_target_items _rpar -> tuple
-            | "[" _with_target_items "]" -> list
+?with_target: expr
 _with_target_items: with_target_item ("," with_target_item)* ","?
 ?with_target_item: with_target
                  | "*" with_target -> star_expr
 
-match_stmt: "match" test ":" _NEWLINE _INDENT case+ _DEDENT
+match_stmt: _MATCH_STMT testlist_star_expr ":" _NEWLINE _INDENT case+ _DEDENT
 
 case: "case" pattern ["if" test] ":" suite
 
@@ -220,8 +216,8 @@ _sequence_pattern: (sequence_item_pattern ("," sequence_item_pattern)* ","?)?
 ?sequence_item_pattern: as_pattern
                       | "*" NAME -> star_pattern
 
-class_pattern: name_or_attr_pattern "(" [arguments_pattern ","?] _rpar
-arguments_pattern: argument ("," argument)*
+class_pattern: name_or_attr_pattern "(" [arguments_pattern] _rpar
+arguments_pattern: argument ("," argument)* ","?
 argument: NAME "=" as_pattern -> keyw_arg_pattern
         | as_pattern
 
@@ -230,6 +226,16 @@ suite: simple_stmt | _NEWLINE _INDENT stmt+ _DEDENT
 ?test: or_test ("if" or_test "else" test)?
      | lambdef
      | assign_expr
+
+?f_test: or_test ("if" or_test "else" f_test)?
+       | lambdef
+
+?f_test_or_star_expr: f_test
+                    | star_expr
+
+?f_testlist_star_expr: f_test_or_star_expr
+                     | f_test_or_star_expr ("," f_test_or_star_expr)+ ","? -> tuple
+                     | f_test_or_star_expr "," -> tuple
 
 assign_expr: name ":=" test
 
@@ -241,6 +247,9 @@ assign_expr: name ":=" test
          | comparison
 ?comparison: expr (comp_op expr)*
 star_expr: "*" expr
+?expr_or_star_expr: expr | star_expr
+?for_target_list: expr_or_star_expr
+                | expr_or_star_expr (("," expr_or_star_expr)+ ","? | ",") -> tuple
 
 ?expr: or_expr
 ?or_expr: xor_expr ("|" xor_expr)*
@@ -336,14 +345,14 @@ stararg: "*" test
 kwargs: "**" test
 
 comprehension{comp_result}: comp_result comp_for+
-comp_for: [ASYNC] "for" exprlist "in" or_test comp_if*
+comp_for: [ASYNC] "for" for_target_list "in" or_test comp_if*
 ASYNC: "async"
 ?comp_if: "if" test_nocond
 
 // not used in grammar, but may appear in "node" passed from Parser to Compiler
 encoding_decl: name
 
-yield_expr: "yield" [testlist]
+yield_expr: "yield" [testlist_star_expr]
           | "yield" "from" test -> yield_from
 
 number: HEX_NUMBER | BIN_NUMBER | OCT_NUMBER | IMAG_NUMBER | RATIONAL
@@ -355,19 +364,23 @@ f_string: FSTRING_DOUBLE_START f_string_content_double* FSTRING_DOUBLE_END
 // adjacent expression closers in nested format specs.
 f_string_content_double: FSTRING_TEXT_DOUBLE
                        | f_expression_double
+                       | FSTRING_NAMED_UNICODE_ESCAPE -> named_unicode_escape
                        | FSTRING_LITERAL_OPEN -> literal_open_brace
                        | _FSTRING_EXPR_END -> literal_close_brace
 
 f_string_content_single: FSTRING_TEXT_SINGLE
                        | f_expression_single
+                       | FSTRING_NAMED_UNICODE_ESCAPE -> named_unicode_escape
                        | FSTRING_LITERAL_OPEN -> literal_open_brace
                        | _FSTRING_EXPR_END -> literal_close_brace
 f_expression_double: "{" f_expression_body debug_eq? conversion? format_spec_double? _FSTRING_EXPR_END
 f_expression_single: "{" f_expression_body debug_eq? conversion? format_spec_single? _FSTRING_EXPR_END
-?f_expression_body: yield_expr | testlist_star_expr
+?f_expression_body: yield_expr | f_testlist_star_expr
 debug_eq: "="
 format_spec_single: ":" (FSTRING_TEXT_SINGLE | f_expression_single)*
+                  | ":=" (FSTRING_TEXT_SINGLE | f_expression_single)* -> format_spec_eq
 format_spec_double: ":" (FSTRING_TEXT_DOUBLE | f_expression_double)*
+                  | ":=" (FSTRING_TEXT_DOUBLE | f_expression_double)* -> format_spec_eq
 conversion: "!" /[rsa]/i
 
 FSTRING_DOUBLE_END.2: /"/
@@ -378,12 +391,13 @@ _FSTRING_EXPR_END.3: "}"
 FSTRING_SINGLE_START.2: /(f|fr|rf)'/i
 FSTRING_DOUBLE_START.2: /(f|fr|rf)"/i
 
-FSTRING_TEXT_DOUBLE.2: /(?:\\.|[^{}"\\])+/
-FSTRING_TEXT_SINGLE.2: /(?:\\.|[^{}'\\])+/
+FSTRING_NAMED_UNICODE_ESCAPE.4: /\\N\{(?:[A-Z][A-Z0-9 -]*|[^\W\d]\w*)\}/
+FSTRING_TEXT_DOUBLE.2: /(?:\\(?=[{}])|\\(?!N\{)[^{}]|[^{}"\\])+/
+FSTRING_TEXT_SINGLE.2: /(?:\\(?=[{}])|\\(?!N\{)[^{}]|[^{}'\\])+/
 
 INVALID_STRING_PREFIX.4: /((ur|ru))("(?!"").*?(?<!\\)(\\\\)*?"|'(?!'').*?(?<!\\)(\\\\)*?')/i
 F_LONG_STRING.3: /((f|fr|rf))(""".*?(?<!\\)(\\\\)*?"""|'''.*?(?<!\\)(\\\\)*?''')/is
-STRING: /((br|rb|b|r|u)?)("(?!"").*?(?<!\\)(\\\\)*?"|'(?!'').*?(?<!\\)(\\\\)*?')/i
+STRING: /((br|rb|b|r|u)?)("(?!"")(?:\\\r?\n|[^\r\n])*?(?<!\\)(\\\\)*?"|'(?!'')(?:\\\r?\n|[^\r\n])*?(?<!\\)(\\\\)*?')/i
 LONG_STRING: /((br|rb|b|r|u)?)(""".*?(?<!\\)(\\\\)*?"""|'''.*?(?<!\\)(\\\\)*?''')/is
 
 // Other terminals
@@ -391,6 +405,7 @@ LONG_STRING: /((br|rb|b|r|u)?)(""".*?(?<!\\)(\\\\)*?"""|'''.*?(?<!\\)(\\\\)*?'''
 _NEWLINE: ( /\r?\n[\t ]*/ | COMMENT )+
 _rpar: ")" | _RPAREN_AS
 _RPAREN_AS.3: /\)(?=[\t \f]*as\b)/
+_MATCH_STMT.3: /match\b(?!(?:[\t \f]*[:=])|[.\[])(?=[^\n]*:)/
 
 %ignore /[\t \f]+/  // WS
 %ignore /\\[\t \f]*\r?\n/   // LINE_CONT
@@ -419,8 +434,7 @@ IMAG_NUMBER.2: (_SPECIAL_DEC      | FLOAT_NUMBER) ("J" | "j")
 
 // ORD DEFINITIONS
 SI: /[afpnumkMGT]/
-RATIONAL: DEC_NUMBER SLASH DEC_NUMBER
-        | DEC_NUMBER SI?
+RATIONAL: DEC_NUMBER SI?
         | FLOAT_NUMBER SI?
 
 celldef: "cell" name ":" suite
@@ -429,8 +443,9 @@ constrain_stmt: "!" test
 context_body: ":" suite
 node_stmt: atom_expr context_target context_body
 node_stmt_nobody: atom_expr context_target ("," context_target)*
-anon_node_stmt: "anonymous" atom_expr context_target context_body
-anon_node_stmt_nobody: "anonymous" atom_expr context_target ("," context_target)*
+anon_node_stmt: _ANONYMOUS_STMT atom_expr context_target context_body
+anon_node_stmt_nobody: _ANONYMOUS_STMT atom_expr context_target ("," context_target)*
+_ANONYMOUS_STMT.3: /anonymous(?![\t \f]*[:=])(?=[\t \f]+)/
 
 ?context_target: context_target "." name -> getattr
 		       | context_target "[" subscriptlist "]" -> getitem

--- a/ordec/ord/ord.lark
+++ b/ordec/ord/ord.lark
@@ -71,7 +71,7 @@ kwparams: "**" typedparam
 
 ?paramvalue: typedparam ("=" test)?
 ?typedparam: name (":" test)?
-?typed_starparam: name (":" test_or_star_expr)?
+?typed_starparam: name (":" test_or_star_expr)? -> typedparam
 
 
 lambdef: "lambda" [lambda_params] ":" test
@@ -159,18 +159,15 @@ with_stmt: "with" with_items ":" suite
          | "with" "(" with_paren_as_item ","? ")" ":" suite
          | "with" "(" with_paren_mixed_items ")" ":" suite
 with_items: with_item ("," with_item)*
-with_paren_as_item: test "as" with_target
+with_paren_as_item: test "as" with_target -> with_item
 with_paren_mixed_items: with_paren_as_item "," with_paren_item ("," with_paren_item)* ","?
                       | with_paren_as_item "," -> with_paren_single_as_item
                       | test "," -> with_paren_single_item
                       | test "," with_paren_item ("," with_paren_item)* ","?
-with_paren_item: test ["as" with_target]
+with_paren_item: test ["as" with_target] -> with_item
 with_item: test ["as" with_target]
 
 ?with_target: expr
-_with_target_items: with_target_item ("," with_target_item)* ","?
-?with_target_item: with_target
-                 | "*" with_target -> star_expr
 
 match_stmt: _MATCH_STMT testlist_star_expr ":" _NEWLINE _INDENT case+ _DEDENT
 
@@ -302,7 +299,7 @@ _tuple_inner: test_or_star_expr (("," test_or_star_expr)+ [","] | ",")
 ?test_or_star_expr: test
                  | star_expr
 
-?subscriptlist: star_expr -> subscript_starred_tuple
+?subscriptlist: star_expr -> subscript_tuple
               | subscript
               | subscript_item (("," subscript_item)+ [","] | ",") -> subscript_tuple
 ?subscript_item: subscript | star_expr
@@ -349,9 +346,6 @@ comp_for: [ASYNC] "for" for_target_list "in" or_test comp_if*
 ASYNC: "async"
 ?comp_if: "if" test_nocond
 
-// not used in grammar, but may appear in "node" passed from Parser to Compiler
-encoding_decl: name
-
 yield_expr: "yield" [testlist_star_expr]
           | "yield" "from" test -> yield_from
 
@@ -377,9 +371,9 @@ f_expression_double: "{" f_expression_body debug_eq? conversion? format_spec_dou
 f_expression_single: "{" f_expression_body debug_eq? conversion? format_spec_single? _FSTRING_EXPR_END
 ?f_expression_body: yield_expr | f_testlist_star_expr
 debug_eq: "="
-format_spec_single: ":" (FSTRING_TEXT_SINGLE | f_expression_single)*
+format_spec_single: ":" (FSTRING_TEXT_SINGLE | f_expression_single)* -> format_spec
                   | ":=" (FSTRING_TEXT_SINGLE | f_expression_single)* -> format_spec_eq
-format_spec_double: ":" (FSTRING_TEXT_DOUBLE | f_expression_double)*
+format_spec_double: ":" (FSTRING_TEXT_DOUBLE | f_expression_double)* -> format_spec
                   | ":=" (FSTRING_TEXT_DOUBLE | f_expression_double)* -> format_spec_eq
 conversion: "!" /[rsa]/i
 
@@ -455,7 +449,3 @@ dotted_atom: "." name?
 path_stmt: "path" context_target ("," context_target)*
 net_stmt: "net" context_target ("," context_target)*
 // END OF ORD DEFINITIONS
-
-// Comma-separated list (with an optional trailing comma)
-cs_list{item}: item ("," item)* ","?
-_cs_list{item}: item ("," item)* ","?

--- a/ordec/ord/ord.lark
+++ b/ordec/ord/ord.lark
@@ -362,8 +362,9 @@ f_string_content_single: FSTRING_TEXT_SINGLE
                        | f_expression_single
                        | FSTRING_LITERAL_OPEN -> literal_open_brace
                        | _FSTRING_EXPR_END -> literal_close_brace
-f_expression_double: "{" test debug_eq? conversion? format_spec_double? _FSTRING_EXPR_END
-f_expression_single: "{" test debug_eq? conversion? format_spec_single? _FSTRING_EXPR_END
+f_expression_double: "{" f_expression_body debug_eq? conversion? format_spec_double? _FSTRING_EXPR_END
+f_expression_single: "{" f_expression_body debug_eq? conversion? format_spec_single? _FSTRING_EXPR_END
+?f_expression_body: yield_expr | testlist_star_expr
 debug_eq: "="
 format_spec_single: ":" (FSTRING_TEXT_SINGLE | f_expression_single)*
 format_spec_double: ":" (FSTRING_TEXT_DOUBLE | f_expression_double)*
@@ -398,6 +399,7 @@ _RPAREN_AS.3: /\)(?=[\t \f]*as\b)/
 
 // Python terminals
 !name: NAME | "match" | "case" | "anonymous"
+     | "type" | "path" | "cell" | "net" | "viewgen"
 NAME: /(?!(?:False|None|True|and|as|assert|async|await|break|class|continue|def|del|elif|else|except|
     finally|for|from|global|if|import|in|is|lambda|nonlocal|not|or|pass|raise|return|try|while|with|yield)\b)
     (?![^\W\d]\w*['"])[^\W\d]\w*/x

--- a/ordec/ord/ord.lark
+++ b/ordec/ord/ord.lark
@@ -319,9 +319,10 @@ type_params: "[" type_param ("," type_param)* ","? "]"
            | name ":" test -> bounded_typevar
            | name ":" test "=" test -> bounded_typevar_default
            | "*" name -> typevartuple
-           | "*" name "=" test -> typevartuple_default
+           | "*" name "=" typevartuple_default_value -> typevartuple_default
            | "**" name -> paramspec
            | "**" name "=" test -> paramspec_default
+?typevartuple_default_value: test | star_expr
 
 arguments: comprehension{test}
          | call_argument ("," call_argument)* ","?

--- a/ordec/ord/ord.lark
+++ b/ordec/ord/ord.lark
@@ -315,9 +315,13 @@ classdef: "class" name [type_params] ["(" [arguments] _rpar] ":" suite
 type_alias_stmt: "type" name [type_params] "=" test
 type_params: "[" type_param ("," type_param)* ","? "]"
 ?type_param: name -> typevar
+           | name "=" test -> typevar_default
            | name ":" test -> bounded_typevar
+           | name ":" test "=" test -> bounded_typevar_default
            | "*" name -> typevartuple
+           | "*" name "=" test -> typevartuple_default
            | "**" name -> paramspec
+           | "**" name "=" test -> paramspec_default
 
 arguments: comprehension{test}
          | call_argument ("," call_argument)* ","?
@@ -346,24 +350,28 @@ string: INVALID_STRING_PREFIX | F_LONG_STRING | STRING | LONG_STRING | f_string
 
 f_string: FSTRING_DOUBLE_START f_string_content_double* FSTRING_DOUBLE_END
         | FSTRING_SINGLE_START f_string_content_single* FSTRING_SINGLE_END
+// Literal close braces are paired in the transformer to avoid `}}` stealing
+// adjacent expression closers in nested format specs.
 f_string_content_double: FSTRING_TEXT_DOUBLE
                        | f_expression_double
-                       | "{{" -> literal_open_brace
-                       | "}}" -> literal_close_brace
+                       | FSTRING_LITERAL_OPEN -> literal_open_brace
+                       | _FSTRING_EXPR_END -> literal_close_brace
 
 f_string_content_single: FSTRING_TEXT_SINGLE
                        | f_expression_single
-                       | "{{" -> literal_open_brace
-                       | "}}" -> literal_close_brace
-f_expression_double: "{" test debug_eq? conversion? format_spec_double? "}"
-f_expression_single: "{" test debug_eq? conversion? format_spec_single? "}"
+                       | FSTRING_LITERAL_OPEN -> literal_open_brace
+                       | _FSTRING_EXPR_END -> literal_close_brace
+f_expression_double: "{" test debug_eq? conversion? format_spec_double? _FSTRING_EXPR_END
+f_expression_single: "{" test debug_eq? conversion? format_spec_single? _FSTRING_EXPR_END
 debug_eq: "="
-format_spec_single: ":" (FSTRING_TEXT_SINGLE | "{" test "}")*
-format_spec_double: ":" (FSTRING_TEXT_DOUBLE | "{" test "}")*
+format_spec_single: ":" (FSTRING_TEXT_SINGLE | f_expression_single)*
+format_spec_double: ":" (FSTRING_TEXT_DOUBLE | f_expression_double)*
 conversion: "!" /[rsa]/i
 
 FSTRING_DOUBLE_END.2: /"/
 FSTRING_SINGLE_END.2: /'/
+FSTRING_LITERAL_OPEN.4: "{{"
+_FSTRING_EXPR_END.3: "}"
 
 FSTRING_SINGLE_START.2: /(f|fr|rf)'/i
 FSTRING_DOUBLE_START.2: /(f|fr|rf)"/i
@@ -389,7 +397,9 @@ _RPAREN_AS.3: /\)(?=[\t \f]*as\b)/
 
 // Python terminals
 !name: NAME | "match" | "case" | "anonymous"
-NAME: /(?!(?:False|None|True|and|as|assert|async|await|break|class|continue|def|del|elif|else|except|finally|for|from|global|if|import|in|is|lambda|nonlocal|not|or|pass|raise|return|try|while|with|yield)\b)(?![^\W\d]\w*['"])[^\W\d]\w*/
+NAME: /(?!(?:False|None|True|and|as|assert|async|await|break|class|continue|def|del|elif|else|except|
+    finally|for|from|global|if|import|in|is|lambda|nonlocal|not|or|pass|raise|return|try|while|with|yield)\b)
+    (?![^\W\d]\w*['"])[^\W\d]\w*/x
 COMMENT: /#[^\n]*/
 
 _SPECIAL_DEC: "0".."9"        ("_"?  "0".."9"                       )*

--- a/ordec/ord/ord.lark
+++ b/ordec/ord/ord.lark
@@ -26,11 +26,11 @@
 
 // ------------------------------------------------------------------------------
 
-// Special Python 3 grammar for Lark
-// This grammar extends the standard Python syntax with additional constructs
-// and syntactic rules specific to custom integrated circuit (IC) design.
-
-// This grammar should parse all python 3.x code successfully.
+// Python grammar for Lark, extended with ORD syntax.
+// Python 3.13 syntax is the primary reference. This grammar aims for broad
+// Python 3.X compatibility but does not guarantee to parse every Python 3.X program.
+// ORD adds constructs and syntactic rules specific to custom integrated circuit
+// (IC) design.
 // Adapted from: https://docs.python.org/3/reference/grammar.html
 
 // Start symbols for the grammar:

--- a/ordec/ord/ord.lark
+++ b/ordec/ord/ord.lark
@@ -50,26 +50,27 @@ single_input: _NEWLINE | simple_stmt | compound_stmt _NEWLINE
 file_input: (_NEWLINE | stmt)*
 eval_input: testlist _NEWLINE*
 
-decorator: "@" dotted_name [ "(" [arguments] ")" ] _NEWLINE
+decorator: "@" test _NEWLINE
 decorators: decorator+
 decorated: decorators (classdef | celldef | funcdef | viewgen | async_funcdef)
 
 async_funcdef: "async" funcdef
-funcdef: "def" name "(" [parameters] ")" ["->" test] ":" suite
+funcdef: "def" name [type_params] "(" [parameters] _rpar ["->" test] ":" suite
 
 parameters: paramvalue ("," paramvalue)* ["," SLASH ("," paramvalue)*] ["," [starparams | kwparams]]
           | starparams
-          | kwparams
+          | kwparams ","?
 
 SLASH: "/" // Otherwise the it will completely disappear and it will be undisguisable in the result
 starparams: (starparam | starguard) poststarparams
-starparam: "*" typedparam
+starparam: "*" typed_starparam
 starguard: "*"
-poststarparams: ("," paramvalue)* ["," kwparams]
-kwparams: "**" typedparam ","?
+poststarparams: ("," paramvalue)* ["," kwparams] ","?
+kwparams: "**" typedparam
 
 ?paramvalue: typedparam ("=" test)?
 ?typedparam: name (":" test)?
+?typed_starparam: name (":" test_or_star_expr)?
 
 
 lambdef: "lambda" [lambda_params] ":" test
@@ -93,6 +94,7 @@ lambda_kwparams: "**" name ","?
             | global_stmt
             | nonlocal_stmt
             | assert_stmt
+            | type_alias_stmt
             | path_stmt
             | net_stmt
             | constrain_stmt
@@ -121,7 +123,7 @@ raise_stmt: "raise" [test ["from" test]]
 import_stmt: import_name | import_from
 import_name: "import" dotted_as_names
 // note below: the ("." | "...") is necessary because "..." is tokenized as ELLIPSIS
-import_from: "from" (dots? dotted_name | dots) "import" ("*" | "(" import_as_names ")" | import_as_names)
+import_from: "from" (dots? dotted_name | dots) "import" ("*" | "(" import_as_names _rpar | import_as_names)
 !dots: "."+
 import_as_name: name ["as" name]
 dotted_as_name: dotted_name ["as" name]
@@ -146,18 +148,29 @@ try_stmt: "try" ":" suite except_clauses ["else" ":" suite] [finally__]
 finally__: "finally" ":" suite
 except_clauses: except_clause+
 except_clause: "except" [test ["as" name]] ":" suite
+             | "except" "*" test ["as" name] ":" suite -> except_star_clause
 // NB compile.c makes sure that the default except clause is last
 
 
 with_stmt: "with" with_items ":" suite
+         | "with" "(" test _RPAREN_AS "as" with_target ":" suite -> with_parenthesized_expr_as
+         | "with" "(" with_paren_mixed_items _RPAREN_AS "as" with_target ":" suite -> with_parenthesized_items_as
+         | "with" "(" with_paren_as_item ","? ")" ":" suite
+         | "with" "(" with_paren_mixed_items ")" ":" suite
 with_items: with_item ("," with_item)*
+with_paren_as_item: test "as" with_target
+with_paren_mixed_items: with_paren_as_item "," with_paren_item ("," with_paren_item)* ","?
+                      | with_paren_as_item "," -> with_paren_single_as_item
+                      | test "," -> with_paren_single_item
+                      | test "," with_paren_item ("," with_paren_item)* ","?
+with_paren_item: test ["as" with_target]
 with_item: test ["as" with_target]
 
 ?with_target: with_target "." name -> getattr
             | with_target "[" subscriptlist "]" -> getitem
             | name -> var
-            | "(" with_target ")"
-            | "(" _with_target_items ")" -> tuple
+            | "(" with_target _rpar
+            | "(" _with_target_items _rpar -> tuple
             | "[" _with_target_items "]" -> list
 _with_target_items: with_target_item ("," with_target_item)* ","?
 ?with_target_item: with_target
@@ -175,9 +188,9 @@ case: "case" pattern ["if" test] ":" suite
                | NAME -> capture_pattern
                | "_" -> any_pattern
                | attr_pattern
-               | "(" as_pattern ")"
+               | "(" as_pattern _rpar
                | "[" _sequence_pattern "]" -> sequence_pattern
-               | "(" (sequence_item_pattern "," _sequence_pattern)? ")" -> sequence_pattern
+               | "(" (sequence_item_pattern "," _sequence_pattern)? _rpar -> sequence_pattern
                | "{" (mapping_item_pattern ("," mapping_item_pattern)* ","?)?"}" -> mapping_pattern
                | "{" (mapping_item_pattern ("," mapping_item_pattern)* ",")? "**" NAME ","? "}" -> mapping_star_pattern
                | class_pattern
@@ -189,9 +202,15 @@ literal_pattern: inner_literal_pattern
                       | "False" -> const_false
                       | STRING
                       | LONG_STRING
+                      | complex_number_pattern
+                      | "-" number -> negative_number
                       | number
 
-attr_pattern: NAME ("." NAME)+ -> value
+complex_number_pattern: signed_real_number _add_op IMAG_NUMBER
+?signed_real_number: "-" number -> negative_number
+                   | number
+
+attr_pattern: NAME ("." NAME)+
 
 name_or_attr_pattern: NAME ("." NAME)* -> value
 
@@ -201,7 +220,7 @@ _sequence_pattern: (sequence_item_pattern ("," sequence_item_pattern)* ","?)?
 ?sequence_item_pattern: as_pattern
                       | "*" NAME -> star_pattern
 
-class_pattern: name_or_attr_pattern "(" [arguments_pattern ","?] ")"
+class_pattern: name_or_attr_pattern "(" [arguments_pattern ","?] _rpar
 arguments_pattern: argument ("," argument)*
 argument: NAME "=" as_pattern -> keyw_arg_pattern
         | as_pattern
@@ -236,23 +255,21 @@ star_expr: "*" expr
 !_add_op: "+"|"-"
 !_shift_op: "<<"|">>"
 !_mul_op: "*"|"@"|"/"|"%"|"//"
-// <> isn't actually a valid comparison operator in Python. It's here for the
-// sake of a __future__ import described in PEP 401 (which really works :-)
-!comp_op: "<"|">"|"=="|">="|"<="|"<>"|"!="|"in"| /not\s+in/ | "is" | /is\s+not/
+!comp_op: "<"|">"|"=="|">="|"<="|"!="|"in"| "not" "in" -> not_in | "is" "not" -> is_not | "is"
 
 ?power: await_expr ("**" factor)?
 ?await_expr: AWAIT? atom_expr
 AWAIT: "await"
 
-?atom_expr: atom_expr "(" [arguments] ")"      -> funccall
+?atom_expr: atom_expr "(" [arguments] _rpar    -> funccall
           | atom_expr "[" subscriptlist "]"    -> getitem
           | atom_expr "." name            -> getattr
           | atom_expr? ".$" name           -> getparam
           | atom
 
-?atom: "(" yield_expr ")"
-     | "(" _tuple_inner? ")" -> tuple
-     | "(" comprehension{test_or_star_expr} ")" -> tuple_comprehension
+?atom: "(" yield_expr _rpar
+     | "(" _tuple_inner? _rpar -> parenthesized_tuple
+     | "(" comprehension{test_or_star_expr} _rpar -> tuple_comprehension
      | "[" _exprlist? "]"  -> list
      | "[" comprehension{test_or_star_expr} "]"  -> list_comprehension
      | "{" _dict_exprlist? "}" -> dict
@@ -262,7 +279,7 @@ AWAIT: "await"
      | name -> var
      | number
      | string_concat
-     | "(" test ")"
+     | "(" test _rpar -> grouped_test
      | dotted_atom
      | "..." -> ellipsis
      | "None"    -> const_none
@@ -276,8 +293,10 @@ _tuple_inner: test_or_star_expr (("," test_or_star_expr)+ [","] | ",")
 ?test_or_star_expr: test
                  | star_expr
 
-?subscriptlist: subscript
-              | subscript (("," subscript)+ [","] | ",") -> subscript_tuple
+?subscriptlist: star_expr -> subscript_starred_tuple
+              | subscript
+              | subscript_item (("," subscript_item)+ [","] | ",") -> subscript_tuple
+?subscript_item: subscript | star_expr
 ?subscript: test | ([test] MARK [test] [sliceop]) -> slice
 MARK: ":"
 sliceop: ":" [test]
@@ -291,21 +310,28 @@ key_value: test ":"  test
 
 _exprlist: test_or_star_expr (","  test_or_star_expr)* [","]
 
-classdef: "class" name ["(" [arguments] ")"] ":" suite
+classdef: "class" name [type_params] ["(" [arguments] _rpar] ":" suite
 
-arguments: argvalue ("," argvalue)* ("," starargs_part)? ("," kwargs)? ","?
-         | starargs_part
-         | kwargs
-         | comprehension{test}
+type_alias_stmt: "type" name [type_params] "=" test
+type_params: "[" type_param ("," type_param)* ","? "]"
+?type_param: name -> typevar
+           | name ":" test -> bounded_typevar
+           | "*" name -> typevartuple
+           | "**" name -> paramspec
 
-starargs_part: stararg ("," stararg)* ("," argvalue)* ("," kwargs)? ","?
+arguments: comprehension{test}
+         | call_argument ("," call_argument)* ","?
+
+?call_argument: name "=" test -> argvalue
+              | stararg
+              | kwargs
+              | test
+
 stararg: "*" test
 kwargs: "**" test
-?argvalue: test ("=" test)?
 
-comprehension{comp_result}: comp_result comp_fors comp_if*
-comp_fors: comp_for+
-comp_for: [ASYNC] "for" exprlist "in" or_test
+comprehension{comp_result}: comp_result comp_for+
+comp_for: [ASYNC] "for" exprlist "in" or_test comp_if*
 ASYNC: "async"
 ?comp_if: "if" test_nocond
 
@@ -316,7 +342,7 @@ yield_expr: "yield" [testlist]
           | "yield" "from" test -> yield_from
 
 number: HEX_NUMBER | BIN_NUMBER | OCT_NUMBER | IMAG_NUMBER | RATIONAL
-string: STRING | LONG_STRING | f_string
+string: INVALID_STRING_PREFIX | F_LONG_STRING | STRING | LONG_STRING | f_string
 
 f_string: FSTRING_DOUBLE_START f_string_content_double* FSTRING_DOUBLE_END
         | FSTRING_SINGLE_START f_string_content_single* FSTRING_SINGLE_END
@@ -332,25 +358,29 @@ f_string_content_single: FSTRING_TEXT_SINGLE
 f_expression_double: "{" test debug_eq? conversion? format_spec_double? "}"
 f_expression_single: "{" test debug_eq? conversion? format_spec_single? "}"
 debug_eq: "="
-format_spec_single: ":" (FSTRING_TEXT_SINGLE | "{" test "}")+
-format_spec_double: ":" (FSTRING_TEXT_DOUBLE | "{" test "}")+
+format_spec_single: ":" (FSTRING_TEXT_SINGLE | "{" test "}")*
+format_spec_double: ":" (FSTRING_TEXT_DOUBLE | "{" test "}")*
 conversion: "!" /[rsa]/i
 
 FSTRING_DOUBLE_END.2: /"/
 FSTRING_SINGLE_END.2: /'/
 
-FSTRING_SINGLE_START.2: /(f|fr|rf)'/
-FSTRING_DOUBLE_START.2: /(f|fr|rf)"/
+FSTRING_SINGLE_START.2: /(f|fr|rf)'/i
+FSTRING_DOUBLE_START.2: /(f|fr|rf)"/i
 
 FSTRING_TEXT_DOUBLE.2: /(?:\\.|[^{}"\\])+/
 FSTRING_TEXT_SINGLE.2: /(?:\\.|[^{}'\\])+/
 
-STRING: /([ub]?r?|r[ub])("(?!"").*?(?<!\\)(\\\\)*?"|'(?!'').*?(?<!\\)(\\\\)*?')/i
-LONG_STRING: /([ub]?r?|r[ub])(""".*?(?<!\\)(\\\\)*?"""|'''.*?(?<!\\)(\\\\)*?''')/is
+INVALID_STRING_PREFIX.4: /((ur|ru))("(?!"").*?(?<!\\)(\\\\)*?"|'(?!'').*?(?<!\\)(\\\\)*?')/i
+F_LONG_STRING.3: /((f|fr|rf))(""".*?(?<!\\)(\\\\)*?"""|'''.*?(?<!\\)(\\\\)*?''')/is
+STRING: /((br|rb|b|r|u)?)("(?!"").*?(?<!\\)(\\\\)*?"|'(?!'').*?(?<!\\)(\\\\)*?')/i
+LONG_STRING: /((br|rb|b|r|u)?)(""".*?(?<!\\)(\\\\)*?"""|'''.*?(?<!\\)(\\\\)*?''')/is
 
 // Other terminals
 
 _NEWLINE: ( /\r?\n[\t ]*/ | COMMENT )+
+_rpar: ")" | _RPAREN_AS
+_RPAREN_AS.3: /\)(?=[\t \f]*as\b)/
 
 %ignore /[\t \f]+/  // WS
 %ignore /\\[\t \f]*\r?\n/   // LINE_CONT
@@ -359,7 +389,7 @@ _NEWLINE: ( /\r?\n[\t ]*/ | COMMENT )+
 
 // Python terminals
 !name: NAME | "match" | "case" | "anonymous"
-NAME: /[^\W\d]\w*(?!['"])/
+NAME: /(?!(?:False|None|True|and|as|assert|async|await|break|class|continue|def|del|elif|else|except|finally|for|from|global|if|import|in|is|lambda|nonlocal|not|or|pass|raise|return|try|while|with|yield)\b)(?![^\W\d]\w*['"])[^\W\d]\w*/
 COMMENT: /#[^\n]*/
 
 _SPECIAL_DEC: "0".."9"        ("_"?  "0".."9"                       )*

--- a/ordec/ord/ord.lark
+++ b/ordec/ord/ord.lark
@@ -61,7 +61,7 @@ parameters: paramvalue ("," paramvalue)* ["," SLASH ("," paramvalue)*] ["," [sta
           | starparams
           | kwparams_trailing
 
-SLASH: "/" // Otherwise the it will completely disappear and it will be undisguisable in the result
+SLASH: "/" // Otherwise it will disappear and be indistinguishable in the result
 starparams: (starparam | starguard) poststarparams
 starparam: "*" typed_starparam
 starguard: "*"
@@ -80,7 +80,7 @@ lambda_params: lambda_paramvalue ("," lambda_paramvalue)* ["," SLASH ("," lambda
           | lambda_starparams
           | lambda_kwparams
 lambda_paramvalue: name ("=" test)?
-lambda_starparams: "*" [name]  ("," lambda_paramvalue)* ["," [lambda_kwparams]]
+lambda_starparams: "*" [name] ("," lambda_paramvalue)* ["," [lambda_kwparams]]
 lambda_kwparams: "**" name ","?
 
 
@@ -260,11 +260,11 @@ star_expr: "*" expr
 ?term: factor (_mul_op factor)*
 ?factor: _unary_op factor | power
 
-!_unary_op: "+"|"-"|"~"|"not"
-!_add_op: "+"|"-"
-!_shift_op: "<<"|">>"
-!_mul_op: "*"|"@"|"/"|"%"|"//"
-!comp_op: "<"|">"|"=="|">="|"<="|"!="|"in"| "not" "in" -> not_in | "is" "not" -> is_not | "is"
+!_unary_op: "+" | "-" | "~" | "not"
+!_add_op: "+" | "-"
+!_shift_op: "<<" | ">>"
+!_mul_op: "*" | "@" | "/" | "%" | "//"
+!comp_op: "<" | ">" | "==" | ">=" | "<=" | "!=" | "in" | "not" "in" -> not_in | "is" "not" -> is_not | "is"
 
 ?power: await_expr ("**" factor)?
 ?await_expr: AWAIT? atom_expr
@@ -315,7 +315,7 @@ sliceop: ":" [test]
 testlist_tuple: test (("," test)+ [","] | ",")
 _dict_exprlist: (key_value | "**" expr) ("," (key_value | "**" expr))* [","]
 
-key_value: test ":"  test
+key_value: test ":" test
 
 _exprlist: test_or_star_expr (","  test_or_star_expr)* [","]
 
@@ -448,9 +448,9 @@ anon_node_stmt_nobody: _ANONYMOUS_STMT atom_expr context_target ("," context_tar
 _ANONYMOUS_STMT.3: /anonymous(?![\t \f]*[:=])(?=[\t \f]+)/
 
 ?context_target: context_target "." name -> getattr
-		       | context_target "[" subscriptlist "]" -> getitem
-   	           | name -> var
-		
+               | context_target "[" subscriptlist "]" -> getitem
+               | name -> var
+
 dotted_atom: "." name?
 path_stmt: "path" context_target ("," context_target)*
 net_stmt: "net" context_target ("," context_target)*

--- a/ordec/ord/ord_transformer.py
+++ b/ordec/ord/ord_transformer.py
@@ -47,7 +47,7 @@ class OrdTransformer(PythonTransformer):
     def RATIONAL(self, token):
         """ Rational numbers with SI suffix (100n, 20u)"""
         si_suffixes = ('a','f','p','n','u','m','k','M','G','T')
-        if token.endswith(si_suffixes) or '/' in token:
+        if token.endswith(si_suffixes):
             token = ast.Constant(token.value)
             return ast.Call(func=self.ast_core("R"), args=[token], keywords=[])
         else:

--- a/ordec/ord/parser.py
+++ b/ordec/ord/parser.py
@@ -1,12 +1,79 @@
 # SPDX-FileCopyrightText: 2025 ORDeC contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from lark import Lark, UnexpectedToken, UnexpectedCharacters, UnexpectedInput
+from lark import Lark, UnexpectedToken, UnexpectedCharacters, UnexpectedInput, Token
 from pathlib import Path
 import argparse
 from lark.indenter import PythonIndenter
 from .ord_transformer import OrdTransformer
 import ast
+
+
+class FStringAwarePythonIndenter(PythonIndenter):
+    """
+    PythonIndenter with f-string brace accounting.
+
+    The stock Lark indenter only balances the standard RBRACE token. This
+    grammar uses _FSTRING_EXPR_END for both f-string expression closes and
+    escaped literal close braces, so newline suppression must distinguish those
+    two cases.
+    """
+
+    FSTRING_START_types = {"FSTRING_DOUBLE_START", "FSTRING_SINGLE_START"}
+    FSTRING_END_types = {"FSTRING_DOUBLE_END", "FSTRING_SINGLE_END"}
+    FSTRING_EXPR_END_type = "_FSTRING_EXPR_END"
+
+    def _process(self, stream):
+        token = None
+        paren_stack = []
+        fstring_brace_levels = []
+
+        for token in stream:
+            if token.type == self.NL_type:
+                yield from self.handle_NL(token)
+            else:
+                yield token
+
+            token_type = token.type
+            if token_type in self.FSTRING_START_types:
+                fstring_brace_levels.append(0)
+                continue
+            if token_type in self.FSTRING_END_types:
+                if fstring_brace_levels and fstring_brace_levels[-1] == 0:
+                    fstring_brace_levels.pop()
+                continue
+
+            if token_type in self.OPEN_PAREN_types:
+                paren_stack.append(token_type)
+                self.paren_level = len(paren_stack)
+                if fstring_brace_levels and token_type == "LBRACE":
+                    fstring_brace_levels[-1] += 1
+                continue
+
+            if token_type in self.CLOSE_PAREN_types:
+                paren_stack.pop()
+                self.paren_level = len(paren_stack)
+                continue
+
+            if token_type == self.FSTRING_EXPR_END_type:
+                if fstring_brace_levels:
+                    if fstring_brace_levels[-1] > 0:
+                        paren_stack.pop()
+                        self.paren_level = len(paren_stack)
+                        fstring_brace_levels[-1] -= 1
+                    continue
+                if paren_stack and paren_stack[-1] == "LBRACE":
+                    paren_stack.pop()
+                    self.paren_level = len(paren_stack)
+
+        while len(self.indent_level) > 1:
+            self.indent_level.pop()
+            if token:
+                yield Token.new_borrow_pos(self.DEDENT_type, '', token)
+            else:
+                yield Token(self.DEDENT_type, '', 0, 0, 0, 0, 0, 0)
+
+        assert self.indent_level == [0], self.indent_level
 
 
 def format_error(code, line, column, window=2):
@@ -88,7 +155,7 @@ parser = Lark.open_from_package(
     __package__,
     "ord.lark",
     parser="lalr",
-    postlex=PythonIndenter(),
+    postlex=FStringAwarePythonIndenter(),
     start="file_input",
     maybe_placeholders=False,
     propagate_positions=True

--- a/ordec/ord/parser.py
+++ b/ordec/ord/parser.py
@@ -9,16 +9,16 @@ from .ord_transformer import OrdTransformer
 import ast
 
 
-class FStringAwarePythonIndenter(PythonIndenter):
+class PythonTokenAwareIndenter(PythonIndenter):
     """
-    PythonIndenter with f-string brace accounting.
+    PythonIndenter with accounting for grammar-specific Python tokens.
 
-    The stock Lark indenter only balances the standard RBRACE token. This
-    grammar uses _FSTRING_EXPR_END for both f-string expression closes and
-    escaped literal close braces, so newline suppression must distinguish those
-    two cases.
+    The stock Lark indenter only balances the standard close-token names. This
+    grammar has extra hidden close tokens for f-strings and with-as lookahead,
+    so newline suppression must account for them explicitly.
     """
 
+    CLOSE_PAREN_types = PythonIndenter.CLOSE_PAREN_types + ["_RPAREN_AS"]
     FSTRING_START_types = {"FSTRING_DOUBLE_START", "FSTRING_SINGLE_START"}
     FSTRING_END_types = {"FSTRING_DOUBLE_END", "FSTRING_SINGLE_END"}
     FSTRING_EXPR_END_type = "_FSTRING_EXPR_END"
@@ -155,7 +155,7 @@ parser = Lark.open_from_package(
     __package__,
     "ord.lark",
     parser="lalr",
-    postlex=FStringAwarePythonIndenter(),
+    postlex=PythonTokenAwareIndenter(),
     start="file_input",
     maybe_placeholders=False,
     propagate_positions=True

--- a/ordec/ord/python_transformer.py
+++ b/ordec/ord/python_transformer.py
@@ -5,7 +5,6 @@
 from lark import Transformer, v_args
 import ast
 import unicodedata
-import sys
 
 class PythonTransformer(Transformer):
     """
@@ -75,7 +74,6 @@ class PythonTransformer(Transformer):
         '==': ast.Eq,
         '>=': ast.GtE,
         '<=': ast.LtE,
-        '<>': ast.NotEq,  # Python 2
         '!=': ast.NotEq,
         'in': ast.In,
         'not in': ast.NotIn,
@@ -165,11 +163,44 @@ class PythonTransformer(Transformer):
 
         # Starred target: *rest
         elif isinstance(node, ast.Starred):
+            if isinstance(ctx, ast.Del):
+                raise SyntaxError("cannot delete starred")
             node.ctx = ctx
             self._set_ctx(node.value, ctx)
 
         else:
-            pass
+            if isinstance(ctx, ast.Store):
+                raise SyntaxError("invalid assignment target")
+            if isinstance(ctx, ast.Del):
+                raise SyntaxError("invalid deletion target")
+
+    @staticmethod
+    def _is_single_target(node):
+        # Augmented and annotated assignments use Python's single-target shape.
+        return isinstance(node, (ast.Name, ast.Attribute, ast.Subscript))
+
+    @staticmethod
+    def _is_unparenthesized_namedexpr(node):
+        return (
+            isinstance(node, ast.NamedExpr) and
+            not getattr(node, "_ord_parenthesized", False)
+        )
+
+    @classmethod
+    def _contains_unparenthesized_namedexpr(cls, node):
+        # The grammar accepts `test` in several places where Python only allows
+        # a named expression when it is parenthesized or nested in a container.
+        if node is None:
+            return False
+        if cls._is_unparenthesized_namedexpr(node):
+            return True
+        if (isinstance(node, ast.Tuple) and
+                not getattr(node, "_ord_parenthesized", False)):
+            return any(
+                cls._is_unparenthesized_namedexpr(elt)
+                for elt in node.elts
+            )
+        return False
 
     # Terminals
     # ---------
@@ -213,6 +244,10 @@ class PythonTransformer(Transformer):
     # ----------
 
     def expr_stmt(self, nodes):
+        if self._contains_unparenthesized_namedexpr(nodes[0]):
+            raise SyntaxError(
+                "assignment expression cannot be used in a bare expression statement"
+            )
         return ast.Expr(value=nodes[0])
 
     def async_stmt(self, nodes):
@@ -239,6 +274,8 @@ class PythonTransformer(Transformer):
     def assign(self, nodes):
         targets = nodes[:-1]
         value = nodes[-1]
+        if self._contains_unparenthesized_namedexpr(value):
+            raise SyntaxError("invalid assignment expression")
         for t in targets:
             self._set_ctx(t, ast.Store())
         return ast.Assign(targets=targets, value=value)
@@ -251,6 +288,10 @@ class PythonTransformer(Transformer):
         target = nodes[0]
         op = nodes[1]
         value = nodes[2]
+        if self._contains_unparenthesized_namedexpr(value):
+            raise SyntaxError("invalid assignment expression")
+        if not self._is_single_target(target):
+            raise SyntaxError("illegal expression for augmented assignment")
         self._set_ctx(target, ast.Store())
         return ast.AugAssign(target=target, op=op, value=value)
 
@@ -258,9 +299,22 @@ class PythonTransformer(Transformer):
         target = nodes[0]
         target_type = nodes[1]
         value = nodes[2] if len(nodes) > 2 else None
+        if (self._contains_unparenthesized_namedexpr(target_type) or
+                self._contains_unparenthesized_namedexpr(value)):
+            raise SyntaxError("invalid assignment expression")
+        if not self._is_single_target(target):
+            raise SyntaxError("illegal target for annotation")
         self._set_ctx(target, ast.Store())
-        simple = 1 if isinstance(target, ast.Name) else 0
-        return ast.AnnAssign(target=target, annotation=target_type, value=value, simple=simple)
+        simple = 1 if (
+            isinstance(target, ast.Name) and
+            not getattr(target, "_ord_parenthesized", False)
+        ) else 0
+        return ast.AnnAssign(
+            target=target,
+            annotation=target_type,
+            value=value,
+            simple=simple
+        )
 
     def raise_stmt(self, nodes):
         if not nodes:
@@ -275,11 +329,18 @@ class PythonTransformer(Transformer):
             # raise expr from cause
             exc, cause = nodes
 
+        if (self._contains_unparenthesized_namedexpr(exc) or
+                self._contains_unparenthesized_namedexpr(cause)):
+            raise SyntaxError("invalid assignment expression")
         return ast.Raise(exc=exc, cause=cause)
 
     def assert_stmt(self, nodes):
         test = nodes[0]
+        if self._contains_unparenthesized_namedexpr(test):
+            raise SyntaxError("invalid assignment expression")
         message = nodes[1] if len(nodes) > 1 else None
+        if self._contains_unparenthesized_namedexpr(message):
+            raise SyntaxError("invalid assignment expression")
         return ast.Assert(test=test, msg=message)
 
     def dotted_name(self, nodes):
@@ -341,7 +402,11 @@ class PythonTransformer(Transformer):
 
     pass_stmt = lambda self, _: ast.Pass()
     assign_stmt = lambda self, nodes: nodes[0]
-    return_stmt = lambda self, nodes: ast.Return(value=nodes[0] if len(nodes) > 0 else None)
+    def return_stmt(self, nodes):
+        value = nodes[0] if len(nodes) > 0 else None
+        if self._contains_unparenthesized_namedexpr(value):
+            raise SyntaxError("invalid assignment expression")
+        return ast.Return(value=value)
     break_stmt = lambda self, _: ast.Break()
     continue_stmt = lambda self, _: ast.Continue()
     global_stmt = lambda self, nodes: ast.Global(nodes)
@@ -384,6 +449,8 @@ class PythonTransformer(Transformer):
             target = ast.Tuple(target, ast.Store())
         self._set_ctx(target, ast.Store())
         iterator = nodes[1]
+        if self._contains_unparenthesized_namedexpr(iterator):
+            raise SyntaxError("invalid assignment expression")
         body = nodes[2]
         or_else = nodes[3] if len(nodes) > 3 else []
         return ast.For(target=target,
@@ -394,12 +461,37 @@ class PythonTransformer(Transformer):
     def try_stmt(self, nodes):
         # try: suite except_clauses [else: suite] [finally]
         body = nodes[0]
-        handlers = nodes[1]
+        raw_handlers = nodes[1]
+        is_star = any(
+            isinstance(handler, tuple) and handler[0] == "except_star"
+            for handler in raw_handlers
+        )
+        if is_star and any(
+            not (isinstance(handler, tuple) and handler[0] == "except_star")
+            for handler in raw_handlers
+        ):
+            raise SyntaxError("cannot mix except and except*")
+        handlers = [
+            handler[1]
+            if isinstance(handler, tuple) and handler[0] == "except_star"
+            else handler
+            for handler in raw_handlers
+        ]
+        for handler in handlers[:-1]:
+            if handler.type is None:
+                raise SyntaxError("default 'except:' must be last")
         orelse = nodes[2] if len(nodes) > 2 and not isinstance(nodes[2], tuple) else []
         if len(orelse) > 0:
             finalbody = nodes[3][1] if len(nodes) > 3 else []
         else:
             finalbody = nodes[2][1] if len(nodes) > 2 else []
+        if is_star:
+            return ast.TryStar(
+                body=body,
+                handlers=handlers,
+                orelse=orelse,
+                finalbody=finalbody
+            )
         return ast.Try(body=body, handlers=handlers, orelse=orelse, finalbody=finalbody)
 
     def try_finally(self, nodes):
@@ -432,13 +524,49 @@ class PythonTransformer(Transformer):
             suite = nodes[2]
         return ast.ExceptHandler(type=exc_type, name=name, body=suite)
 
+    def except_star_clause(self, nodes):
+        if len(nodes) == 2:
+            exc_type = nodes[0]
+            name = None
+            suite = nodes[1]
+        else:
+            exc_type = nodes[0]
+            name = nodes[1]
+            suite = nodes[2]
+        return "except_star", ast.ExceptHandler(type=exc_type, name=name, body=suite)
+
     def with_stmt(self, nodes):
         with_items = nodes[0]
-        suite = nodes [1]
+        if isinstance(with_items, ast.withitem):
+            with_items = [with_items]
+        suite = nodes[1]
+        if (len(with_items) == 1 and
+                with_items[0].optional_vars is None and
+                isinstance(with_items[0].context_expr, ast.Tuple) and
+                not getattr(with_items[0].context_expr, "_ord_parenthesized", False)):
+            with_items = [
+                ast.withitem(context_expr=elt, optional_vars=None)
+                for elt in with_items[0].context_expr.elts
+            ]
         return ast.With(items=with_items, body=suite)
+
+    def with_parenthesized_expr_as(self, nodes):
+        return ast.With(items=[self.with_item(nodes[:2])], body=nodes[2])
+
+    def with_parenthesized_items_as(self, nodes):
+        items = nodes[0]
+        if any(item.optional_vars is not None for item in items):
+            raise SyntaxError("invalid syntax")
+        tuple_expr = ast.Tuple(
+            elts=[item.context_expr for item in items],
+            ctx=ast.Load()
+        )
+        return ast.With(items=[self.with_item([tuple_expr, nodes[1]])], body=nodes[2])
 
     def with_item(self, nodes):
         test = nodes[0]
+        if self._contains_unparenthesized_namedexpr(test):
+            raise SyntaxError("invalid assignment expression")
         name = nodes[1] if len(nodes) > 1 else None
         if isinstance(name, str):
             name = ast.Name(id=name, ctx=ast.Store())
@@ -449,13 +577,29 @@ class PythonTransformer(Transformer):
             optional_vars=name
         )
 
+    def with_paren_item(self, nodes):
+        return self.with_item(nodes)
+
+    def with_paren_as_item(self, nodes):
+        return self.with_item(nodes)
+
+    def with_paren_single_item(self, nodes):
+        return [ast.withitem(context_expr=nodes[0], optional_vars=None)]
+
+    def with_paren_single_as_item(self, nodes):
+        return [nodes[0]]
+
+    def with_paren_mixed_items(self, nodes):
+        if isinstance(nodes[0], ast.withitem):
+            return nodes
+        return [ast.withitem(context_expr=nodes[0], optional_vars=None), *nodes[1:]]
+
     def match_stmt(self, nodes):
         test = nodes[0]
         cases = nodes[1:]
         return ast.Match(test, cases)
 
     elifs = lambda self, nodes: nodes
-    comp_fors = lambda self, nodes: nodes
     except_clauses = lambda self, nodes: nodes
     with_items = lambda self, nodes: nodes
 
@@ -468,42 +612,49 @@ class PythonTransformer(Transformer):
         prelim_args = nodes[1] if len(nodes) > 1 else []
         keywords = []
         args = []
-        for arg in prelim_args:
-            # star arguments
-            if isinstance(arg, list):
-                for inner_arg in arg:
-                    if isinstance(inner_arg, tuple) and inner_arg[0] == "stararg":
-                        args.append(ast.Starred(inner_arg[1], ctx=ast.Load()))
-                    elif isinstance(inner_arg, tuple) and inner_arg[0] == "argvalue":
-                        keywords.append(ast.keyword(arg=inner_arg[1].id, value=inner_arg[2]))
-                    elif isinstance(inner_arg, tuple) and inner_arg[0] == "kwargs":
-                        keywords.append(ast.keyword(arg=None, value=inner_arg[1]))
-                        # valued kwarg
-                        if len(inner_arg[2]) > 0:
-                            for kw in inner_arg[2]:
-                                keywords.append(ast.keyword(arg=kw[1].id, value=kw[2]))
-            # valued argument
+        ordered_args = []
+
+        def append_argument(arg):
+            if isinstance(arg, tuple) and arg[0] == "stararg":
+                args.append(ast.Starred(arg[1], ctx=ast.Load()))
             elif isinstance(arg, tuple) and arg[0] == "argvalue":
-                # normal value
-                keywords.append(ast.keyword(arg=arg[1].id, value=arg[2]))
-            # keyword arguments
+                keywords.append(ast.keyword(arg=arg[1], value=arg[2]))
             elif isinstance(arg, tuple) and arg[0] == "kwargs":
                 keywords.append(ast.keyword(arg=None, value=arg[1]))
-                # valued kwarg
-                if len(arg[2]) > 0:
-                    for kw in arg[2]:
-                        keywords.append(ast.keyword(arg=kw[1].id, value=kw[2]))
-            # comprehension or single argument
             elif isinstance(arg, tuple) and len(arg) == 2 and isinstance(arg[1], list):
-                # Generator + comprehension
-                joined_str, comprehensions = arg
-                gen_expr = ast.GeneratorExp(
-                    elt=joined_str,
-                    generators=comprehensions
-                )
-                args.append(gen_expr)
+                args.append(ast.GeneratorExp(elt=arg[0], generators=arg[1]))
             else:
                 args.append(arg)
+
+        for arg in prelim_args:
+            if isinstance(arg, list):
+                ordered_args.extend(arg)
+            else:
+                ordered_args.append(arg)
+
+        seen_keyword = False
+        seen_kwargs = False
+        for arg in ordered_args:
+            if isinstance(arg, tuple) and arg[0] == "stararg":
+                if seen_kwargs:
+                    raise SyntaxError(
+                        "iterable argument unpacking follows keyword argument unpacking"
+                    )
+            elif isinstance(arg, tuple) and arg[0] == "argvalue":
+                seen_keyword = True
+            elif isinstance(arg, tuple) and arg[0] == "kwargs":
+                seen_kwargs = True
+            elif isinstance(arg, tuple) and len(arg) == 2 and isinstance(arg[1], list):
+                if seen_keyword or seen_kwargs:
+                    raise SyntaxError("positional argument follows keyword argument")
+            else:
+                if seen_keyword:
+                    raise SyntaxError("positional argument follows keyword argument")
+                if seen_kwargs:
+                    raise SyntaxError(
+                        "positional argument follows keyword argument unpacking"
+                    )
+            append_argument(arg)
 
         return ast.Call(
             func=function_name,
@@ -514,6 +665,9 @@ class PythonTransformer(Transformer):
     def key_value(self, nodes):
         key = nodes[0]
         value = nodes[1]
+        if (self._contains_unparenthesized_namedexpr(key) or
+                self._contains_unparenthesized_namedexpr(value)):
+            raise SyntaxError("invalid assignment expression")
         return key, value
 
     def dict(self, nodes):
@@ -648,11 +802,7 @@ class PythonTransformer(Transformer):
     def comprehension(self, nodes):
         # comprehension
         comp_result = nodes[0]
-        comp_fors = nodes[1]
-
-        # Attach all trailing comprehension filters to the last for-clause
-        for comp_if in nodes[2:]:
-            comp_fors[-1].ifs.append(comp_if)
+        comp_fors = nodes[1:]
         return comp_result, comp_fors
 
     def comp_for(self, nodes):
@@ -665,6 +815,7 @@ class PythonTransformer(Transformer):
 
         target = nodes[index]
         iterable = nodes[index + 1]
+        ifs = nodes[index + 2:]
 
         if isinstance(target, list):
             target = ast.Tuple(target)
@@ -673,7 +824,7 @@ class PythonTransformer(Transformer):
         return ast.comprehension(
             target=target,
             iter=iterable,
-            ifs=[],
+            ifs=ifs,
             is_async=int(async_flag)
         )
 
@@ -685,6 +836,9 @@ class PythonTransformer(Transformer):
             ops.append(self.CMP_OP_MAP[" ".join(nodes[i].split())]())
             comparators.append(nodes[i + 1])
         return ast.Compare(left=lhs, ops=ops, comparators=comparators)
+
+    not_in = lambda self, _: "not in"
+    is_not = lambda self, _: "is not"
 
     def or_test(self, nodes):
         return ast.BoolOp(op=ast.Or(), values=nodes)
@@ -702,10 +856,14 @@ class PythonTransformer(Transformer):
 
     def yield_expr(self, nodes):
         value = nodes[0] if len(nodes) > 0 else None
+        if self._contains_unparenthesized_namedexpr(value):
+            raise SyntaxError("invalid assignment expression")
         return ast.Yield(value=value)
 
     def yield_from(self, nodes):
         value = nodes[0] if len(nodes) > 0 else None
+        if self._contains_unparenthesized_namedexpr(value):
+            raise SyntaxError("invalid assignment expression")
         return ast.YieldFrom(value=value)
 
     def await_expr(self, nodes):
@@ -715,6 +873,12 @@ class PythonTransformer(Transformer):
         target = ast.Name(id=nodes[0], ctx=ast.Store())
         value = nodes[1]
         return ast.NamedExpr(target=target, value=value)
+
+    def grouped_test(self, nodes):
+        node = nodes[0]
+        if isinstance(node, ast.AST):
+            node._ord_parenthesized = True
+        return node
 
     def test(self, nodes):
         # x if y else z
@@ -759,8 +923,16 @@ class PythonTransformer(Transformer):
     def subscript_tuple(self, nodes):
         return ast.Tuple(elts=nodes, ctx=ast.Load())
 
+    def subscript_starred_tuple(self, nodes):
+        return ast.Tuple(elts=nodes, ctx=ast.Load())
+
     def tuple(selfs, nodes):
         return ast.Tuple(elts=nodes, ctx=ast.Load())
+
+    def parenthesized_tuple(self, nodes):
+        node = ast.Tuple(elts=nodes, ctx=ast.Load())
+        node._ord_parenthesized = True
+        return node
 
     def testlist_tuple(self, nodes):
         return ast.Tuple(elts=nodes, ctx=ast.Load())
@@ -883,53 +1055,10 @@ class PythonTransformer(Transformer):
         inner = segment[1:-1]
         eq_index = inner.rfind("=")
 
-        # CPython changed debug-fstring prefix extraction in 3.13:
-        # legacy versions truncate at top-level !/: before the final debug '=',
-        # while 3.13+ keeps the full expression text.
-        if sys.version_info < (3, 13):
-            marker_index = self._find_top_level_marker(inner)
-            if marker_index != -1 and marker_index < eq_index:
-                return inner[:marker_index]
-
         after_eq = eq_index + 1
         while after_eq < len(inner) and inner[after_eq] in " \t":
             after_eq += 1
         return inner[:after_eq]
-
-    @staticmethod
-    def _find_top_level_marker(text):
-        # Find the first top-level debug-fstring marker ('!' conversion or ':' format),
-        # skipping nested brackets and quoted strings.
-        depth = 0
-        quote = None
-        escaped = False
-
-        for i, char in enumerate(text):
-            if quote is not None:
-                if escaped:
-                    escaped = False
-                elif char == "\\":
-                    escaped = True
-                elif char == quote:
-                    quote = None
-                continue
-
-            if char in ("'", '"'):
-                quote = char
-                continue
-
-            if char in "([{":
-                depth += 1
-                continue
-
-            if char in ")]}" and depth > 0:
-                depth -= 1
-                continue
-
-            if depth == 0 and char in ("!", ":"):
-                return i
-
-        return -1
 
     def debug_eq(self, nodes):
         return "debug_eq", "="
@@ -1007,7 +1136,7 @@ class PythonTransformer(Transformer):
         while quote_start < len(token_value) and token_value[quote_start].isalpha():
             quote_start += 1
 
-        prefix = token_value[:quote_start].lower()
+        prefix = token_value[:quote_start]
         if token_value[quote_start:quote_start + 3] in ('"""', "'''"):
             quote_len = 3
         else:
@@ -1136,8 +1265,9 @@ class PythonTransformer(Transformer):
 
     def STRING(self, token):
         prefix, content = self._split_string_literal(token.value)
-        is_raw = "r" in prefix
-        is_bytes = "b" in prefix
+        prefix_lower = prefix.lower()
+        is_raw = "r" in prefix_lower
+        is_bytes = "b" in prefix_lower
 
         if is_bytes:
             if is_raw:
@@ -1147,11 +1277,17 @@ class PythonTransformer(Transformer):
             return ast.Constant(value=self._decode_bytes_escapes(content))
 
         value = content if is_raw else self._decode_string_escapes(content)
-        kind = "u" if "u" in prefix else None
+        kind = "u" if prefix == "u" else None
         return ast.Constant(value=value, kind=kind)
 
     def LONG_STRING(self, token):
         return self.STRING(token)
+
+    def F_LONG_STRING(self, token):
+        return ast.parse(token.value, mode="eval").body
+
+    def INVALID_STRING_PREFIX(self, token):
+        raise SyntaxError("invalid string prefix")
 
     def var(self, nodes):
         return ast.Name(id=nodes[0], ctx=ast.Load())
@@ -1173,19 +1309,7 @@ class PythonTransformer(Transformer):
     # -----------
 
     def decorator(self, nodes):
-        dotted_name = nodes[0]
-        func_name = ast.Name(id=dotted_name, ctx=ast.Load())
-
-        if len(nodes) > 1 and nodes[1]:
-            args = []
-            keywords = []
-            for value in nodes[1]:
-                if isinstance(value, ast.Constant):
-                    args.append(value)
-                elif isinstance(value, tuple) and value[0] == "argvalue":
-                    keywords.append(ast.keyword(arg=value[1].id, value=value[2]))
-            return ast.Call(func=func_name, args=args, keywords=keywords)
-        return func_name
+        return nodes[0]
 
     def decorated(self, nodes):
         decorators = nodes[0]
@@ -1196,22 +1320,19 @@ class PythonTransformer(Transformer):
 
     def funcdef(self, nodes):
         name = str(nodes[0])
-        if isinstance(nodes[1], ast.arguments):
-            parameters = nodes[1]
-            rest = nodes[2:]
+        index = 1
+        type_params = []
+        if index < len(nodes) and self._is_type_params(nodes[index]):
+            type_params = nodes[index][1]
+            index += 1
+        if index < len(nodes) and isinstance(nodes[index], ast.arguments):
+            parameters = nodes[index]
+            index += 1
         else:
-            parameters = ast.arguments(
-                posonlyargs=[],
-                args=[],
-                vararg=None,
-                kwonlyargs=[],
-                kw_defaults=[],
-                kwarg=None,
-                defaults=[]
-            )
-            rest = nodes[1:]
+            parameters = self._empty_arguments()
 
         # Extract return type and suite
+        rest = nodes[index:]
         if len(rest) == 2:
             return_type, suite = rest
         else:
@@ -1223,7 +1344,7 @@ class PythonTransformer(Transformer):
             args=parameters,
             body=suite,
             decorator_list=[],
-            type_params=[],
+            type_params=type_params,
             returns=return_type
         )
 
@@ -1233,31 +1354,54 @@ class PythonTransformer(Transformer):
         args = funcdef.args
         body = funcdef.body
         returns = funcdef.returns
+        type_params = funcdef.type_params
         return ast.AsyncFunctionDef(
             name=name,
             args=args,
             body=body,
             decorator_list=[],
-            type_params=[],
+            type_params=type_params,
             returns=returns
         )
 
     def classdef(self, nodes):
         name = nodes[0]
-
-        if len(nodes) == 3:
-            bases_node = nodes[1]
-            suite = nodes[2]
+        index = 1
+        type_params = []
+        if index < len(nodes) and self._is_type_params(nodes[index]):
+            type_params = nodes[index][1]
+            index += 1
+        if index < len(nodes) - 1:
+            bases_node = nodes[index]
+            suite = nodes[index + 1]
         else:
             bases_node = []
-            suite = nodes[1]
+            suite = nodes[index]
 
         bases = []
         keywords = []
+        seen_keyword = False
+        seen_kwargs = False
         for base in bases_node:
             if isinstance(base, tuple) and base[0] == "argvalue":
-                keywords.append(ast.keyword(arg=base[1].id, value=base[2]))
+                seen_keyword = True
+                keywords.append(ast.keyword(arg=base[1], value=base[2]))
+            elif isinstance(base, tuple) and base[0] == "stararg":
+                if seen_kwargs:
+                    raise SyntaxError(
+                        "iterable argument unpacking follows keyword argument unpacking"
+                    )
+                bases.append(ast.Starred(value=base[1], ctx=ast.Load()))
+            elif isinstance(base, tuple) and base[0] == "kwargs":
+                seen_kwargs = True
+                keywords.append(ast.keyword(arg=None, value=base[1]))
             else:
+                if seen_keyword:
+                    raise SyntaxError("positional argument follows keyword argument")
+                if seen_kwargs:
+                    raise SyntaxError(
+                        "positional argument follows keyword argument unpacking"
+                    )
                 bases.append(base)
 
         return ast.ClassDef(
@@ -1266,8 +1410,51 @@ class PythonTransformer(Transformer):
             keywords=keywords,
             body=suite,
             decorator_list=[],
-            type_params=[]
+            type_params=type_params
         )
+
+    @staticmethod
+    def _empty_arguments():
+        return ast.arguments(
+            posonlyargs=[],
+            args=[],
+            vararg=None,
+            kwonlyargs=[],
+            kw_defaults=[],
+            kwarg=None,
+            defaults=[]
+        )
+
+    @staticmethod
+    def _is_type_params(node):
+        return isinstance(node, tuple) and len(node) == 2 and node[0] == "type_params"
+
+    def type_params(self, nodes):
+        return "type_params", nodes
+
+    def typevar(self, nodes):
+        return ast.TypeVar(name=nodes[0], bound=None)
+
+    def bounded_typevar(self, nodes):
+        return ast.TypeVar(name=nodes[0], bound=nodes[1])
+
+    def typevartuple(self, nodes):
+        return ast.TypeVarTuple(name=nodes[0])
+
+    def paramspec(self, nodes):
+        return ast.ParamSpec(name=nodes[0])
+
+    def type_alias_stmt(self, nodes):
+        name = ast.Name(id=nodes[0], ctx=ast.Store())
+        if len(nodes) == 3:
+            type_params = nodes[1][1]
+            value = nodes[2]
+        else:
+            type_params = []
+            value = nodes[1]
+        if self._contains_unparenthesized_namedexpr(value):
+            raise SyntaxError("invalid assignment expression")
+        return ast.TypeAlias(name=name, type_params=type_params, value=value)
 
     decorators = lambda self, nodes: nodes
     arguments = lambda self, nodes: nodes
@@ -1343,6 +1530,12 @@ class PythonTransformer(Transformer):
             unpack_param(param, posonlyargs, defaults)
         for param in params_args:
             unpack_param(param, args, defaults)
+        if any(default is not None for default in defaults):
+            seen_default = False
+            for default in defaults:
+                if default is None and seen_default:
+                    raise SyntaxError("non-default argument follows default argument")
+                seen_default = seen_default or default is not None
 
         # process starparams if present
         if starparams:
@@ -1376,6 +1569,8 @@ class PythonTransformer(Transformer):
             # post is expected to be (paramvalues, kwparams)
             if post:
                 paramvalues, maybe_kwparam = post
+                if param_type == "starguard" and not paramvalues and maybe_kwparam is None:
+                    raise SyntaxError("named arguments must follow bare *")
                 for paramvalue in paramvalues:
                     unpack_param(paramvalue, kwonlyargs, kw_defaults)
                 if maybe_kwparam:
@@ -1430,6 +1625,8 @@ class PythonTransformer(Transformer):
     def paramvalue(self, nodes):
         typedparam = nodes[0]
         default = nodes[1] if len(nodes) > 1 else None
+        if self._contains_unparenthesized_namedexpr(default):
+            raise SyntaxError("invalid assignment expression")
         return "arg_with_default", typedparam, default
 
     def typedparam(self, nodes):
@@ -1438,19 +1635,24 @@ class PythonTransformer(Transformer):
         annotation = nodes[1] if len(nodes) > 1 else None
         return ast.arg(arg=name, annotation=annotation)
 
+    def typed_starparam(self, nodes):
+        return self.typedparam(nodes)
+
     def argvalue(self, nodes):
-        arg_node = nodes[0]
-        default = nodes[1] if len(nodes) == 2 else None
-        return "argvalue", arg_node, default
+        if self._contains_unparenthesized_namedexpr(nodes[1]):
+            raise SyntaxError("invalid assignment expression")
+        return "argvalue", nodes[0], nodes[1]
 
     def stararg(self, nodes):
         argument = nodes[0]
+        if self._contains_unparenthesized_namedexpr(argument):
+            raise SyntaxError("invalid assignment expression")
         return "stararg", argument
 
     def kwargs(self, nodes):
-        test = nodes[0]
-        argvalues = nodes[1:] if len(nodes) > 1 else []
-        return "kwargs", test, argvalues
+        if self._contains_unparenthesized_namedexpr(nodes[0]):
+            raise SyntaxError("invalid assignment expression")
+        return "kwargs", nodes[0]
 
     def starargs(self, nodes):
         return nodes
@@ -1458,6 +1660,8 @@ class PythonTransformer(Transformer):
     def lambda_paramvalue(self, nodes):
         name_node = nodes[0]
         default_node = nodes[1] if len(nodes) > 1 else None
+        if self._contains_unparenthesized_namedexpr(default_node):
+            raise SyntaxError("invalid assignment expression")
         arg_node = ast.arg(arg=name_node,
                            annotation=None)
         return arg_node, default_node
@@ -1482,6 +1686,9 @@ class PythonTransformer(Transformer):
             elif isinstance(node, dict) and "kwarg" in node:
                 kwarg = node["kwarg"]
             index += 1
+
+        if vararg is None and not kwonlyargs and kwarg is None:
+            raise SyntaxError("named arguments must follow bare *")
 
         return ast.arguments(
             posonlyargs=[], args=[],
@@ -1550,6 +1757,12 @@ class PythonTransformer(Transformer):
             unpack_param(param, posonlyargs)
         for param in params_args:
             unpack_param(param, args)
+        if any(default is not None for default in defaults):
+            seen_default = False
+            for default in defaults:
+                if default is None and seen_default:
+                    raise SyntaxError("non-default argument follows default argument")
+                seen_default = seen_default or default is not None
 
         while defaults and defaults[0] is None:
             defaults.pop(0)
@@ -1577,9 +1790,9 @@ class PythonTransformer(Transformer):
             )
             body = nodes[0]
 
+        if self._is_unparenthesized_namedexpr(body):
+            raise SyntaxError("invalid assignment expression")
         return ast.Lambda(args=params, body=body)
-
-    starargs_part = lambda self, nodes: nodes
 
     # Match Case
     # ----------
@@ -1616,6 +1829,9 @@ class PythonTransformer(Transformer):
             node = ast.Attribute(value=node, attr=attr, ctx=ast.Load())
         return node
 
+    def attr_pattern(self, nodes):
+        return ast.MatchValue(self.value(nodes))
+
     def keyw_arg_pattern(self, nodes):
         key = nodes[0]
         pattern = nodes[1]
@@ -1624,13 +1840,16 @@ class PythonTransformer(Transformer):
     def as_pattern(self, nodes):
         pattern = nodes[0]
         name = nodes[1]
+        if name == "_":
+            raise SyntaxError("cannot use '_' as a target")
         return ast.MatchAs(pattern=pattern, name=name)
 
     def or_pattern(self, nodes):
         return ast.MatchOr(patterns=nodes)
 
     def star_pattern(self, nodes):
-        return ast.MatchStar(name=nodes[0])
+        name = None if nodes[0] == "_" else nodes[0]
+        return ast.MatchStar(name=name)
 
     def sequence_pattern(self, nodes):
         # nodes = list of sequence_item_pattern
@@ -1660,17 +1879,23 @@ class PythonTransformer(Transformer):
         keys = [self._mapping_key_to_expr(k) for k, v in nodes[:-1]]
         patterns = [v for k, v in nodes[:-1]]
         rest_name = nodes[-1][1] if isinstance(nodes[-1], tuple) else nodes[-1]
+        if rest_name == "_":
+            raise SyntaxError("invalid mapping pattern rest name '_'")
         return ast.MatchMapping(keys=keys, patterns=patterns, rest=rest_name)
 
     def arguments_pattern(self, nodes):
         pos_args = []
         kw_names = []
         kw_values = []
+        seen_keyword = False
         for argument in nodes:
             if isinstance(argument, tuple):
+                seen_keyword = True
                 kw_names.append(argument[0])
                 kw_values.append(argument[1])
             else:
+                if seen_keyword:
+                    raise SyntaxError("positional patterns follow keyword patterns")
                 pos_args.append(argument)
         return pos_args, (kw_names, kw_values)
 
@@ -1678,11 +1903,13 @@ class PythonTransformer(Transformer):
     def class_pattern(self, nodes):
         # dotted_name (value)
         class_name = nodes[0]
-        pos_args, keywords = ([], [])
+        pos_args = []
+        keys = []
+        patterns = []
         # optional arguments
         if len(nodes) > 1 and nodes[1]:
             pos_args, keywords = nodes[1]
-        keys, patterns = keywords
+            keys, patterns = keywords
         return ast.MatchClass(cls=class_name,
                               patterns=pos_args,
                               kwd_attrs=keys,
@@ -1711,6 +1938,15 @@ class PythonTransformer(Transformer):
             return ast.MatchValue(self.convert_string(const))
         # Other values
         return ast.MatchValue(const)
+
+    def negative_number(self, nodes):
+        return ast.UnaryOp(op=ast.USub(), operand=nodes[0])
+
+    def complex_number_pattern(self, nodes):
+        left = nodes[0]
+        op = self.ADD_OP_MAP[nodes[1]]()
+        right = nodes[2]
+        return ast.BinOp(left=left, op=op, right=right)
 
     lambdef_nocond = lambda self, nodes: nodes
     encoding_decl = lambda self, nodes: nodes[0]

--- a/ordec/ord/python_transformer.py
+++ b/ordec/ord/python_transformer.py
@@ -1310,7 +1310,7 @@ class PythonTransformer(Transformer):
 
     number = lambda self, nodes: nodes[0]
     star_expr = lambda self, nodes: ast.Starred(value=nodes[0], ctx=ast.Load())
-    name = lambda self, nodes: nodes[0]
+    name = lambda self, nodes: str(nodes[0])
     comp_op = lambda self, nodes: nodes[0]
     ellipsis = lambda self, _: ast.Constant(value=Ellipsis)
     f_string_content_single = lambda self, nodes: nodes[0]

--- a/ordec/ord/python_transformer.py
+++ b/ordec/ord/python_transformer.py
@@ -197,10 +197,6 @@ class PythonTransformer(Transformer):
     # Terminals
     # ---------
 
-    def DEC_NUMBER(self, nodes):
-        value = nodes.value.replace("_", "")
-        return ast.Constant(value=int(value, 10))
-
     def HEX_NUMBER(self, nodes):
         value = nodes.value.replace("_", "")
         return ast.Constant(value=int(value, 16))
@@ -214,8 +210,6 @@ class PythonTransformer(Transformer):
         return ast.Constant(value=int(value, 2))
 
     IMAG_NUMBER = lambda self, token: ast.Constant(value=complex(token.value))
-    FLOAT_NUMBER = lambda self, token: ast.Constant(value=float(token.value))
-    DECIMAL = lambda self, token: ast.Constant(value=int(token.value, 10))
     NAME = lambda self, token: token.value
     ASYNC = lambda self, token: token.value
     AWAIT = lambda self, token: token.value
@@ -560,12 +554,6 @@ class PythonTransformer(Transformer):
             optional_vars=name
         )
 
-    def with_paren_item(self, nodes):
-        return self.with_item(nodes)
-
-    def with_paren_as_item(self, nodes):
-        return self.with_item(nodes)
-
     def with_paren_single_item(self, nodes):
         return [ast.withitem(context_expr=nodes[0], optional_vars=None)]
 
@@ -906,9 +894,6 @@ class PythonTransformer(Transformer):
     def subscript_tuple(self, nodes):
         return ast.Tuple(elts=nodes, ctx=ast.Load())
 
-    def subscript_starred_tuple(self, nodes):
-        return ast.Tuple(elts=nodes, ctx=ast.Load())
-
     def tuple(self, nodes):
         return ast.Tuple(elts=nodes, ctx=ast.Load())
 
@@ -1090,12 +1075,6 @@ class PythonTransformer(Transformer):
 
     def conversion(self, token):
         return token[0]
-
-    def format_spec_single(self, nodes):
-        return self.format_spec(nodes)
-
-    def format_spec_double(self, nodes):
-        return self.format_spec(nodes)
 
     def format_spec_eq(self, nodes):
         return self.format_spec(["=", *nodes])
@@ -1671,9 +1650,6 @@ class PythonTransformer(Transformer):
         annotation = nodes[1] if len(nodes) > 1 else None
         return ast.arg(arg=name, annotation=annotation)
 
-    def typed_starparam(self, nodes):
-        return self.typedparam(nodes)
-
     def argvalue(self, nodes):
         if self._contains_unparenthesized_namedexpr(nodes[1]):
             raise SyntaxError("invalid assignment expression")
@@ -1932,7 +1908,6 @@ class PythonTransformer(Transformer):
                 pos_args.append(argument)
         return pos_args, (kw_names, kw_values)
 
-
     def class_pattern(self, nodes):
         # dotted_name (value)
         class_name = nodes[0]
@@ -1948,27 +1923,12 @@ class PythonTransformer(Transformer):
                               kwd_attrs=keys,
                               kwd_patterns=patterns)
 
-    @staticmethod
-    def convert_string(current_string):
-        prefix, string = current_string
-        if len(prefix) == 0:
-            return ast.Constant(value=string)
-        elif 'b' in prefix:
-            return ast.Constant(value=string.encode('utf-8'))
-        elif 'u' == prefix:
-            return ast.Constant(value=string, kind=prefix)
-        else:
-            return ast.Constant(value=string)
-
     def literal_pattern(self, nodes):
         const = nodes[0]
         # Constants
         if (isinstance(const, ast.Constant) and
                 (type(const.value) is bool or const.value is None)):
             return ast.MatchSingleton(value=const.value)
-        # Strings
-        elif isinstance(const, tuple):
-            return ast.MatchValue(self.convert_string(const))
         # Other values
         return ast.MatchValue(const)
 
@@ -1982,7 +1942,6 @@ class PythonTransformer(Transformer):
         return ast.BinOp(left=left, op=op, right=right)
 
     lambdef_nocond = lambda self, nodes: nodes
-    encoding_decl = lambda self, nodes: nodes[0]
     const_none = lambda self, _: ast.Constant(value=None)
     const_true = lambda self, _: ast.Constant(value=True)
     const_false = lambda self, _: ast.Constant(value=False)

--- a/ordec/ord/python_transformer.py
+++ b/ordec/ord/python_transformer.py
@@ -8,24 +8,17 @@ import unicodedata
 
 class PythonTransformer(Transformer):
     """
-    Transformer that transforms any Python code back into a Python AST.
-    This Class represents the base of the ORD language
+    Transform parsed Python syntax into a Python AST.
+
+    This generic Python transformer provides the Python-language foundation for
+    ORD. It builds standard ``ast`` nodes, uses Python 3.13 syntax and AST
+    behavior as its primary reference, and raises ``SyntaxError`` for parsed
+    forms that are not valid Python syntax.
     """
 
-    def _call_userfunc(self, tree, new_children=None):
-        result = super()._call_userfunc(tree, new_children)
-        if isinstance(result, ast.AST) and hasattr(tree, 'meta'):
-            meta = tree.meta
-            if meta.line is not None:
-                result.lineno = meta.line
-                result.col_offset = (meta.column or 1) - 1
-            if meta.end_line is not None:
-                result.end_lineno = meta.end_line
-                result.end_col_offset = (meta.end_column or 1) - 1
-        return result
-
+    # -------------------------------------------------------------------------
     # Variables
-    # ---------
+    # -------------------------------------------------------------------------
 
     AUG_OP_MAP = {
         "+=": ast.Add,
@@ -113,8 +106,21 @@ class PythonTransformer(Transformer):
         super().__init__()
         self.source_text = source_text
 
+    # -------------------------------------------------------------------------
     # Helpers
-    # -------
+    # -------------------------------------------------------------------------
+
+    def _call_userfunc(self, tree, new_children=None):
+        result = super()._call_userfunc(tree, new_children)
+        if isinstance(result, ast.AST) and hasattr(tree, 'meta'):
+            meta = tree.meta
+            if meta.line is not None:
+                result.lineno = meta.line
+                result.col_offset = (meta.column or 1) - 1
+            if meta.end_line is not None:
+                result.end_lineno = meta.end_line
+                result.end_col_offset = (meta.end_column or 1) - 1
+        return result
 
     def _flatten_body(self, body):
         # flatten ast statements
@@ -194,8 +200,227 @@ class PythonTransformer(Transformer):
             )
         return False
 
+    @staticmethod
+    def merge_adjacent_strings(items):
+        merged_buffer = []
+        temp_value = None
+        temp_kind = None
+
+        for item in items:
+            if isinstance(item, str):
+                item = ast.Constant(value=item)
+
+            if isinstance(item, ast.Constant) and isinstance(item.value, (str, bytes)):
+                if temp_value is None:
+                    temp_value = item.value
+                    temp_kind = item.kind
+                # Merge items of the same type directly
+                elif isinstance(item.value, type(temp_value)):
+                    temp_value += item.value
+                    if temp_kind is None:
+                        temp_kind = item.kind
+                # Append if the type differs
+                else:
+                    merged_buffer.append(ast.Constant(value=temp_value, kind=temp_kind))
+                    temp_value = item.value
+                    temp_kind = item.kind
+                continue
+            # Append if not string or bytes
+            if temp_value is not None:
+                merged_buffer.append(ast.Constant(value=temp_value, kind=temp_kind))
+                temp_value = None
+                temp_kind = None
+
+            merged_buffer.append(item)
+
+        if temp_value is not None:
+            merged_buffer.append(ast.Constant(value=temp_value, kind=temp_kind))
+        return merged_buffer
+
+    def _debug_prefix_from_source(self, meta):
+        # Parser additions:
+        # - propagate_positions=True provides start_pos/end_pos on f_expression nodes.
+        # - source_text contains the parsed source.
+        segment = self.source_text[meta.start_pos:meta.end_pos]
+        inner = segment[1:-1]
+        eq_index = inner.rfind("=")
+
+        after_eq = eq_index + 1
+        while after_eq < len(inner) and inner[after_eq] in " \t":
+            after_eq += 1
+        return inner[:after_eq]
+
+    def _normalize_joined_str(self, node, decode_literals):
+        """
+        Merge adjacent literal Constant(str) pieces into one piece
+        and recursively normalize joined strings
+        """
+        normalized_values = []
+        literal_buffer = []
+
+        def flush_literal_buffer():
+            if literal_buffer:
+                literal = "".join(literal_buffer)
+                if literal:
+                    normalized_values.append(ast.Constant(value=literal))
+                literal_buffer.clear()
+
+        for value in node.values:
+            if isinstance(value, ast.Constant) and isinstance(value.value, str):
+                literal = value.value
+                if decode_literals:
+                    literal = self._decode_string_escapes(literal)
+                literal_buffer.append(literal)
+                continue
+
+            flush_literal_buffer()
+            if isinstance(value, ast.FormattedValue) and isinstance(value.format_spec, ast.JoinedStr):
+                value.format_spec = self._normalize_joined_str(
+                    value.format_spec,
+                    decode_literals=decode_literals
+                )
+            normalized_values.append(value)
+
+        flush_literal_buffer()
+        return ast.JoinedStr(values=normalized_values)
+
+    @staticmethod
+    def _split_string_literal(token_value):
+        """Extract string literal"""
+        quote_start = 0
+        while quote_start < len(token_value) and token_value[quote_start].isalpha():
+            quote_start += 1
+
+        prefix = token_value[:quote_start]
+        if token_value[quote_start:quote_start + 3] in ('"""', "'''"):
+            quote_len = 3
+        else:
+            quote_len = 1
+
+        content = token_value[quote_start + quote_len:-quote_len]
+        return prefix, content
+
+    @staticmethod
+    def _is_hex_digits(value):
+        return all(ch in "0123456789abcdefABCDEF" for ch in value)
+
+    def _decode_string_escapes(self, value):
+        # Decode Python literal escape sequences so transformed AST constants match Python.
+        decoded = []
+        i = 0
+        while i < len(value):
+            char = value[i]
+            if char != "\\":
+                decoded.append(char)
+                i += 1
+                continue
+
+            if i + 1 >= len(value):
+                decoded.append("\\")
+                i += 1
+                continue
+
+            esc = value[i + 1]
+            if esc == "\n":
+                i += 2
+                continue
+            if esc in self.STRING_ESCAPE_MAP:
+                decoded.append(self.STRING_ESCAPE_MAP[esc])
+                i += 2
+                continue
+            if esc in "01234567":
+                j = i + 1
+                while j < len(value) and j < i + 4 and value[j] in "01234567":
+                    j += 1
+                decoded.append(chr(int(value[i + 1:j], 8)))
+                i = j
+                continue
+            if esc == "x":
+                hex_digits = value[i + 2:i + 4]
+                if len(hex_digits) != 2 or not self._is_hex_digits(hex_digits):
+                    raise SyntaxError("invalid \\x escape sequence")
+                decoded.append(chr(int(hex_digits, 16)))
+                i += 4
+                continue
+            if esc == "u":
+                hex_digits = value[i + 2:i + 6]
+                if len(hex_digits) != 4 or not self._is_hex_digits(hex_digits):
+                    raise SyntaxError("invalid \\u escape sequence")
+                decoded.append(chr(int(hex_digits, 16)))
+                i += 6
+                continue
+            if esc == "U":
+                hex_digits = value[i + 2:i + 10]
+                if len(hex_digits) != 8 or not self._is_hex_digits(hex_digits):
+                    raise SyntaxError("invalid \\U escape sequence")
+                decoded.append(chr(int(hex_digits, 16)))
+                i += 10
+                continue
+            if esc == "N" and i + 2 < len(value) and value[i + 2] == "{":
+                closing_brace = value.find("}", i + 3)
+                if closing_brace == -1:
+                    raise SyntaxError("malformed \\N escape sequence")
+                unicode_name = value[i + 3:closing_brace]
+                try:
+                    decoded.append(unicodedata.lookup(unicode_name))
+                except KeyError as exc:
+                    raise SyntaxError("unknown Unicode character name") from exc
+                i = closing_brace + 1
+                continue
+
+            decoded.append("\\")
+            decoded.append(esc)
+            i += 2
+        return "".join(decoded)
+
+    def _decode_bytes_escapes(self, value):
+        decoded = bytearray()
+        i = 0
+        while i < len(value):
+            char = value[i]
+            if char != "\\":
+                if ord(char) > 0x7F:
+                    raise SyntaxError("bytes literals may only contain ASCII characters")
+                decoded.append(ord(char))
+                i += 1
+                continue
+
+            if i + 1 >= len(value):
+                decoded.append(ord("\\"))
+                i += 1
+                continue
+
+            esc = value[i + 1]
+            if esc == "\n":
+                i += 2
+                continue
+            if esc in self.BYTES_ESCAPE_MAP:
+                decoded.append(self.BYTES_ESCAPE_MAP[esc])
+                i += 2
+                continue
+            if esc in "01234567":
+                j = i + 1
+                while j < len(value) and j < i + 4 and value[j] in "01234567":
+                    j += 1
+                decoded.append(int(value[i + 1:j], 8) & 0xFF)
+                i = j
+                continue
+            if esc == "x":
+                hex_digits = value[i + 2:i + 4]
+                if len(hex_digits) != 2 or not self._is_hex_digits(hex_digits):
+                    raise SyntaxError("invalid \\x escape sequence")
+                decoded.append(int(hex_digits, 16))
+                i += 4
+                continue
+
+            decoded.append(ord("\\"))
+            decoded.append(ord(esc))
+            i += 2
+        return bytes(decoded)
+
+    # -------------------------------------------------------------------------
     # Terminals
-    # ---------
+    # -------------------------------------------------------------------------
 
     def HEX_NUMBER(self, nodes):
         value = nodes.value.replace("_", "")
@@ -221,8 +446,10 @@ class PythonTransformer(Transformer):
     FSTRING_SINGLE_END = lambda self, token: token.value
     FSTRING_DOUBLE_END = lambda self, token: token.value
     SLASH = lambda self, token: token.value
+
+    # -------------------------------------------------------------------------
     # Statements
-    # ----------
+    # -------------------------------------------------------------------------
 
     def expr_stmt(self, nodes):
         if self._contains_unparenthesized_namedexpr(nodes[0]):
@@ -393,8 +620,9 @@ class PythonTransformer(Transformer):
     import_stmt = lambda self, nodes: nodes[0]
     yield_stmt = lambda self, nodes: ast.Expr(value=nodes[0])
 
+    # -------------------------------------------------------------------------
     # Compound Statements
-    # -------------------
+    # -------------------------------------------------------------------------
 
     def if_stmt(self, nodes):
         condition = nodes[0]
@@ -574,8 +802,9 @@ class PythonTransformer(Transformer):
     except_clauses = lambda self, nodes: nodes
     with_items = lambda self, nodes: nodes
 
+    # -------------------------------------------------------------------------
     # Expressions
-    # -----------
+    # -------------------------------------------------------------------------
 
     def funccall(self, nodes):
         # Converts argvalue/stararg/kwargs into arguments
@@ -905,43 +1134,6 @@ class PythonTransformer(Transformer):
     def testlist_tuple(self, nodes):
         return ast.Tuple(elts=nodes, ctx=ast.Load())
 
-    @staticmethod
-    def merge_adjacent_strings(items):
-        merged_buffer = []
-        temp_value = None
-        temp_kind = None
-
-        for item in items:
-            if isinstance(item, str):
-                item = ast.Constant(value=item)
-
-            if isinstance(item, ast.Constant) and isinstance(item.value, (str, bytes)):
-                if temp_value is None:
-                    temp_value = item.value
-                    temp_kind = item.kind
-                # Merge items of the same type directly
-                elif isinstance(item.value, type(temp_value)):
-                    temp_value += item.value
-                    if temp_kind is None:
-                        temp_kind = item.kind
-                # Append if the type differs
-                else:
-                    merged_buffer.append(ast.Constant(value=temp_value, kind=temp_kind))
-                    temp_value = item.value
-                    temp_kind = item.kind
-                continue
-            # Append if not string or bytes
-            if temp_value is not None:
-                merged_buffer.append(ast.Constant(value=temp_value, kind=temp_kind))
-                temp_value = None
-                temp_kind = None
-
-            merged_buffer.append(item)
-
-        if temp_value is not None:
-            merged_buffer.append(ast.Constant(value=temp_value, kind=temp_kind))
-        return merged_buffer
-
     def string_concat(self, nodes):
         merged_string = self.merge_adjacent_strings(nodes)
         # Return if only one value
@@ -1057,19 +1249,6 @@ class PythonTransformer(Transformer):
             return "debug_fexpr", self._debug_prefix_from_source(meta), formatted_value
         return formatted_value
 
-    def _debug_prefix_from_source(self, meta):
-        # Parser additions:
-        # - propagate_positions=True provides start_pos/end_pos on f_expression nodes.
-        # - source_text contains the parsed source.
-        segment = self.source_text[meta.start_pos:meta.end_pos]
-        inner = segment[1:-1]
-        eq_index = inner.rfind("=")
-
-        after_eq = eq_index + 1
-        while after_eq < len(inner) and inner[after_eq] in " \t":
-            after_eq += 1
-        return inner[:after_eq]
-
     def debug_eq(self, nodes):
         return "debug_eq", "="
 
@@ -1091,40 +1270,6 @@ class PythonTransformer(Transformer):
                 values.append(self.f_expression([node]))
         return ast.JoinedStr(values=values)
 
-    def _normalize_joined_str(self, node, decode_literals):
-        """
-        Merge adjacent literal Constant(str) pieces into one piece
-        and recursively normalize joined strings
-        """
-        normalized_values = []
-        literal_buffer = []
-
-        def flush_literal_buffer():
-            if literal_buffer:
-                literal = "".join(literal_buffer)
-                if literal:
-                    normalized_values.append(ast.Constant(value=literal))
-                literal_buffer.clear()
-
-        for value in node.values:
-            if isinstance(value, ast.Constant) and isinstance(value.value, str):
-                literal = value.value
-                if decode_literals:
-                    literal = self._decode_string_escapes(literal)
-                literal_buffer.append(literal)
-                continue
-
-            flush_literal_buffer()
-            if isinstance(value, ast.FormattedValue) and isinstance(value.format_spec, ast.JoinedStr):
-                value.format_spec = self._normalize_joined_str(
-                    value.format_spec,
-                    decode_literals=decode_literals
-                )
-            normalized_values.append(value)
-
-        flush_literal_buffer()
-        return ast.JoinedStr(values=normalized_values)
-
     def string(self, nodes):
         current_string = nodes[0]
         if isinstance(current_string, (ast.JoinedStr, ast.Constant)):
@@ -1139,140 +1284,6 @@ class PythonTransformer(Transformer):
             return ast.Constant(value=string, kind=prefix)
         else:
             return ast.Constant(value=string)
-
-    @staticmethod
-    def _split_string_literal(token_value):
-        """Extract string literal"""
-        quote_start = 0
-        while quote_start < len(token_value) and token_value[quote_start].isalpha():
-            quote_start += 1
-
-        prefix = token_value[:quote_start]
-        if token_value[quote_start:quote_start + 3] in ('"""', "'''"):
-            quote_len = 3
-        else:
-            quote_len = 1
-
-        content = token_value[quote_start + quote_len:-quote_len]
-        return prefix, content
-
-    @staticmethod
-    def _is_hex_digits(value):
-        return all(ch in "0123456789abcdefABCDEF" for ch in value)
-
-    def _decode_string_escapes(self, value):
-        # Decode Python literal escape sequences so transformed AST constants match Python.
-        decoded = []
-        i = 0
-        while i < len(value):
-            char = value[i]
-            if char != "\\":
-                decoded.append(char)
-                i += 1
-                continue
-
-            if i + 1 >= len(value):
-                decoded.append("\\")
-                i += 1
-                continue
-
-            esc = value[i + 1]
-            if esc == "\n":
-                i += 2
-                continue
-            if esc in self.STRING_ESCAPE_MAP:
-                decoded.append(self.STRING_ESCAPE_MAP[esc])
-                i += 2
-                continue
-            if esc in "01234567":
-                j = i + 1
-                while j < len(value) and j < i + 4 and value[j] in "01234567":
-                    j += 1
-                decoded.append(chr(int(value[i + 1:j], 8)))
-                i = j
-                continue
-            if esc == "x":
-                hex_digits = value[i + 2:i + 4]
-                if len(hex_digits) != 2 or not self._is_hex_digits(hex_digits):
-                    raise SyntaxError("invalid \\x escape sequence")
-                decoded.append(chr(int(hex_digits, 16)))
-                i += 4
-                continue
-            if esc == "u":
-                hex_digits = value[i + 2:i + 6]
-                if len(hex_digits) != 4 or not self._is_hex_digits(hex_digits):
-                    raise SyntaxError("invalid \\u escape sequence")
-                decoded.append(chr(int(hex_digits, 16)))
-                i += 6
-                continue
-            if esc == "U":
-                hex_digits = value[i + 2:i + 10]
-                if len(hex_digits) != 8 or not self._is_hex_digits(hex_digits):
-                    raise SyntaxError("invalid \\U escape sequence")
-                decoded.append(chr(int(hex_digits, 16)))
-                i += 10
-                continue
-            if esc == "N" and i + 2 < len(value) and value[i + 2] == "{":
-                closing_brace = value.find("}", i + 3)
-                if closing_brace == -1:
-                    raise SyntaxError("malformed \\N escape sequence")
-                unicode_name = value[i + 3:closing_brace]
-                try:
-                    decoded.append(unicodedata.lookup(unicode_name))
-                except KeyError as exc:
-                    raise SyntaxError("unknown Unicode character name") from exc
-                i = closing_brace + 1
-                continue
-
-            decoded.append("\\")
-            decoded.append(esc)
-            i += 2
-        return "".join(decoded)
-
-    def _decode_bytes_escapes(self, value):
-        decoded = bytearray()
-        i = 0
-        while i < len(value):
-            char = value[i]
-            if char != "\\":
-                if ord(char) > 0x7F:
-                    raise SyntaxError("bytes literals may only contain ASCII characters")
-                decoded.append(ord(char))
-                i += 1
-                continue
-
-            if i + 1 >= len(value):
-                decoded.append(ord("\\"))
-                i += 1
-                continue
-
-            esc = value[i + 1]
-            if esc == "\n":
-                i += 2
-                continue
-            if esc in self.BYTES_ESCAPE_MAP:
-                decoded.append(self.BYTES_ESCAPE_MAP[esc])
-                i += 2
-                continue
-            if esc in "01234567":
-                j = i + 1
-                while j < len(value) and j < i + 4 and value[j] in "01234567":
-                    j += 1
-                decoded.append(int(value[i + 1:j], 8) & 0xFF)
-                i = j
-                continue
-            if esc == "x":
-                hex_digits = value[i + 2:i + 4]
-                if len(hex_digits) != 2 or not self._is_hex_digits(hex_digits):
-                    raise SyntaxError("invalid \\x escape sequence")
-                decoded.append(int(hex_digits, 16))
-                i += 4
-                continue
-
-            decoded.append(ord("\\"))
-            decoded.append(ord(esc))
-            i += 2
-        return bytes(decoded)
 
     def STRING(self, token):
         prefix, content = self._split_string_literal(token.value)
@@ -1315,8 +1326,9 @@ class PythonTransformer(Transformer):
     named_unicode_escape = lambda self, nodes: ("named_unicode_escape", str(nodes[0])[3:-1])
     exprlist = lambda self, nodes: nodes
 
+    # -------------------------------------------------------------------------
     # Definitions
-    # -----------
+    # -------------------------------------------------------------------------
 
     def decorator(self, nodes):
         return nodes[0]
@@ -1474,8 +1486,9 @@ class PythonTransformer(Transformer):
     decorators = lambda self, nodes: nodes
     arguments = lambda self, nodes: nodes
 
+    # -------------------------------------------------------------------------
     # Parameters / Arguments
-    # ----------------------
+    # -------------------------------------------------------------------------
 
     def parameters(self, nodes):
         """
@@ -1803,8 +1816,9 @@ class PythonTransformer(Transformer):
             raise SyntaxError("invalid assignment expression")
         return ast.Lambda(args=params, body=body)
 
+    # -------------------------------------------------------------------------
     # Match Case
-    # ----------
+    # -------------------------------------------------------------------------
 
     def case(self, nodes):
         pattern = nodes[0]
@@ -1947,8 +1961,9 @@ class PythonTransformer(Transformer):
     const_false = lambda self, _: ast.Constant(value=False)
     argument = lambda self, nodes: nodes[0]
 
+    # -------------------------------------------------------------------------
     # Top-Level
-    # ---------
+    # -------------------------------------------------------------------------
 
     single_input = lambda self, nodes: nodes[0]
     file_input = lambda self, nodes: ast.Module(body=self._flatten_body(nodes), type_ignores=[])

--- a/ordec/ord/python_transformer.py
+++ b/ordec/ord/python_transformer.py
@@ -884,6 +884,9 @@ class PythonTransformer(Transformer):
         orelse = nodes[2]
         return ast.IfExp(test=test_cond, body=body, orelse=orelse)
 
+    def f_test(self, nodes):
+        return self.test(nodes)
+
     def sliceop(self, nodes):
         step = nodes[0] if nodes else None
         return ":", step
@@ -1013,6 +1016,25 @@ class PythonTransformer(Transformer):
             if pending_close_brace:
                 raise SyntaxError("f-string: single '}' is not allowed")
 
+            if (
+                    isinstance(item, tuple) and len(item) == 2 and
+                    item[0] == "named_unicode_escape"):
+                if is_raw:
+                    if not item[1].isidentifier():
+                        raise SyntaxError("invalid syntax")
+                    values_raw.append("\\N")
+                    values_raw.append(ast.FormattedValue(
+                        value=ast.Name(id=item[1], ctx=ast.Load()),
+                        conversion=-1,
+                        format_spec=None
+                    ))
+                else:
+                    try:
+                        values_raw.append(unicodedata.lookup(item[1]))
+                    except KeyError as exc:
+                        raise SyntaxError("unknown Unicode character name") from exc
+                continue
+
             if isinstance(item, tuple) and len(item) == 3 and item[0] == "debug_fexpr":
                 values_raw.append(ast.Constant(value=item[1]))
                 values_raw.append(item[2])
@@ -1086,6 +1108,9 @@ class PythonTransformer(Transformer):
     def format_spec_double(self, nodes):
         return self.format_spec(nodes)
 
+    def format_spec_eq(self, nodes):
+        return self.format_spec(["=", *nodes])
+
     def format_spec(self, nodes):
         values = []
         for node in nodes:
@@ -1108,7 +1133,9 @@ class PythonTransformer(Transformer):
 
         def flush_literal_buffer():
             if literal_buffer:
-                normalized_values.append(ast.Constant(value="".join(literal_buffer)))
+                literal = "".join(literal_buffer)
+                if literal:
+                    normalized_values.append(ast.Constant(value=literal))
                 literal_buffer.clear()
 
         for value in node.values:
@@ -1319,6 +1346,7 @@ class PythonTransformer(Transformer):
     f_string_escaped_content_single = lambda self, nodes: nodes[0]
     literal_open_brace = lambda self, _: '{'
     literal_close_brace = lambda self, _: self.FSTRING_LITERAL_CLOSE_BRACE
+    named_unicode_escape = lambda self, nodes: ("named_unicode_escape", str(nodes[0])[3:-1])
     exprlist = lambda self, nodes: nodes
 
     # Definitions

--- a/ordec/ord/python_transformer.py
+++ b/ordec/ord/python_transformer.py
@@ -177,11 +177,6 @@ class PythonTransformer(Transformer):
                 raise SyntaxError("invalid deletion target")
 
     @staticmethod
-    def _is_single_target(node):
-        # Augmented and annotated assignments use Python's single-target shape.
-        return isinstance(node, (ast.Name, ast.Attribute, ast.Subscript))
-
-    @staticmethod
     def _contains_unparenthesized_namedexpr(node):
         # The grammar accepts `test` in several places where Python only allows
         # a named expression when it is parenthesized or nested in a container.
@@ -232,11 +227,6 @@ class PythonTransformer(Transformer):
     FSTRING_SINGLE_END = lambda self, token: token.value
     FSTRING_DOUBLE_END = lambda self, token: token.value
     SLASH = lambda self, token: token.value
-    STRING_OTHER_PREFIX = lambda self, token: token.value
-    MATCH = lambda self, token: token.value
-    CASE = lambda self, token: token.value
-    ANONYMOUS = lambda self, token: token.value
-
     # Statements
     # ----------
 
@@ -262,11 +252,7 @@ class PythonTransformer(Transformer):
                                 orelse=for_stmt.orelse)
 
     def simple_stmt(self, nodes):
-        statements = []
-        for node in nodes:
-            if node is not None:
-                statements.append(node)
-        return statements
+        return [node for node in nodes if node is not None]
 
     def assign(self, nodes):
         targets = nodes[:-1]
@@ -287,7 +273,7 @@ class PythonTransformer(Transformer):
         value = nodes[2]
         if self._contains_unparenthesized_namedexpr(value):
             raise SyntaxError("invalid assignment expression")
-        if not self._is_single_target(target):
+        if not isinstance(target, (ast.Name, ast.Attribute, ast.Subscript)):
             raise SyntaxError("illegal expression for augmented assignment")
         self._set_ctx(target, ast.Store())
         return ast.AugAssign(target=target, op=op, value=value)
@@ -299,7 +285,7 @@ class PythonTransformer(Transformer):
         if (self._contains_unparenthesized_namedexpr(target_type) or
                 self._contains_unparenthesized_namedexpr(value)):
             raise SyntaxError("invalid assignment expression")
-        if not self._is_single_target(target):
+        if not isinstance(target, (ast.Name, ast.Attribute, ast.Subscript)):
             raise SyntaxError("illegal target for annotation")
         self._set_ctx(target, ast.Store())
         simple = 1 if (
@@ -393,8 +379,8 @@ class PythonTransformer(Transformer):
     def del_stmt(self, nodes):
         # Set for each of the inner nodes
         del_stmts = nodes[0] if isinstance(nodes[0], list) else [nodes[0]]
-        for del_stmt in del_stmts:
-            self._set_ctx(del_stmt, ast.Del())
+        for target in del_stmts:
+            self._set_ctx(target, ast.Del())
         return ast.Delete(targets=del_stmts)
 
     pass_stmt = lambda self, _: ast.Pass()
@@ -611,18 +597,6 @@ class PythonTransformer(Transformer):
         args = []
         ordered_args = []
 
-        def append_argument(arg):
-            if isinstance(arg, tuple) and arg[0] == "stararg":
-                args.append(ast.Starred(arg[1], ctx=ast.Load()))
-            elif isinstance(arg, tuple) and arg[0] == "argvalue":
-                keywords.append(ast.keyword(arg=arg[1], value=arg[2]))
-            elif isinstance(arg, tuple) and arg[0] == "kwargs":
-                keywords.append(ast.keyword(arg=None, value=arg[1]))
-            elif isinstance(arg, tuple) and len(arg) == 2 and isinstance(arg[1], list):
-                args.append(ast.GeneratorExp(elt=arg[0], generators=arg[1]))
-            else:
-                args.append(arg)
-
         for arg in prelim_args:
             if isinstance(arg, list):
                 ordered_args.extend(arg)
@@ -651,7 +625,17 @@ class PythonTransformer(Transformer):
                     raise SyntaxError(
                         "positional argument follows keyword argument unpacking"
                     )
-            append_argument(arg)
+
+            if isinstance(arg, tuple) and arg[0] == "stararg":
+                args.append(ast.Starred(arg[1], ctx=ast.Load()))
+            elif isinstance(arg, tuple) and arg[0] == "argvalue":
+                keywords.append(ast.keyword(arg=arg[1], value=arg[2]))
+            elif isinstance(arg, tuple) and arg[0] == "kwargs":
+                keywords.append(ast.keyword(arg=None, value=arg[1]))
+            elif isinstance(arg, tuple) and len(arg) == 2 and isinstance(arg[1], list):
+                args.append(ast.GeneratorExp(elt=arg[0], generators=arg[1]))
+            else:
+                args.append(arg)
 
         return ast.Call(
             func=function_name,
@@ -685,8 +669,7 @@ class PythonTransformer(Transformer):
         return ast.Dict(keys=keys, values=values)
 
     def list(self, nodes):
-        list_items = nodes if nodes else []
-        return ast.List(elts=list_items, ctx=ast.Load())
+        return ast.List(elts=nodes if nodes else [], ctx=ast.Load())
 
     def getitem(self, nodes):
         object = nodes[0]
@@ -794,7 +777,7 @@ class PythonTransformer(Transformer):
         return ast.SetComp(elt=elt, generators=generators)
 
     def set(self, nodes):
-        return ast.Set(nodes)
+        return ast.Set(elts=nodes)
 
     def comprehension(self, nodes):
         # comprehension
@@ -926,7 +909,7 @@ class PythonTransformer(Transformer):
     def subscript_starred_tuple(self, nodes):
         return ast.Tuple(elts=nodes, ctx=ast.Load())
 
-    def tuple(selfs, nodes):
+    def tuple(self, nodes):
         return ast.Tuple(elts=nodes, ctx=ast.Load())
 
     def parenthesized_tuple(self, nodes):
@@ -980,7 +963,11 @@ class PythonTransformer(Transformer):
         if len(merged_string) == 1:
             return merged_string[0]
 
-        if all(isinstance(item, ast.Constant) and isinstance(item.value, (str, bytes)) for item in merged_string):
+        if all(
+            isinstance(item, ast.Constant) and
+            isinstance(item.value, (str, bytes))
+            for item in merged_string
+        ):
             if isinstance(merged_string[0].value, str):
                 return ast.Constant(value="".join(item.value for item in merged_string))
             return ast.Constant(value=b"".join(item.value for item in merged_string))
@@ -995,7 +982,10 @@ class PythonTransformer(Transformer):
                     raise SyntaxError("Cannot concatenate bytes literals with f-strings")
             elif isinstance(string, ast.JoinedStr):
                 return_string.extend(string.values)
-        return self._normalize_joined_str(ast.JoinedStr(values=return_string), decode_literals=False)
+        return self._normalize_joined_str(
+            ast.JoinedStr(values=return_string),
+            decode_literals=False
+        )
 
     def f_string(self, nodes):
         is_raw = isinstance(nodes[0], str) and "r" in nodes[0].lower()
@@ -1064,8 +1054,7 @@ class PythonTransformer(Transformer):
         for node in nodes[1:]:
             # check for the conversion
             if isinstance(node, str):
-                conv_map = {"r": ord('r'), "s": ord('s'), "a": ord('a')}
-                conversion = conv_map[node.lower()]
+                conversion = ord(node.lower())
             elif isinstance(node, tuple) and len(node) == 2 and node[0] == "debug_eq":
                 debug_eq = node[1]
             elif isinstance(node, ast.AST):
@@ -1161,16 +1150,16 @@ class PythonTransformer(Transformer):
         current_string = nodes[0]
         if isinstance(current_string, (ast.JoinedStr, ast.Constant)):
             return current_string
+
+        prefix, string = current_string
+        if len(prefix) == 0:
+            return ast.Constant(value=string)
+        elif 'b' in prefix:
+            return ast.Constant(value=string.encode('utf-8'))
+        elif 'u' == prefix:
+            return ast.Constant(value=string, kind=prefix)
         else:
-            prefix, string = current_string
-            if len(prefix) == 0:
-                return ast.Constant(value=string)
-            elif 'b' in prefix:
-                return ast.Constant(value=string.encode('utf-8'))
-            elif 'u' == prefix:
-                return ast.Constant(value=string, kind=prefix)
-            else:
-                return ast.Constant(value=string)
+            return ast.Constant(value=string)
 
     @staticmethod
     def _split_string_literal(token_value):
@@ -1342,8 +1331,6 @@ class PythonTransformer(Transformer):
     ellipsis = lambda self, _: ast.Constant(value=Ellipsis)
     f_string_content_single = lambda self, nodes: nodes[0]
     f_string_content_double = lambda self, nodes: nodes[0]
-    f_string_escaped_content_double = lambda self, nodes: nodes[0]
-    f_string_escaped_content_single = lambda self, nodes: nodes[0]
     literal_open_brace = lambda self, _: '{'
     literal_close_brace = lambda self, _: self.FSTRING_LITERAL_CLOSE_BRACE
     named_unicode_escape = lambda self, nodes: ("named_unicode_escape", str(nodes[0])[3:-1])
@@ -1366,14 +1353,25 @@ class PythonTransformer(Transformer):
         name = str(nodes[0])
         index = 1
         type_params = []
-        if index < len(nodes) and self._is_type_params(nodes[index]):
+        if (
+            index < len(nodes) and isinstance(nodes[index], tuple) and
+            len(nodes[index]) == 2 and nodes[index][0] == "type_params"
+        ):
             type_params = nodes[index][1]
             index += 1
         if index < len(nodes) and isinstance(nodes[index], ast.arguments):
             parameters = nodes[index]
             index += 1
         else:
-            parameters = self._empty_arguments()
+            parameters = ast.arguments(
+                posonlyargs=[],
+                args=[],
+                vararg=None,
+                kwonlyargs=[],
+                kw_defaults=[],
+                kwarg=None,
+                defaults=[]
+            )
 
         # Extract return type and suite
         rest = nodes[index:]
@@ -1394,25 +1392,23 @@ class PythonTransformer(Transformer):
 
     def async_funcdef(self, nodes):
         funcdef = nodes[0] if isinstance(nodes, list) else nodes
-        name = funcdef.name
-        args = funcdef.args
-        body = funcdef.body
-        returns = funcdef.returns
-        type_params = funcdef.type_params
         return ast.AsyncFunctionDef(
-            name=name,
-            args=args,
-            body=body,
+            name=funcdef.name,
+            args=funcdef.args,
+            body=funcdef.body,
             decorator_list=[],
-            type_params=type_params,
-            returns=returns
+            type_params=funcdef.type_params,
+            returns=funcdef.returns
         )
 
     def classdef(self, nodes):
         name = nodes[0]
         index = 1
         type_params = []
-        if index < len(nodes) and self._is_type_params(nodes[index]):
+        if (
+            index < len(nodes) and isinstance(nodes[index], tuple) and
+            len(nodes[index]) == 2 and nodes[index][0] == "type_params"
+        ):
             type_params = nodes[index][1]
             index += 1
         if index < len(nodes) - 1:
@@ -1456,22 +1452,6 @@ class PythonTransformer(Transformer):
             decorator_list=[],
             type_params=type_params
         )
-
-    @staticmethod
-    def _empty_arguments():
-        return ast.arguments(
-            posonlyargs=[],
-            args=[],
-            vararg=None,
-            kwonlyargs=[],
-            kw_defaults=[],
-            kwarg=None,
-            defaults=[]
-        )
-
-    @staticmethod
-    def _is_type_params(node):
-        return isinstance(node, tuple) and len(node) == 2 and node[0] == "type_params"
 
     def type_params(self, nodes):
         return "type_params", nodes
@@ -1709,9 +1689,6 @@ class PythonTransformer(Transformer):
         if self._contains_unparenthesized_namedexpr(nodes[0]):
             raise SyntaxError("invalid assignment expression")
         return "kwargs", nodes[0]
-
-    def starargs(self, nodes):
-        return nodes
 
     def lambda_paramvalue(self, nodes):
         name_node = nodes[0]

--- a/ordec/ord/python_transformer.py
+++ b/ordec/ord/python_transformer.py
@@ -180,24 +180,19 @@ class PythonTransformer(Transformer):
         return isinstance(node, (ast.Name, ast.Attribute, ast.Subscript))
 
     @staticmethod
-    def _is_unparenthesized_namedexpr(node):
-        return (
-            isinstance(node, ast.NamedExpr) and
-            not getattr(node, "_ord_parenthesized", False)
-        )
-
-    @classmethod
-    def _contains_unparenthesized_namedexpr(cls, node):
+    def _contains_unparenthesized_namedexpr(node):
         # The grammar accepts `test` in several places where Python only allows
         # a named expression when it is parenthesized or nested in a container.
         if node is None:
             return False
-        if cls._is_unparenthesized_namedexpr(node):
+        if (isinstance(node, ast.NamedExpr) and
+                not getattr(node, "_parenthesized_expr", False)):
             return True
         if (isinstance(node, ast.Tuple) and
-                not getattr(node, "_ord_parenthesized", False)):
+                not getattr(node, "_parenthesized_expr", False)):
             return any(
-                cls._is_unparenthesized_namedexpr(elt)
+                isinstance(elt, ast.NamedExpr) and
+                not getattr(elt, "_parenthesized_expr", False)
                 for elt in node.elts
             )
         return False
@@ -307,7 +302,7 @@ class PythonTransformer(Transformer):
         self._set_ctx(target, ast.Store())
         simple = 1 if (
             isinstance(target, ast.Name) and
-            not getattr(target, "_ord_parenthesized", False)
+            not getattr(target, "_parenthesized_expr", False)
         ) else 0
         return ast.AnnAssign(
             target=target,
@@ -543,7 +538,7 @@ class PythonTransformer(Transformer):
         if (len(with_items) == 1 and
                 with_items[0].optional_vars is None and
                 isinstance(with_items[0].context_expr, ast.Tuple) and
-                not getattr(with_items[0].context_expr, "_ord_parenthesized", False)):
+                not getattr(with_items[0].context_expr, "_parenthesized_expr", False)):
             with_items = [
                 ast.withitem(context_expr=elt, optional_vars=None)
                 for elt in with_items[0].context_expr.elts
@@ -877,7 +872,7 @@ class PythonTransformer(Transformer):
     def grouped_test(self, nodes):
         node = nodes[0]
         if isinstance(node, ast.AST):
-            node._ord_parenthesized = True
+            node._parenthesized_expr = True
         return node
 
     def test(self, nodes):
@@ -931,7 +926,7 @@ class PythonTransformer(Transformer):
 
     def parenthesized_tuple(self, nodes):
         node = ast.Tuple(elts=nodes, ctx=ast.Load())
-        node._ord_parenthesized = True
+        node._parenthesized_expr = True
         return node
 
     def testlist_tuple(self, nodes):
@@ -1790,7 +1785,7 @@ class PythonTransformer(Transformer):
             )
             body = nodes[0]
 
-        if self._is_unparenthesized_namedexpr(body):
+        if self._contains_unparenthesized_namedexpr(body):
             raise SyntaxError("invalid assignment expression")
         return ast.Lambda(args=params, body=body)
 

--- a/ordec/ord/python_transformer.py
+++ b/ordec/ord/python_transformer.py
@@ -107,6 +107,8 @@ class PythonTransformer(Transformer):
         "v": 11,
     }
 
+    FSTRING_LITERAL_CLOSE_BRACE = object()
+
     def __init__(self, source_text=""):
         super().__init__()
         self.source_text = source_text
@@ -995,12 +997,29 @@ class PythonTransformer(Transformer):
     def f_string(self, nodes):
         is_raw = isinstance(nodes[0], str) and "r" in nodes[0].lower()
         values_raw = []
+        pending_close_brace = False
         for item in nodes[1:-1]:
+            # Close braces are accepted singly in the grammar so nested format
+            # specs can split adjacent expression closers. Pair literal braces
+            # here to preserve CPython's escaped "}}" rule.
+            if item is self.FSTRING_LITERAL_CLOSE_BRACE:
+                if pending_close_brace:
+                    values_raw.append("}")
+                    pending_close_brace = False
+                else:
+                    pending_close_brace = True
+                continue
+
+            if pending_close_brace:
+                raise SyntaxError("f-string: single '}' is not allowed")
+
             if isinstance(item, tuple) and len(item) == 3 and item[0] == "debug_fexpr":
                 values_raw.append(ast.Constant(value=item[1]))
                 values_raw.append(item[2])
             else:
                 values_raw.append(item)
+        if pending_close_brace:
+            raise SyntaxError("f-string: single '}' is not allowed")
         values = self.merge_adjacent_strings(values_raw)
         joined = ast.JoinedStr(values=values)
         return self._normalize_joined_str(joined, decode_literals=not is_raw)
@@ -1073,6 +1092,8 @@ class PythonTransformer(Transformer):
             # string or expression
             if isinstance(node, str):
                 values.append(ast.Constant(value=node))
+            elif isinstance(node, ast.FormattedValue):
+                values.append(node)
             elif isinstance(node, ast.AST):
                 values.append(self.f_expression([node]))
         return ast.JoinedStr(values=values)
@@ -1297,7 +1318,7 @@ class PythonTransformer(Transformer):
     f_string_escaped_content_double = lambda self, nodes: nodes[0]
     f_string_escaped_content_single = lambda self, nodes: nodes[0]
     literal_open_brace = lambda self, _: '{'
-    literal_close_brace = lambda self, _: '}'
+    literal_close_brace = lambda self, _: self.FSTRING_LITERAL_CLOSE_BRACE
     exprlist = lambda self, nodes: nodes
 
     # Definitions
@@ -1428,16 +1449,28 @@ class PythonTransformer(Transformer):
         return "type_params", nodes
 
     def typevar(self, nodes):
-        return ast.TypeVar(name=nodes[0], bound=None)
+        return ast.TypeVar(name=nodes[0], bound=None, default_value=None)
+
+    def typevar_default(self, nodes):
+        return ast.TypeVar(name=nodes[0], bound=None, default_value=nodes[1])
 
     def bounded_typevar(self, nodes):
-        return ast.TypeVar(name=nodes[0], bound=nodes[1])
+        return ast.TypeVar(name=nodes[0], bound=nodes[1], default_value=None)
+
+    def bounded_typevar_default(self, nodes):
+        return ast.TypeVar(name=nodes[0], bound=nodes[1], default_value=nodes[2])
 
     def typevartuple(self, nodes):
-        return ast.TypeVarTuple(name=nodes[0])
+        return ast.TypeVarTuple(name=nodes[0], default_value=None)
+
+    def typevartuple_default(self, nodes):
+        return ast.TypeVarTuple(name=nodes[0], default_value=nodes[1])
 
     def paramspec(self, nodes):
-        return ast.ParamSpec(name=nodes[0])
+        return ast.ParamSpec(name=nodes[0], default_value=None)
+
+    def paramspec_default(self, nodes):
+        return ast.ParamSpec(name=nodes[0], default_value=nodes[1])
 
     def type_alias_stmt(self, nodes):
         name = ast.Name(id=nodes[0], ctx=ast.Store())

--- a/tests/test_ord_compiler.py
+++ b/tests/test_ord_compiler.py
@@ -500,6 +500,14 @@ def test_match_args_pattern():
     ord_string = "match point:\n    case Point(x, y):\n        pass"
     compare_asts(ord_string)
 
+def test_match_empty_class_pattern():
+    ord_string = "match point:\n    case Point():\n        pass"
+    compare_asts(ord_string)
+
+def test_match_empty_class_as_pattern():
+    ord_string = "match point:\n    case Point() as p:\n        pass"
+    compare_asts(ord_string)
+
 def test_match_get_pattern():
     ord_string = "match point:\n    case pointclass.Point(x, y):\n        pass"
     compare_asts(ord_string)
@@ -723,3 +731,379 @@ def test_lineno_celldef():
     code = "cell Foo:\n    pass"
     tree = ord_to_py(code)
     assert tree.body[0].lineno == 1
+
+def test_except_star():
+    ord_string = "try:\n    pass\nexcept* ValueError:\n    pass"
+    compare_asts(ord_string)
+
+def test_type_alias_stmt():
+    ord_string = "type Vec[T] = list[T]"
+    compare_asts(ord_string)
+
+def test_funcdef_type_params():
+    ord_string = "def identity[T](x: T) -> T:\n    return x"
+    compare_asts(ord_string)
+
+def test_classdef_type_params():
+    ord_string = "class Box[T]:\n    pass"
+    compare_asts(ord_string)
+
+def test_decorator_call_expression():
+    ord_string = "@(decorator_factory())\ndef f():\n    pass"
+    compare_asts(ord_string)
+
+def test_decorator_subscript_expression():
+    ord_string = "@decorators[0]\ndef f():\n    pass"
+    compare_asts(ord_string)
+
+def test_decorator_dotted_call_ast():
+    ord_string = "@pkg.decorator(arg=1)\ndef f():\n    pass"
+    compare_asts(ord_string)
+
+def test_decorator_nonconstant_argument():
+    ord_string = "@decorator(x)\ndef f():\n    pass"
+    compare_asts(ord_string)
+
+def test_decorator_kwargs():
+    ord_string = "@decorator(**kw)\ndef f():\n    pass"
+    compare_asts(ord_string)
+
+def test_compare_not_in():
+    ord_string = "x = a not in b"
+    compare_asts(ord_string)
+
+def test_compare_is_not():
+    ord_string = "x = a is not b"
+    compare_asts(ord_string)
+
+def test_call_positional_after_stararg():
+    ord_string = "func(*args, 1)"
+    compare_asts(ord_string)
+
+def test_call_multiple_kwargs_unpacking():
+    ord_string = "func(**a, **b)"
+    compare_asts(ord_string)
+
+def test_class_starred_base():
+    ord_string = "class A(*bases):\n    pass"
+    compare_asts(ord_string)
+
+def test_class_kwargs_base():
+    ord_string = "class A(**kw):\n    pass"
+    compare_asts(ord_string)
+
+def test_parenthesized_with_items():
+    ord_string = "with (a as x, b as y):\n    pass"
+    compare_asts(ord_string)
+
+def test_comprehension_filter_before_second_for():
+    ord_string = "[(x, y) for x in xs if x for y in ys]"
+    compare_asts(ord_string)
+
+def test_triple_quoted_f_string():
+    ord_string = "f'''hello {name}'''"
+    compare_asts(ord_string)
+
+def test_uppercase_f_string_prefix():
+    ord_string = "F'{name}'"
+    compare_asts(ord_string)
+
+def test_match_negative_literal_pattern():
+    ord_string = "match x:\n    case -1:\n        pass"
+    compare_asts(ord_string)
+
+def test_match_dotted_value_pattern():
+    ord_string = "match x:\n    case Color.RED:\n        pass"
+    compare_asts(ord_string)
+
+def test_match_star_wildcard_pattern():
+    ord_string = "match x:\n    case [*_]:\n        pass"
+    compare_asts(ord_string)
+
+def test_parenthesized_annotation_simple_flag():
+    ord_string = "(x): int"
+    compare_asts(ord_string)
+
+def test_invalid_bare_walrus():
+    ord_string = "x := 1"
+    compare_syntax_errors(ord_string)
+
+def test_invalid_old_not_equal_operator():
+    ord_string = "x = a <> b"
+    compare_syntax_errors(ord_string)
+
+def test_assignment_starred_target():
+    ord_string = "*a, = b"
+    compare_asts(ord_string)
+
+def test_assignment_empty_tuple_target():
+    ord_string = "() = values"
+    compare_asts(ord_string)
+
+def test_invalid_assignment_literal_target():
+    ord_string = "1 = x"
+    compare_syntax_errors(ord_string)
+
+def test_invalid_assignment_expression_target():
+    ord_string = "a + b = x"
+    compare_syntax_errors(ord_string)
+
+def test_invalid_assignment_call_target():
+    ord_string = "f() = x"
+    compare_syntax_errors(ord_string)
+
+def test_invalid_augassign_tuple_target():
+    ord_string = "a, b += c"
+    compare_syntax_errors(ord_string)
+
+def test_invalid_augassign_starred_target():
+    ord_string = "*a += b"
+    compare_syntax_errors(ord_string)
+
+def test_invalid_annassign_tuple_target():
+    ord_string = "a, b: int"
+    compare_syntax_errors(ord_string)
+
+def test_invalid_annassign_call_target():
+    ord_string = "f(): int"
+    compare_syntax_errors(ord_string)
+
+def test_invalid_del_literal_target():
+    ord_string = "del 1"
+    compare_syntax_errors(ord_string)
+
+def test_invalid_del_starred_target():
+    ord_string = "del *items"
+    compare_syntax_errors(ord_string)
+
+def test_invalid_for_literal_target():
+    ord_string = "for 1 in values:\n    pass"
+    compare_syntax_errors(ord_string)
+
+def test_invalid_for_expression_target():
+    ord_string = "for a + b in values:\n    pass"
+    compare_syntax_errors(ord_string)
+
+def test_invalid_function_default_order():
+    ord_string = "def f(a=1, b):\n    pass"
+    compare_syntax_errors(ord_string)
+
+def test_invalid_ur_string_prefix():
+    ord_string = "ur'x'"
+    compare_syntax_errors(ord_string)
+
+def test_subscript_starred_single():
+    ord_string = "tuple[*Ts]"
+    compare_asts(ord_string)
+
+def test_subscript_starred_tuple():
+    ord_string = "tuple[int, *Ts]"
+    compare_asts(ord_string)
+
+def test_type_alias_typevartuple_used():
+    ord_string = "type TupleAlias[*Ts] = tuple[*Ts]"
+    compare_asts(ord_string)
+
+def test_funcdef_typevartuple_annotation():
+    ord_string = "def f[*Ts](*args: *Ts):\n    pass"
+    compare_asts(ord_string)
+
+def test_parenthesized_with_bare_items():
+    ord_string = "with (a, b):\n    pass"
+    compare_asts(ord_string)
+
+def test_parenthesized_with_mixed_items():
+    ord_string = "with (a, b as y):\n    pass"
+    compare_asts(ord_string)
+
+def test_parenthesized_with_single_as_target():
+    ord_string = "with (a) as t:\n    pass"
+    compare_asts(ord_string)
+
+def test_parenthesized_tuple_with_as_target():
+    ord_string = "with (a, b) as t:\n    pass"
+    compare_asts(ord_string)
+
+def test_parenthesized_with_trailing_comma():
+    ord_string = "with (a,):\n    pass"
+    compare_asts(ord_string)
+
+def test_parenthesized_with_as_trailing_comma():
+    ord_string = "with (a as x,):\n    pass"
+    compare_asts(ord_string)
+
+def test_invalid_parenthesized_with_item_and_outer_as():
+    ord_string = "with (a as x, b) as t:\n    pass"
+    compare_syntax_errors(ord_string)
+
+def test_invalid_walrus_assignment_rhs():
+    ord_string = "a = x := 1"
+    compare_syntax_errors(ord_string)
+
+def test_invalid_walrus_return_value():
+    ord_string = "def f():\n    return x := 1"
+    compare_syntax_errors(ord_string)
+
+def test_invalid_walrus_lambda_body():
+    ord_string = "lambda: x := 1"
+    compare_syntax_errors(ord_string)
+
+def test_invalid_walrus_keyword_argument():
+    ord_string = "func(a=x := 1)"
+    compare_syntax_errors(ord_string)
+
+def test_match_complex_literal_pattern():
+    ord_string = "match x:\n    case 1+2j:\n        pass"
+    compare_asts(ord_string)
+
+def test_match_negative_complex_literal_pattern():
+    ord_string = "match x:\n    case -1-2j:\n        pass"
+    compare_asts(ord_string)
+
+def test_invalid_keyword_as_name():
+    ord_string = "and = 1"
+    compare_syntax_errors(ord_string)
+
+def test_invalid_keyword_in_call_argument_name():
+    ord_string = "func(if=1)"
+    compare_syntax_errors(ord_string)
+
+def test_invalid_keyword_as_parameter_name():
+    ord_string = "def f(if):\n    pass"
+    compare_syntax_errors(ord_string)
+
+def test_funcdef_stararg_trailing_comma():
+    ord_string = "def f(*args,):\n    pass"
+    compare_asts(ord_string)
+
+def test_funcdef_kwonly_trailing_comma():
+    ord_string = "def f(*, a,):\n    pass"
+    compare_asts(ord_string)
+
+def test_funcdef_kwonly_after_arg_trailing_comma():
+    ord_string = "def f(a, *, b,):\n    pass"
+    compare_asts(ord_string)
+
+def test_funcdef_kwargs_trailing_comma():
+    ord_string = "def f(**kw,):\n    pass"
+    compare_asts(ord_string)
+
+def test_funcdef_stararg_kwargs_trailing_comma():
+    ord_string = "def f(*args, **kw,):\n    pass"
+    compare_asts(ord_string)
+
+def test_invalid_funcdef_bare_star():
+    ord_string = "def f(*):\n    pass"
+    compare_syntax_errors(ord_string)
+
+def test_invalid_funcdef_kwargs_double_trailing_comma():
+    ord_string = "def f(*args, **kw,,):\n    pass"
+    compare_syntax_errors(ord_string)
+
+def test_invalid_lambda_bare_star():
+    ord_string = "lambda *: 1"
+    compare_syntax_errors(ord_string)
+
+def test_invalid_lambda_bare_star_trailing_comma():
+    ord_string = "lambda *,: 1"
+    compare_syntax_errors(ord_string)
+
+def test_invalid_call_positional_after_keyword():
+    ord_string = "func(a=1, 2)"
+    compare_syntax_errors(ord_string)
+
+def test_invalid_call_positional_after_kwargs():
+    ord_string = "func(**kw, 1)"
+    compare_syntax_errors(ord_string)
+
+def test_invalid_call_stararg_after_kwargs():
+    ord_string = "func(**kw, *args)"
+    compare_syntax_errors(ord_string)
+
+def test_invalid_class_positional_after_keyword():
+    ord_string = "class A(metaclass=Meta, B):\n    pass"
+    compare_syntax_errors(ord_string)
+
+def test_invalid_class_stararg_after_kwargs():
+    ord_string = "class A(**kw, *bases):\n    pass"
+    compare_syntax_errors(ord_string)
+
+def test_invalid_walrus_function_default():
+    ord_string = "def f(a=x:=1):\n    pass"
+    compare_syntax_errors(ord_string)
+
+def test_invalid_walrus_augassign_value():
+    ord_string = "a += x := 1"
+    compare_syntax_errors(ord_string)
+
+def test_invalid_walrus_annassign_value():
+    ord_string = "x: int = y := 1"
+    compare_syntax_errors(ord_string)
+
+def test_invalid_walrus_raise_cause():
+    ord_string = "raise err from x := cause"
+    compare_syntax_errors(ord_string)
+
+def test_invalid_walrus_with_item():
+    ord_string = "with x := cm():\n    pass"
+    compare_syntax_errors(ord_string)
+
+def test_invalid_walrus_for_iter():
+    ord_string = "for x in y := z:\n    pass"
+    compare_syntax_errors(ord_string)
+
+def test_invalid_walrus_tuple_assignment_value():
+    ord_string = "a = b, c := 1"
+    compare_syntax_errors(ord_string)
+
+def test_walrus_list_expression_statement():
+    ord_string = "[x := 1]"
+    compare_asts(ord_string)
+
+def test_walrus_comprehension_expression_statement():
+    ord_string = "[y := x for x in xs]"
+    compare_asts(ord_string)
+
+def test_walrus_assignment_nested_container():
+    ord_string = "a = [x := 1]"
+    compare_asts(ord_string)
+
+def test_walrus_assignment_parenthesized_tuple():
+    ord_string = "a = (b, c := 1)"
+    compare_asts(ord_string)
+
+def test_walrus_call_positional_argument():
+    ord_string = "func(x := 1)"
+    compare_asts(ord_string)
+
+def test_walrus_keyword_nested_container():
+    ord_string = "func(a=[x := 1])"
+    compare_asts(ord_string)
+
+def test_walrus_return_nested_container():
+    ord_string = "def f():\n    return [x := 1]"
+    compare_asts(ord_string)
+
+def test_walrus_class_base():
+    ord_string = "class C(x := Base):\n    pass"
+    compare_asts(ord_string)
+
+def test_f_string_empty_format_spec():
+    ord_string = "f'{x:}'"
+    compare_asts(ord_string)
+
+def test_f_string_conversion_empty_format_spec():
+    ord_string = "f'{x!r:}'"
+    compare_asts(ord_string)
+
+def test_f_string_nested_format_spec_trailing_empty():
+    ord_string = "f'{x:{width}}'"
+    compare_asts(ord_string)
+
+def test_invalid_match_class_positional_after_keyword():
+    ord_string = "match x:\n    case Point(x=1, y):\n        pass"
+    compare_syntax_errors(ord_string)
+
+def test_invalid_match_as_wildcard_target():
+    ord_string = "match x:\n    case y as _:\n        pass"
+    compare_syntax_errors(ord_string)

--- a/tests/test_ord_compiler.py
+++ b/tests/test_ord_compiler.py
@@ -744,8 +744,20 @@ def test_funcdef_type_params():
     ord_string = "def identity[T](x: T) -> T:\n    return x"
     compare_asts(ord_string)
 
+def test_funcdef_type_param_default():
+    ord_string = "def identity[T = int](x: T) -> T:\n    return x"
+    compare_asts(ord_string)
+
+def test_funcdef_bounded_type_param_default():
+    ord_string = "def identity[T: int = bool](x: T) -> T:\n    return x"
+    compare_asts(ord_string)
+
 def test_classdef_type_params():
     ord_string = "class Box[T]:\n    pass"
+    compare_asts(ord_string)
+
+def test_classdef_type_param_defaults():
+    ord_string = "class Box[T = int, *Ts = tuple[int, ...], **P = [int, str]]:\n    pass"
     compare_asts(ord_string)
 
 def test_decorator_call_expression():
@@ -902,6 +914,22 @@ def test_subscript_starred_tuple():
 
 def test_type_alias_typevartuple_used():
     ord_string = "type TupleAlias[*Ts] = tuple[*Ts]"
+    compare_asts(ord_string)
+
+def test_type_alias_type_param_default():
+    ord_string = "type Alias[T = int] = list[T]"
+    compare_asts(ord_string)
+
+def test_type_alias_bounded_type_param_default():
+    ord_string = "type Alias[T: int = bool] = list[T]"
+    compare_asts(ord_string)
+
+def test_type_alias_typevartuple_default():
+    ord_string = "type TupleAlias[*Ts = tuple[int, ...]] = tuple[*Ts]"
+    compare_asts(ord_string)
+
+def test_type_alias_paramspec_default():
+    ord_string = "type CallableAlias[**P = [int, str]] = Callable[P, int]"
     compare_asts(ord_string)
 
 def test_funcdef_typevartuple_annotation():
@@ -1099,6 +1127,18 @@ def test_f_string_conversion_empty_format_spec():
 def test_f_string_nested_format_spec_trailing_empty():
     ord_string = "f'{x:{width}}'"
     compare_asts(ord_string)
+
+def test_f_string_nested_format_spec_conversion():
+    ord_string = "f'{x:{width!r}}'"
+    compare_asts(ord_string)
+
+def test_f_string_nested_format_spec_nested_spec():
+    ord_string = "f'{x:{width:{precision}}}'"
+    compare_asts(ord_string)
+
+def test_invalid_f_string_single_close_brace():
+    ord_string = "f'}'"
+    compare_syntax_errors(ord_string)
 
 def test_invalid_match_class_positional_after_keyword():
     ord_string = "match x:\n    case Point(x=1, y):\n        pass"

--- a/tests/test_ord_compiler.py
+++ b/tests/test_ord_compiler.py
@@ -928,6 +928,10 @@ def test_type_alias_typevartuple_default():
     ord_string = "type TupleAlias[*Ts = tuple[int, ...]] = tuple[*Ts]"
     compare_asts(ord_string)
 
+def test_type_alias_typevartuple_starred_default():
+    ord_string = "type TupleAlias[*Ts = *default] = tuple[*Ts]"
+    compare_asts(ord_string)
+
 def test_type_alias_paramspec_default():
     ord_string = "type CallableAlias[**P = [int, str]] = Callable[P, int]"
     compare_asts(ord_string)

--- a/tests/test_ord_compiler.py
+++ b/tests/test_ord_compiler.py
@@ -1151,3 +1151,47 @@ def test_invalid_match_class_positional_after_keyword():
 def test_invalid_match_as_wildcard_target():
     ord_string = "match x:\n    case y as _:\n        pass"
     compare_syntax_errors(ord_string)
+
+# Python conformance cases found by sweeping the CPython 3.13 stdlib through
+# ord_to_py and comparing ASTs against ast.parse. These guard against ORD
+# statement keywords (type/path/cell/net/viewgen) becoming hard-reserved.
+
+def test_name_type_assignment():
+    ord_string = "type = None"
+    compare_asts(ord_string)
+
+def test_name_path_assignment():
+    ord_string = "path = 1"
+    compare_asts(ord_string)
+
+def test_name_cell_assignment():
+    ord_string = "cell = 1"
+    compare_asts(ord_string)
+
+def test_name_net_assignment():
+    ord_string = "net = 1"
+    compare_asts(ord_string)
+
+def test_name_viewgen_assignment():
+    ord_string = "viewgen = 1"
+    compare_asts(ord_string)
+
+def test_name_type_aug_assignment():
+    ord_string = "type += 1"
+    compare_asts(ord_string)
+
+def test_name_path_annotation():
+    ord_string = "path: int = 1"
+    compare_asts(ord_string)
+
+def test_name_type_loop_target():
+    ord_string = "for i, type in x: pass"
+    compare_asts(ord_string)
+
+def test_name_type_call_statement():
+    ord_string = "type(x).y()"
+    compare_asts(ord_string)
+
+def test_fstring_tuple_field():
+    ord_string = 's = f"{x,}"'
+    compare_asts(ord_string)

--- a/tests/test_ord_compiler.py
+++ b/tests/test_ord_compiler.py
@@ -1196,10 +1196,6 @@ def test_with_call_as_name_multi_stmt():
     ord_string = "with f() as b:\n    x\n    y"
     compare_asts(ord_string)
 
-def test_with_open_as_file_body():
-    ord_string = "with open(p) as f:\n    a = 1\n    b = 2"
-    compare_asts(ord_string)
-
 def test_with_parenthesized_call_as():
     ord_string = "with (f()) as b:\n    x\n    y"
     compare_asts(ord_string)
@@ -1317,10 +1313,6 @@ def test_case_class_pattern_trailing_comma():
 
 def test_fstring_named_escape_after_text():
     ord_string = "s = f'2\\N{GREEK CAPITAL LETTER DELTA}'"
-    compare_asts(ord_string)
-
-def test_fstring_named_escape_at_start_guard():
-    ord_string = "s = f'\\N{GREEK CAPITAL LETTER DELTA}'"
     compare_asts(ord_string)
 
 def test_for_iter_starred_exprs():

--- a/tests/test_ord_compiler.py
+++ b/tests/test_ord_compiler.py
@@ -1152,10 +1152,6 @@ def test_invalid_match_as_wildcard_target():
     ord_string = "match x:\n    case y as _:\n        pass"
     compare_syntax_errors(ord_string)
 
-# Python conformance cases found by sweeping the CPython 3.13 stdlib through
-# ord_to_py and comparing ASTs against ast.parse. These guard against ORD
-# statement keywords (type/path/cell/net/viewgen) becoming hard-reserved.
-
 def test_name_type_assignment():
     ord_string = "type = None"
     compare_asts(ord_string)
@@ -1194,4 +1190,175 @@ def test_name_type_call_statement():
 
 def test_fstring_tuple_field():
     ord_string = 's = f"{x,}"'
+    compare_asts(ord_string)
+
+def test_with_call_as_name_multi_stmt():
+    ord_string = "with f() as b:\n    x\n    y"
+    compare_asts(ord_string)
+
+def test_with_open_as_file_body():
+    ord_string = "with open(p) as f:\n    a = 1\n    b = 2"
+    compare_asts(ord_string)
+
+def test_with_parenthesized_call_as():
+    ord_string = "with (f()) as b:\n    x\n    y"
+    compare_asts(ord_string)
+
+def test_with_multiple_call_as_items():
+    ord_string = "with f() as b, g() as c:\n    x\n    y"
+    compare_asts(ord_string)
+
+def test_funcdef_kwargs_trailing_comma_after_param():
+    ord_string = "def f(a, **kw,): pass"
+    compare_asts(ord_string)
+
+def test_funcdef_annotated_kwargs_trailing_comma():
+    ord_string = "def f(a, **kw: int,): pass"
+    compare_asts(ord_string)
+
+@pytest.mark.filterwarnings("ignore:invalid escape sequence.*:SyntaxWarning")
+def test_fstring_backslash_before_field():
+    ord_string = 's = f"a\\{b}"'
+    compare_asts(ord_string)
+
+def test_raw_fstring_backslash_before_field():
+    ord_string = 's = rf"\\{b}"'
+    compare_asts(ord_string)
+
+@pytest.mark.filterwarnings("ignore:invalid escape sequence.*:SyntaxWarning")
+def test_fstring_backslash_before_field_single_quote():
+    ord_string = "s = f'a\\{b}'"
+    compare_asts(ord_string)
+
+@pytest.mark.filterwarnings("ignore:invalid escape sequence.*:SyntaxWarning")
+def test_fstring_backslash_before_field_multiple():
+    ord_string = 's = f"\\{b}\\{c}"'
+    compare_asts(ord_string)
+
+def test_fstring_named_unicode_escape():
+    ord_string = 's = f"\\N{BULLET}"'
+    compare_asts(ord_string)
+
+def test_fstring_named_unicode_escape_then_field():
+    ord_string = 's = f"\\N{BULLET}{x}"'
+    compare_asts(ord_string)
+
+def test_fstring_valid_escape_before_field():
+    ord_string = 's = f"\\n{b}"'
+    compare_asts(ord_string)
+
+def test_fstring_escaped_backslash_before_field():
+    ord_string = 's = f"\\\\{b}"'
+    compare_asts(ord_string)
+
+def test_raw_fstring_named_escape_is_field():
+    ord_string = 's = rf"\\N{x}"'
+    compare_asts(ord_string)
+
+def test_match_tuple_subject_trailing_comma():
+    ord_string = "match x,:\n    case y:\n        z = 0"
+    compare_asts(ord_string)
+
+def test_match_soft_keyword_as_identifier():
+    ord_string = "match.foo()"
+    compare_asts(ord_string)
+
+def test_for_target_single_elem_tuple():
+    ord_string = "for x, in y:\n    pass"
+    compare_asts(ord_string)
+
+def test_fstring_format_spec_starting_eq():
+    ord_string = "s = f'{x:=10}'"
+    compare_asts(ord_string)
+
+def test_string_backslash_newline_continuation():
+    ord_string = "x = 'a\\\nb'"
+    compare_asts(ord_string)
+
+def test_return_starred_unparenthesized_tuple():
+    ord_string = "def f():\n    return *a, b"
+    compare_asts(ord_string)
+
+def test_return_starred_trailing_comma():
+    ord_string = "def f():\n    return *a,"
+    compare_asts(ord_string)
+
+def test_yield_starred_unparenthesized_tuple():
+    ord_string = "def g():\n    yield *a, b"
+    compare_asts(ord_string)
+
+def test_return_starred_parenthesized_tuple():
+    ord_string = "def f():\n    return (*a, b)"
+    compare_asts(ord_string)
+
+def test_assign_starred_unparenthesized_tuple():
+    ord_string = "x = *a, b"
+    compare_asts(ord_string)
+
+def test_match_prefixed_identifier_annotation():
+    ord_string = "match_tests: int"
+    compare_asts(ord_string)
+
+def test_match_prefixed_identifier_assignment_guard():
+    ord_string = "match_x = 1"
+    compare_asts(ord_string)
+
+def test_anonymous_keyword_as_call():
+    ord_string = "anonymous()"
+    compare_asts(ord_string)
+
+def test_path_keyword_as_call_guard():
+    ord_string = "path()"
+    compare_asts(ord_string)
+
+def test_case_class_pattern_trailing_comma():
+    ord_string = "match p:\n    case Foo(a,):\n        pass"
+    compare_asts(ord_string)
+
+def test_fstring_named_escape_after_text():
+    ord_string = "s = f'2\\N{GREEK CAPITAL LETTER DELTA}'"
+    compare_asts(ord_string)
+
+def test_fstring_named_escape_at_start_guard():
+    ord_string = "s = f'\\N{GREEK CAPITAL LETTER DELTA}'"
+    compare_asts(ord_string)
+
+def test_for_iter_starred_exprs():
+    ord_string = "for x in *a, *b:\n    pass"
+    compare_asts(ord_string)
+
+def test_with_as_call_subscript_target():
+    ord_string = "with c() as f()[0]:\n    pass"
+    compare_asts(ord_string)
+
+def test_fstring_concat_empty_str_empty_fstring():
+    ord_string = "x = '' f''"
+    compare_asts(ord_string)
+
+def test_fstring_concat_empty_str_then_field():
+    ord_string = "x = '' f'{y}'"
+    compare_asts(ord_string)
+
+def test_fstring_concat_field_then_empty_str():
+    ord_string = "x = f'{y}' ''"
+    compare_asts(ord_string)
+
+def test_fstring_concat_empty_fstring_alone_guard():
+    ord_string = "x = f''"
+    compare_asts(ord_string)
+
+def test_fstring_concat_two_empty_plain_guard():
+    ord_string = "x = '' ''"
+    compare_asts(ord_string)
+
+def test_fstring_concat_nonempty_str_empty_fstring_guard():
+    ord_string = "x = 'a' f''"
+    compare_asts(ord_string)
+
+def test_fstring_concat_empty_str_nonempty_fstring_guard():
+    ord_string = "x = '' f'b'"
+    compare_asts(ord_string)
+
+def test_fstring_concat_two_empty_fstrings_guard():
+    ord_string = "x = f'' f''"
     compare_asts(ord_string)


### PR DESCRIPTION
## Summary  

- Improves Python transformer parity with Python, especially around f-strings, keywords, type parameters and assignment-expression validation.

## Changes

- Harden Python AST generation and target/context validation in `PythonTransformer`
- Improve f-string parsing, nested format specs, debug expressions, escapes, and indentation handling
- Treat ORD keywords as soft where valid Python identifiers are expected
- Add parser coverage for edge cases
- Clarify transformer comments and organize `PythonTransformer`
