### PR TITLE
ORDB serialization (wire)

### DIFF
--- a/docs/dev/index.rst
+++ b/docs/dev/index.rst
@@ -14,4 +14,5 @@ Developer's Corner
    ngspice_pipe_mode
    ordb_benchmarks
    ordb_benchmark_workloads
+   ordb_wire
    design_decisions

--- a/docs/dev/ordb_wire.rst
+++ b/docs/dev/ordb_wire.rst
@@ -1,0 +1,90 @@
+:mod:`ordec.core.wire` --- ORDB wire layer
+==========================================
+
+.. automodule:: ordec.core.wire
+
+Node classes opt in by declaring ``wire_id = WIRE_DOMAIN | n`` in their
+class body (inherited wire_ids do not count; uniqueness is asserted at
+class registration, and serializing a class without one is an error).
+Domain prefixes:
+
+- 1<<16: ordb (NPath)
+- 2<<16: schema/base
+- 3<<16: schematic
+- 4<<16: layout
+- 5<<16: simhier
+- 6<<16: drc
+- 7<<16: lvs
+- 8<<16: report
+- 15<<16: tests
+
+CBOR tags
+---------
+
+Native CBOR covers None, bool, int, str, bytes, float and tuple (as
+array, recursive). Everything else is tagged:
+
+.. csv-table::
+  :header: Tag, Type, Payload
+
+  30, R, "[numerator, denominator] (standard rational tag; always reduced)"
+  390001/390002, Vec2R / Vec2I, "[x, y]"
+  390003/390004, Rect4R / Rect4I, "[lx, ly, ux, uy]"
+  390005/390006, TD4R / TD4I, "[transl, d4]"
+  390007; 390010–390016, "D4; PathEndType, PinType, SchemErrorType, ScaleType, SimType, LvsStatus, LvsItemType", member name string
+  390020, SimArray, "[[[fid, dtype], ...], data bytes]"
+  390021, SourceLocInfo, "[filename, line, column]"
+  390022, GdsLayer, "[layer, data_type]"
+  390023, RGBColor, "[r, g, b]"
+  390030, LocalRef value, nid
+  390031, ExternalRef value, nid
+  390032, SubgraphRef value, 32-byte wire_hash of the referenced subgraph
+  390033, LiveRef value, "[endpoint_id (16 bytes), obj_id (uint), name (str)]"
+
+Format stability
+----------------
+
+There is no schema-skew detection: all endpoints are built from the same
+monorepo tree and wire data is never persisted, so the format version
+digit in ``HASH_DOMAIN`` is the only versioning. Canonical (shortest-form)
+float encoding is deterministic per cbor2 version; a cbor2 major-version
+bump warrants re-checking it and bumping the format version (cbor2>=6 is
+pinned, its tag_hook signature differs from 5.x). A foreign-language
+encoder must reproduce the canonical encoding byte-exactly for hashes to
+match.
+
+Encoding, hashing, decoding
+---------------------------
+
+.. automethod:: ordec.core.ordb.base.FrozenSubgraph.wire_encode
+
+.. automethod:: ordec.core.ordb.base.FrozenSubgraph.wire_hash
+
+.. automethod:: ordec.core.ordb.base.FrozenSubgraph.wire_deps
+
+.. autofunction:: wire_decode
+
+Live references
+---------------
+
+.. autoclass:: ordec.core.ordb.base.LiveRef
+
+.. autoclass:: ordec.core.ordb.base.FarRef
+
+.. autoclass:: ExportTable
+  :members:
+
+Want/have exchange
+------------------
+
+.. autoclass:: WireSender
+  :members:
+
+.. autoclass:: WireReceiver
+  :members:
+
+``tests/test_wire_subprocess.py`` demonstrates the full stack end to end:
+an unwired schematic is transferred to a cold subprocess over pipes,
+auto-wired there and transferred back, with symbols served from the
+store instead of being retransmitted and LiveRefs crossing as FarRefs
+that resolve back to the identical live objects at home.

--- a/docs/ord_tutorial.py
+++ b/docs/ord_tutorial.py
@@ -423,7 +423,7 @@ cell LayoutDemo:
                 ! .ly == in_bar.uy + 120
 # -
 # + tags=["remove-input"]
-_, layout_data = LayoutDemo().layout.webdata()
+_, layout_data = LayoutDemo().layout.webdata_static()
 lx, ly, ux, uy = layout_data["extent"]
 
 svg = ET.Element(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "inotify-simple>=1.3.0",
     "python-gdsii>=0.2.1",
     "sc-leflib>=0.5.1",
+    "cbor2>=6.0.0",
 ]
 dynamic = ["version"]
 license = "Apache-2.0"

--- a/src/ordec/core/ordb/base.py
+++ b/src/ordec/core/ordb/base.py
@@ -1732,11 +1732,45 @@ class FrozenSubgraph(Subgraph):
         self._nid_alloc = nid_alloc
         self._backend = backend
         self._cached_hash = None
-        self._cached_wire_hash = None # memoized by ordec.core.wire.wire_hash
+        self._cached_wire_hash = None # memoized by wire_hash()
         self._root_cursor = self.cursor_at(0)
 
     def __copy__(self) -> 'FrozenSubgraph':
         return self # Since FrozenSubgraph is immutable, copies are never needed?!
+
+    # Wire-layer API: canonical CBOR serialization and session-scoped
+    # hashing. The implementation lives in ordec.core.wire, which depends on
+    # this module; the deferred imports below keep that dependency one-way
+    # at import time.
+
+    def wire_encode(self) -> bytes:
+        """
+        Canonical CBOR wire bytes of this subgraph. Nested SubgraphRefs are
+        represented by their wire_hash; use wire_deps() to collect the
+        referenced subgraphs for transmission.
+        """
+        from ..wire import encode_subgraph
+        return encode_subgraph(self)
+
+    def wire_hash(self) -> bytes:
+        """
+        Session-scoped SHA-256 wire hash (32 bytes) of this subgraph,
+        memoized. Covers transitive SubgraphRef dependencies (Merkle-style).
+        """
+        h = self._cached_wire_hash
+        if h is None:
+            from ..wire import compute_wire_hash
+            h = self._cached_wire_hash = compute_wire_hash(self)
+        return h
+
+    def wire_deps(self) -> dict:
+        """
+        Transitive SubgraphRef dependencies of this subgraph, keyed by their
+        wire_hash. Suitable as the deps argument of
+        ordec.core.wire.wire_decode.
+        """
+        from ..wire import collect_wire_deps
+        return collect_wire_deps(self)
 
     def copy(self):
         return self # No need to copy frozen subgraph

--- a/src/ordec/core/ordb/base.py
+++ b/src/ordec/core/ordb/base.py
@@ -1763,25 +1763,26 @@ class FrozenSubgraph(Subgraph):
         Canonical CBOR wire bytes of this subgraph, with LiveRefs exported
         via the given ExportTable. Nested SubgraphRefs are represented by
         their wire_hash; use wire_deps() to collect the referenced subgraphs
-        for transmission.
+        for transmission. The wire hash is a digest of these bytes and is
+        memoized as a side effect.
         """
-        from ..wire import encode_subgraph
-        return encode_subgraph(self, ept)
+        from ..wire import encode_subgraph, hash_wire_bytes
+        data = encode_subgraph(self, ept)
+        self._cached_wire_hash = (ept, hash_wire_bytes(data))
+        return data
 
     def wire_hash(self, ept) -> bytes:
         """
         Endpoint-scoped SHA-256 wire hash (32 bytes) of this subgraph under
         the given ExportTable, memoized per table (single entry; the normal
-        case is one table per process). Covers transitive SubgraphRef
+        case is one table per connection). Covers transitive SubgraphRef
         dependencies (Merkle-style).
         """
         cached = self._cached_wire_hash
         if cached is not None and cached[0] is ept:
             return cached[1]
-        from ..wire import compute_wire_hash
-        h = compute_wire_hash(self, ept)
-        self._cached_wire_hash = (ept, h)
-        return h
+        self.wire_encode(ept) # memoizes the hash, bytes are discarded
+        return self._cached_wire_hash[1]
 
     def wire_deps(self, ept) -> dict:
         """

--- a/src/ordec/core/ordb/base.py
+++ b/src/ordec/core/ordb/base.py
@@ -360,7 +360,52 @@ class ExternalRef(Attr):
         if not isinstance(val, int):
             raise TypeError('Only None, int or Node can be assigned to ExternalRef.')
         return val
-            
+
+
+@public
+class FarRef:
+    """
+    Placeholder for a live object residing on a foreign endpoint. FarRefs are
+    created when decoding a :class:`LiveRef` attribute whose export reference
+    was minted by a different process (see ordec.core.wire); they cannot be
+    resolved locally. Equality and hash use (endpoint_id, obj_id) only; name
+    is human-readable metadata chosen by the exporting endpoint.
+    """
+    __slots__ = ('endpoint_id', 'obj_id', 'name')
+
+    def __init__(self, endpoint_id: bytes, obj_id: int, name: str=''):
+        self.endpoint_id = endpoint_id
+        self.obj_id = obj_id
+        self.name = name
+
+    def __eq__(self, other):
+        if not isinstance(other, FarRef):
+            return NotImplemented
+        return (self.endpoint_id, self.obj_id) == (other.endpoint_id, other.obj_id)
+
+    def __hash__(self):
+        return hash((FarRef, self.endpoint_id, self.obj_id))
+
+    def __repr__(self):
+        return f"FarRef({self.endpoint_id.hex()}, {self.obj_id}, name={self.name!r})"
+
+@public
+class LiveRef(Attr):
+    """
+    Defines a node attribute holding a live Python object (e.g. a Cell) that
+    stays resident on its endpoint. In-process, the object is stored in the
+    node tuple directly, like a plain Attr value. On the wire
+    (ordec.core.wire), the value is replaced by an export reference; decoding
+    a reference minted by a foreign endpoint yields an opaque :class:`FarRef`,
+    which is therefore also an accepted value.
+
+    Args:
+        type: The type that locally assigned values must be an instance of.
+    """
+    def __init__(self, type: type, **kwargs):
+        super().__init__(type=type,
+            typecheck_custom=lambda val: isinstance(val, (type, FarRef)),
+            **kwargs)
 
 @public
 class Index(GenericIndex):
@@ -659,6 +704,13 @@ class NodeTuple(tuple):
 # Register NodeTuple as virtual subclass of Inserter. Combining tuple and ABC seems like it could cause problems.
 Inserter.register(NodeTuple)
 
+#: Maps declared wire_ids to their Node classes (see ordec.core.wire). Node
+#: classes opt into wire serialization by declaring wire_id = WIRE_DOMAIN | n
+#: in their class body, with WIRE_DOMAIN a per-module constant.
+wire_registry = {}
+
+WIRE_DOMAIN = 1 << 16 # ordb-internal node types (NPath)
+
 class NodeMeta(type):
     @staticmethod
     def _collect_raw_attrs(d, bases):
@@ -752,6 +804,24 @@ class NodeMeta(type):
             cls.Tuple.__module__ = cls.__module__
             cls.Mutable.__module__ = cls.__module__
             cls.Frozen.__module__ = cls.__module__
+
+            # Register a wire_id declared in this class's own body (inherited
+            # wire_ids are deliberately not registered: subclasses must declare
+            # their own to be wire-serializable). Re-registration under the
+            # same (module, qualname) is allowed, as module reloads (server
+            # purge_modules, pytest) re-execute class definitions.
+            wid = attrs.get('wire_id')
+            if wid is not None:
+                if not isinstance(wid, int) or wid <= 0:
+                    raise TypeError(f"{name}: wire_id must be a positive int.")
+                other = wire_registry.get(wid)
+                if other is not None and (other.__module__, other.__qualname__) \
+                        != (cls.__module__, cls.__qualname__):
+                    raise TypeError(
+                        f"wire_id {wid:#x} of {name} is already used by "
+                        f"{other.__module__}.{other.__qualname__}."
+                    )
+                wire_registry[wid] = cls
 
         return super().__init__(name, bases, attrs)
 
@@ -1115,6 +1185,8 @@ class SubgraphRoot(NonLeafNode):
     Each subgraph has a single SubgraphRoot node. The subclass of SubgraphRoot
     defines what kind of design data the subgraph represents.
     """
+    # No wire_id here: SubgraphRoot is never serialized as an exact class;
+    # every wire-serializable root subclass declares its own.
 
     def __new__(cls, **kwargs):
         # __new__ calls super().__new__ via SubgraphRoot.Tuple(), but wraps the result in a Subgraph object.
@@ -1653,13 +1725,14 @@ class FrozenSubgraph(Subgraph):
     not checked for equivalence, as it should be equal by construction.
     """
 
-    __slots__=('_cached_hash',)
+    __slots__=('_cached_hash', '_cached_wire_hash')
     def __init__(self, nodes, index, nid_alloc, backend):
         self._nodes = nodes
         self._index = index
         self._nid_alloc = nid_alloc
         self._backend = backend
         self._cached_hash = None
+        self._cached_wire_hash = None # memoized by ordec.core.wire.wire_hash
         self._root_cursor = self.cursor_at(0)
 
     def __copy__(self) -> 'FrozenSubgraph':
@@ -1832,3 +1905,4 @@ class NPath(Node):
     idx_path_of = Index(ref, unique=True)
 
     in_subgraphs = [SubgraphRoot]
+    wire_id = WIRE_DOMAIN | 1

--- a/src/ordec/core/ordb/base.py
+++ b/src/ordec/core/ordb/base.py
@@ -1263,11 +1263,26 @@ class SubgraphRoot(NonLeafNode):
     def __copy__(self) -> 'Self':
         return self.copy()
 
-    def webdata(self):
+    def webdata(self, ept):
+        """
+        Web representation as (viewtype, data), rendered for the endpoint
+        owning the given ExportTable. The default implementation delegates to
+        webdata_static(); views whose webdata depends on the endpoint (e.g.
+        wire hashes in LVS/DRC reports) override this method instead.
+        """
+        return self.webdata_static()
+
+    def webdata_static(self):
+        """
+        Endpoint-independent web representation, same (viewtype, data) shape
+        as webdata(). Exists only for views whose output cannot depend on an
+        ExportTable, so it may be called without a connection (e.g. by
+        Svg.from_view at report construction time).
+        """
         from ..schema import Report
         report = Report()
         report.html(self.tables(html=True))
-        return report.webdata()
+        return report.webdata_static()
 
 class SubgraphQueryMixin:
     __slots__ = ()
@@ -1732,7 +1747,7 @@ class FrozenSubgraph(Subgraph):
         self._nid_alloc = nid_alloc
         self._backend = backend
         self._cached_hash = None
-        self._cached_wire_hash = None # memoized by wire_hash()
+        self._cached_wire_hash = None # (ept, hash) memoized by wire_hash()
         self._root_cursor = self.cursor_at(0)
 
     def __copy__(self) -> 'FrozenSubgraph':
@@ -1743,34 +1758,39 @@ class FrozenSubgraph(Subgraph):
     # this module; the deferred imports below keep that dependency one-way
     # at import time.
 
-    def wire_encode(self) -> bytes:
+    def wire_encode(self, ept) -> bytes:
         """
-        Canonical CBOR wire bytes of this subgraph. Nested SubgraphRefs are
-        represented by their wire_hash; use wire_deps() to collect the
-        referenced subgraphs for transmission.
+        Canonical CBOR wire bytes of this subgraph, with LiveRefs exported
+        via the given ExportTable. Nested SubgraphRefs are represented by
+        their wire_hash; use wire_deps() to collect the referenced subgraphs
+        for transmission.
         """
         from ..wire import encode_subgraph
-        return encode_subgraph(self)
+        return encode_subgraph(self, ept)
 
-    def wire_hash(self) -> bytes:
+    def wire_hash(self, ept) -> bytes:
         """
-        Session-scoped SHA-256 wire hash (32 bytes) of this subgraph,
-        memoized. Covers transitive SubgraphRef dependencies (Merkle-style).
+        Endpoint-scoped SHA-256 wire hash (32 bytes) of this subgraph under
+        the given ExportTable, memoized per table (single entry; the normal
+        case is one table per process). Covers transitive SubgraphRef
+        dependencies (Merkle-style).
         """
-        h = self._cached_wire_hash
-        if h is None:
-            from ..wire import compute_wire_hash
-            h = self._cached_wire_hash = compute_wire_hash(self)
+        cached = self._cached_wire_hash
+        if cached is not None and cached[0] is ept:
+            return cached[1]
+        from ..wire import compute_wire_hash
+        h = compute_wire_hash(self, ept)
+        self._cached_wire_hash = (ept, h)
         return h
 
-    def wire_deps(self) -> dict:
+    def wire_deps(self, ept) -> dict:
         """
         Transitive SubgraphRef dependencies of this subgraph, keyed by their
-        wire_hash. Suitable as the deps argument of
-        ordec.core.wire.wire_decode.
+        wire_hash under the given ExportTable. Suitable as the deps argument
+        of ordec.core.wire.wire_decode.
         """
         from ..wire import collect_wire_deps
-        return collect_wire_deps(self)
+        return collect_wire_deps(self, ept)
 
     def copy(self):
         return self # No need to copy frozen subgraph

--- a/src/ordec/core/schema/base.py
+++ b/src/ordec/core/schema/base.py
@@ -129,6 +129,8 @@ class MixinClosedPolygon:
         d.append("Z")
         return ' '.join(d)
 
+WIRE_DOMAIN = 2 << 16
+
 class GenericPoly(Node):
     # Concrete subclasses declare their own in_subgraphs.
     in_subgraphs = []
@@ -188,6 +190,7 @@ class GenericPolyI(GenericPoly):
 class PolyVec2R(Node):
     """One vertex of a Vec2R polygonal chain or polygon."""
     in_subgraphs = [] # Consuming schema modules append their subgraph roots.
+    wire_id = WIRE_DOMAIN | 1
     ref    = LocalRef(GenericPolyR, optional=False)
     order   = Attr(int, optional=False) #: Order of the point in the polygonal chain
     pos     = Attr(Vec2R, factory=coerce_tuple(Vec2R, 2))
@@ -199,6 +202,7 @@ class PolyVec2R(Node):
 class PolyVec2I(Node):
     """One vertex of a Vec2I polygonal chain or polygon."""
     in_subgraphs = [] # Consuming schema modules append their subgraph roots.
+    wire_id = WIRE_DOMAIN | 2
     ref    = LocalRef(GenericPolyI, optional=False)
     order   = Attr(int, optional=False) #: Order of the point in the polygonal chain
     pos     = ConstrainableAttr(Vec2I, factory=coerce_tuple(Vec2I, 2),

--- a/src/ordec/core/schema/drc.py
+++ b/src/ordec/core/schema/drc.py
@@ -32,9 +32,9 @@ class DrcReport(SubgraphRoot):
             counts[name] = counts.get(name, 0) + 1
         return counts
 
-    def webdata(self):
+    def webdata(self, ept):
         from ...layout.drc import webdata
-        return webdata(self)
+        return webdata(self, ept)
 
 
 @public

--- a/src/ordec/core/schema/drc.py
+++ b/src/ordec/core/schema/drc.py
@@ -9,10 +9,13 @@ from ..context import AssignableViewContext
 from .base import coerce_tuple, PathEndType, GenericPolyI, PolyVec2I
 from .layout import Layout
 
+WIRE_DOMAIN = 6 << 16
+
 @public
 class DrcReport(SubgraphRoot):
     """DRC report containing design rule check results."""
     view_context = AssignableViewContext
+    wire_id = WIRE_DOMAIN | 1
 
     ref_layout = SubgraphRef(Layout)
     top_cell_name = Attr(str)
@@ -38,6 +41,7 @@ class DrcReport(SubgraphRoot):
 class DrcCategory(Node):
     """Category of DRC violations (e.g., 'Minimum spacing', 'Minimum width')."""
     in_subgraphs = [DrcReport]
+    wire_id = WIRE_DOMAIN | 2
 
     name = Attr(str)
     description = Attr(str, default='')
@@ -58,6 +62,7 @@ class DrcCell(Node):
     (e.g. KLayout variant cells like 'sub$VAR1').
     """
     in_subgraphs = [DrcReport]
+    wire_id = WIRE_DOMAIN | 3
 
     name = Attr(str)
     ref_layout = SubgraphRef(Layout, optional=True)
@@ -67,6 +72,7 @@ class DrcCell(Node):
 class DrcItem(Node):
     """Individual DRC violation item within a category."""
     in_subgraphs = [DrcReport]
+    wire_id = WIRE_DOMAIN | 4
 
     category = LocalRef(DrcCategory, optional=False)
     category_idx = Index(category)
@@ -79,6 +85,7 @@ class DrcItem(Node):
 class DrcBox(Node):
     """Box geometry in a DRC item."""
     in_subgraphs = [DrcReport]
+    wire_id = WIRE_DOMAIN | 5
 
     item = LocalRef(DrcItem, optional=False)
     item_idx = Index(item, sortkey=lambda node: node.order)
@@ -92,6 +99,7 @@ class DrcBox(Node):
 class DrcEdge(Node):
     """Edge geometry in a DRC item."""
     in_subgraphs = [DrcReport]
+    wire_id = WIRE_DOMAIN | 6
 
     item = LocalRef(DrcItem, optional=False)
     item_idx = Index(item, sortkey=lambda node: node.order)
@@ -106,6 +114,7 @@ class DrcEdge(Node):
 class DrcEdgePair(Node):
     """Edge pair geometry in a DRC item (e.g., for spacing violations)."""
     in_subgraphs = [DrcReport]
+    wire_id = WIRE_DOMAIN | 7
 
     item = LocalRef(DrcItem, optional=False)
     item_idx = Index(item, sortkey=lambda node: node.order)
@@ -128,6 +137,7 @@ class DrcPolyBase(GenericPolyI):
 class DrcPoly(DrcPolyBase):
     """Polygon geometry in a DRC item."""
     in_subgraphs = [DrcReport]
+    wire_id = WIRE_DOMAIN | 8
     vertex_cls = PolyVec2I
 
     item = LocalRef(DrcItem, optional=False)
@@ -148,6 +158,7 @@ class DrcPathBase(GenericPolyI):
 class DrcPath(DrcPathBase):
     """Path geometry in a DRC item."""
     in_subgraphs = [DrcReport]
+    wire_id = WIRE_DOMAIN | 9
     vertex_cls = PolyVec2I
 
     item = LocalRef(DrcItem, optional=False)
@@ -160,6 +171,7 @@ class DrcPath(DrcPathBase):
 class DrcText(Node):
     """Text geometry in a DRC item."""
     in_subgraphs = [DrcReport]
+    wire_id = WIRE_DOMAIN | 10
 
     item = LocalRef(DrcItem, optional=False)
     item_idx = Index(item, sortkey=lambda node: node.order)
@@ -174,6 +186,7 @@ class DrcText(Node):
 class DrcValue(Node):
     """Arbitrary string value in a DRC item."""
     in_subgraphs = [DrcReport]
+    wire_id = WIRE_DOMAIN | 11
 
     item = LocalRef(DrcItem, optional=False)
     item_idx = Index(item, sortkey=lambda node: node.order)

--- a/src/ordec/core/schema/layout.py
+++ b/src/ordec/core/schema/layout.py
@@ -130,11 +130,9 @@ class Layout(SubgraphRoot):
     symbol = SubgraphRef(Symbol) #: All LayoutPins in this subgraph reference this symbol.
     ref_layers = SubgraphRef(LayerStack) #: All .layer attributes of nodes in this subgraph reference this LayerStack.
 
-    def webdata(self):
+    def webdata_static(self):
         from ...layout.webdata import webdata
         return webdata(self)
-        #from ..render import render
-        #return render(self).webdata()
 
 @public
 class LayoutLabel(Node):

--- a/src/ordec/core/schema/layout.py
+++ b/src/ordec/core/schema/layout.py
@@ -15,6 +15,8 @@ from .base import (
 )
 from .schematic import Symbol, Pin
 
+WIRE_DOMAIN = 4 << 16
+
 class MixinLayoutPinnable:
     """Mixin for layout shapes that can have LayoutPin associations."""
     __slots__ = ()
@@ -35,12 +37,14 @@ class MixinLayoutPinnable:
 
 @public
 class LayerStack(SubgraphRoot):
-    cell = Attr(Cell)
+    wire_id = WIRE_DOMAIN | 1
+    cell = LiveRef(Cell)
     unit = Attr(R)
 
 @public
 class Layer(NonLeafNode):
     in_subgraphs = [LayerStack]
+    wire_id = WIRE_DOMAIN | 2
     gdslayer_text = Attr(GdsLayer)
     gdslayer_shapes = Attr(GdsLayer)
 
@@ -78,12 +82,14 @@ class Layer(NonLeafNode):
 @public
 class RoutingSpec(SubgraphRoot):
     """Routing specification for SRouter, decoupled from LayerStack."""
+    wire_id = WIRE_DOMAIN | 3
     ref_layers = SubgraphRef(LayerStack, optional=False)
 
 @public
 class RoutingSpecLayer(Node):
     """Per-layer routing parameters for SRouter."""
     in_subgraphs = [RoutingSpec]
+    wire_id = WIRE_DOMAIN | 4
 
     layer = ExternalRef(Layer, of_subgraph=lambda c: c.root.ref_layers, optional=False)
 
@@ -118,8 +124,9 @@ class Layout(SubgraphRoot):
     hierarchical instances of other Layout subgraphs.
     """
     view_context = LayoutViewContext
+    wire_id = WIRE_DOMAIN | 5
 
-    cell = Attr(Cell)
+    cell = LiveRef(Cell)
     symbol = SubgraphRef(Symbol) #: All LayoutPins in this subgraph reference this symbol.
     ref_layers = SubgraphRef(LayerStack) #: All .layer attributes of nodes in this subgraph reference this LayerStack.
 
@@ -136,6 +143,7 @@ class LayoutLabel(Node):
     prefer :class:`LayoutPin` to raw LayoutLabels.
     """
     in_subgraphs = [Layout]
+    wire_id = WIRE_DOMAIN | 6
 
     layer = ExternalRef(Layer, of_subgraph=lambda c: c.root.ref_layers)
     pos = ConstrainableAttr(Vec2I, factory=coerce_tuple(Vec2I, 2),
@@ -153,6 +161,7 @@ class LayoutPoly(GenericPolyI, MixinClosedPolygon, MixinLayoutPinnable):
     are flipped automatically to CCW orientation.
     """
     in_subgraphs = [Layout]
+    wire_id = WIRE_DOMAIN | 7
 
     layer = ExternalRef(Layer, of_subgraph=lambda c: c.root.ref_layers)
 
@@ -178,12 +187,14 @@ class LayoutPathBase(GenericPolyI):
 class LayoutPath(LayoutPathBase, MixinPolygonalChain, MixinLayoutPinnable):
     """Layout path (polygonal chain with width)."""
     in_subgraphs = [Layout]
+    wire_id = WIRE_DOMAIN | 8
 
 
 @public
 class LayoutRect(Node, MixinLayoutPinnable):
     """Layout rectangle."""
     in_subgraphs = [Layout]
+    wire_id = WIRE_DOMAIN | 9
 
     layer = ExternalRef(Layer, of_subgraph=lambda c: c.root.ref_layers)
     rect = ConstrainableAttr(Rect4I, factory=coerce_tuple(Rect4I, 4),
@@ -340,6 +351,7 @@ class LayoutInstanceSubcursor(tuple):
 class LayoutInstance(Node):
     """Hierarchical layout instance, equivalent to GDS SRef."""
     in_subgraphs = [Layout]
+    wire_id = WIRE_DOMAIN | 10
 
     pos = ConstrainableAttr(Vec2I, factory=coerce_tuple(Vec2I, 2),
         placeholder=Vec2LinearTerm)
@@ -363,6 +375,7 @@ class LayoutInstanceArray(LayoutInstance):
     """Hierarchical layout instance array, equivalent to GDS ARef."""
 
     in_subgraphs = [Layout]
+    wire_id = WIRE_DOMAIN | 11
 
     #: Number of columns or None (=1 column). If None, LayoutInstanceSubcursor
     #:  indices are collaposed to row-only.
@@ -392,6 +405,7 @@ class LayoutPin(Node):
     The associated shape can be a LayoutPoly, LayoutRect, or LayoutPath.
     """
     in_subgraphs = [Layout]
+    wire_id = WIRE_DOMAIN | 12
 
     ref = LocalRef(LayoutPoly|LayoutPath,
         refcheck_custom=lambda val: issubclass(val, (LayoutPoly, LayoutRect, LayoutPath)),

--- a/src/ordec/core/schema/lvs.py
+++ b/src/ordec/core/schema/lvs.py
@@ -11,6 +11,8 @@ from .base import coerce_tuple
 from .schematic import Schematic, Net, SchemInstance
 from .layout import Layout
 
+WIRE_DOMAIN = 7 << 16
+
 @public
 class LvsStatus(Enum):
     """Status of an LVS comparison item or circuit pair, following KLayout's
@@ -49,6 +51,7 @@ class LvsItemType(Enum):
 class LvsReport(SubgraphRoot):
     """LVS report containing layout vs. schematic comparison results."""
     view_context = AssignableViewContext
+    wire_id = WIRE_DOMAIN | 1
 
     ref_layout = SubgraphRef(Layout, optional=True)
     ref_schematic = SubgraphRef(Schematic, optional=True)
@@ -67,6 +70,7 @@ class LvsReport(SubgraphRoot):
 class LvsCircuitPair(Node):
     """Comparison record for a layout cell vs schematic cell pair."""
     in_subgraphs = [LvsReport]
+    wire_id = WIRE_DOMAIN | 2
 
     #: Direct ref to the Layout being compared. Only set for top-level circuit
     #: (where LVSDB cell name matches top_cell); None for subcircuits.
@@ -85,6 +89,7 @@ class LvsCircuitPair(Node):
 class LvsItem(Node):
     """Individual LVS comparison item (net, device, pin, or subcircuit)."""
     in_subgraphs = [LvsReport]
+    wire_id = WIRE_DOMAIN | 3
 
     circuit = LocalRef(LvsCircuitPair, optional=False)
     circuit_idx = Index(circuit)

--- a/src/ordec/core/schema/lvs.py
+++ b/src/ordec/core/schema/lvs.py
@@ -61,9 +61,9 @@ class LvsReport(SubgraphRoot):
     def clean(self):
         return self.status in (LvsStatus.Match, LvsStatus.MatchWarning)
 
-    def webdata(self):
+    def webdata(self, ept):
         from ...layout.lvs import webdata
-        return webdata(self)
+        return webdata(self, ept)
 
 
 @public

--- a/src/ordec/core/schema/report.py
+++ b/src/ordec/core/schema/report.py
@@ -9,6 +9,8 @@ from public import public
 from ..ordb import *
 from ..context import ReportViewContext
 
+WIRE_DOMAIN = 8 << 16
+
 @public
 class Report(SubgraphRoot):
     """
@@ -18,6 +20,7 @@ class Report(SubgraphRoot):
     append-style API for building reports programmatically.
     """
     view_context = ReportViewContext
+    wire_id = WIRE_DOMAIN | 1
 
     fill_height = Attr(bool, default=False, optional=False)
 
@@ -98,6 +101,7 @@ class Markdown(ReportElement):
     TeX math delimited by $...$ (inline) or $$...$$ (display) is rendered
     via KaTeX; dollar signs inside code spans are left alone.
     """
+    wire_id = WIRE_DOMAIN | 2
     markdown = Attr(str, optional=False)
 
     # TeX math spans are protected from markdown2 (which would otherwise
@@ -155,6 +159,7 @@ class Markdown(ReportElement):
 @public
 class PreformattedText(ReportElement):
     """Preformatted text rendered using a monospace font."""
+    wire_id = WIRE_DOMAIN | 3
     text = Attr(str, optional=False)
 
     def element_webdata(self) -> dict:
@@ -164,6 +169,7 @@ class PreformattedText(ReportElement):
 @public
 class Html(ReportElement):
     """Raw HTML content rendered directly in the web interface."""
+    wire_id = WIRE_DOMAIN | 4
     html = Attr(str, optional=False)
 
     def element_webdata(self) -> dict:
@@ -176,6 +182,7 @@ class PassFail(ReportElement):
     Single pass/fail check result, e.g. for course lessons. A lesson is
     considered passed when all PassFail elements of its report pass.
     """
+    wire_id = WIRE_DOMAIN | 5
     label = Attr(str, optional=False) #: short name of the check
     passed = Attr(bool, optional=False)
     instructions = Attr(str, default="", optional=False) #: what the user should achieve / status details; failing checks only
@@ -196,6 +203,7 @@ class PassFail(ReportElement):
 @public
 class Svg(ReportElement):
     """Static SVG element rendered without zoom."""
+    wire_id = WIRE_DOMAIN | 6
     inner = Attr(str, optional=False) #: SVG markup inside the <svg> element
     viewbox_min_x = Attr(float, optional=False) #: viewBox left edge
     viewbox_min_y = Attr(float, optional=False) #: viewBox top edge
@@ -257,10 +265,12 @@ def coerce_plot_x(x):
 class PlotGroup(Node):
     """Groups Plot2D elements that share a synchronized x-axis."""
     in_subgraphs = [Report]
+    wire_id = WIRE_DOMAIN | 7
 
 @public
 class Plot2D(ReportElement):
     """2D plot element rendered with the frontend simulation plot component."""
+    wire_id = WIRE_DOMAIN | 8
     x = Attr(tuple, optional=False, factory=coerce_plot_x)
     xlabel = Attr(str, default="", optional=False)
     ylabel = Attr(str, default="", optional=False)
@@ -295,6 +305,7 @@ def coerce_plot_values(values):
 class Plot2DSeries(Node):
     """A single data series belonging to a Plot2D element."""
     in_subgraphs = [Report]
+    wire_id = WIRE_DOMAIN | 9
     ref = LocalRef(Plot2D, optional=False)
     ref_idx = Index(ref)
     name = Attr(str, optional=False)

--- a/src/ordec/core/schema/report.py
+++ b/src/ordec/core/schema/report.py
@@ -73,7 +73,7 @@ class Report(SubgraphRoot):
         from ...sim.helpers import bode_plot
         bode_plot(self, *signals, **kwargs)
 
-    def webdata(self):
+    def webdata_static(self):
         return "report", {
             "elements": [element.element_webdata() for element in self.elements()],
             "fill_height": self.fill_height,
@@ -214,8 +214,8 @@ class Svg(ReportElement):
 
     @classmethod
     def from_view(cls, view) -> "Svg":
-        """Creates an SVG report element from an object exposing webdata()."""
-        view_type, data = view.webdata()
+        """Creates an SVG report element from an object exposing webdata_static()."""
+        view_type, data = view.webdata_static()
         if view_type != "svg":
             raise ValueError(f"Expected svg webdata, got {view_type!r}")
         vb = data["viewbox"]

--- a/src/ordec/core/schema/schematic.py
+++ b/src/ordec/core/schema/schematic.py
@@ -66,7 +66,7 @@ class MixinRenderable:
     def _repr_svg_(self):
         return self.render().svg().decode('ascii'), {'isolated': False}
 
-    def webdata(self):
+    def webdata_static(self):
         return self.render().webdata()
 
 

--- a/src/ordec/core/schema/schematic.py
+++ b/src/ordec/core/schema/schematic.py
@@ -16,6 +16,8 @@ from .base import (
     coerce_tuple, SourceLocInfo, MixinPolygonalChain, GenericPolyR, PolyVec2R,
 )
 
+WIRE_DOMAIN = 3 << 16
+
 # Enums
 # -----
 
@@ -72,9 +74,10 @@ class MixinRenderable:
 class Symbol(MixinRenderable, SubgraphRoot):
     """A symbol of an individual cell."""
     view_context = SymbolViewContext
+    wire_id = WIRE_DOMAIN | 1
     outline = Attr(Rect4R, factory=coerce_tuple(Rect4R, 4))
     caption = Attr(str)
-    cell = Attr(Cell)
+    cell = LiveRef(Cell)
 
     def portmap(self, **kwargs):
         def inserter_func(main, sgu, primary_nid):
@@ -92,6 +95,7 @@ class Symbol(MixinRenderable, SubgraphRoot):
 class Pin(Node):
     """Pins are single wire connections exposed through a symbol."""
     in_subgraphs = [Symbol]
+    wire_id = WIRE_DOMAIN | 2
 
     pintype = Attr(PinType, default=PinType.Inout)
     pos     = Attr(Vec2R, factory=coerce_tuple(Vec2R, 2))
@@ -101,11 +105,13 @@ class Pin(Node):
 class SymbolPoly(GenericPolyR, MixinPolygonalChain):
     """A drawn polygonal chain in Symbol. For visual purposes only."""
     in_subgraphs = [Symbol]
+    wire_id = WIRE_DOMAIN | 3
 
 @public
 class SymbolArc(Node):
     """A drawn circle or circular segment in Symbol. For visual purposes only."""
     in_subgraphs = [Symbol]
+    wire_id = WIRE_DOMAIN | 4
 
     pos         = Attr(Vec2R, factory=coerce_tuple(Vec2R, 2)) #: Center point
     radius      = Attr(R) #: Radius of the arc.
@@ -151,9 +157,10 @@ class SymbolArc(Node):
 class Schematic(MixinRenderable, SubgraphRoot):
     """A schematic of an individual cell."""
     view_context = SchematicViewContext
+    wire_id = WIRE_DOMAIN | 5
     symbol = SubgraphRef(Symbol)
     outline = Attr(Rect4R, factory=coerce_tuple(Rect4R, 4))
-    cell = Attr(Cell)
+    cell = LiveRef(Cell)
     default_supply = LocalRef('Net', refcheck_custom=lambda val: issubclass(val, Net))
     default_ground = LocalRef('Net', refcheck_custom=lambda val: issubclass(val, Net))
 
@@ -203,6 +210,7 @@ class NegatedWireOperand:
 @public
 class Net(Node):
     in_subgraphs = [Schematic]
+    wire_id = WIRE_DOMAIN | 6
     pin = ExternalRef(Pin, of_subgraph=lambda c: c.root.symbol)
     auto_wire = Attr(bool, default=True) #: Controls whether the Net is auto-wired
 
@@ -237,6 +245,7 @@ class SchemPort(Node):
     Port of a Schematic, corresponding to a Pin of the schematic's Symbol.
     """
     in_subgraphs = [Schematic]
+    wire_id = WIRE_DOMAIN | 7
 
     ref = LocalRef(Net, optional=False)
     ref_idx = Index(ref, unique=True)
@@ -249,6 +258,7 @@ class SchemPort(Node):
 class SchemWire(GenericPolyR, MixinPolygonalChain):
     """A drawn schematic wire representing an electrical connection."""
     in_subgraphs = [Schematic]
+    wire_id = WIRE_DOMAIN | 8
 
     ref = LocalRef(Net, optional=False)
     ref_idx = Index(ref)
@@ -323,6 +333,7 @@ class SchemInstance(Node, MixinSourceLoc):
     An instance of a Symbol in a Schematic (foundation for schematic hierarchy).
     """
     in_subgraphs = [Schematic]
+    wire_id = WIRE_DOMAIN | 9
 
     pos = ConstrainableAttr(Vec2R, placeholder=Vec2LinearTerm,
         factory=coerce_tuple(Vec2R, 2))
@@ -359,6 +370,7 @@ class SchemInstance(Node, MixinSourceLoc):
 class SchemInstanceConn(Node):
     """Maps one Pin of a SchemInstance to a Net of its Schematic."""
     in_subgraphs = [Schematic]
+    wire_id = WIRE_DOMAIN | 10
 
     ref = LocalRef(SchemInstance, optional=False)
     ref_idx = Index(ref)
@@ -439,12 +451,13 @@ class SchemInstanceUnresolved(Node, MixinSourceLoc):
             self._inst % SchemInstanceUnresolvedParameter(name=name, value=value)
 
     in_subgraphs = [Schematic]
+    wire_id = WIRE_DOMAIN | 11
 
     pos = ConstrainableAttr(Vec2R, placeholder=Vec2LinearTerm,
         factory=coerce_tuple(Vec2R, 2))
     orientation = Attr(D4, default=D4.R0)
 
-    resolver = Attr(object) # closure?
+    resolver = LiveRef(object)
 
     @property
     def params(self):
@@ -472,6 +485,7 @@ class SchemInstanceUnresolved(Node, MixinSourceLoc):
 class SchemInstanceUnresolvedConn(Node):
     """Unresolved SchemInstanceConn."""
     in_subgraphs = [Schematic]
+    wire_id = WIRE_DOMAIN | 12
 
     ref = LocalRef(SchemInstanceUnresolved, optional=False)
     ref_idx = Index(ref)
@@ -483,6 +497,7 @@ class SchemInstanceUnresolvedConn(Node):
 @public
 class SchemInstanceUnresolvedParameter(Node):
     in_subgraphs = [Schematic]
+    wire_id = WIRE_DOMAIN | 13
 
     ref = LocalRef(SchemInstanceUnresolved, optional=False)
     ref_idx = Index(ref)
@@ -497,6 +512,7 @@ class SchemTapPoint(Node):
     using the net's name.
     """
     in_subgraphs = [Schematic]
+    wire_id = WIRE_DOMAIN | 14
 
     ref = LocalRef(Net, optional=False)
     ref_idx = Index(ref)
@@ -512,6 +528,7 @@ class SchemTapPoint(Node):
 class SchemConnPoint(Node):
     """A schematic point to indicate a connection at a 3- or 4-way junction of wires."""
     in_subgraphs = [Schematic]
+    wire_id = WIRE_DOMAIN | 15
     ref = LocalRef(Net, optional=False)
     ref_idx = Index(ref)
 
@@ -522,6 +539,7 @@ class SchemConnPoint(Node):
 class SchemErrorMarker(Node):
     """An error marker indicating a schematic check failure."""
     in_subgraphs = [Schematic]
+    wire_id = WIRE_DOMAIN | 16
     ref = LocalRef(Schematic)
     pos = Attr(Vec2R, factory=coerce_tuple(Vec2R, 2))
     align = Attr(D4, default=D4.R0)

--- a/src/ordec/core/schema/simhier.py
+++ b/src/ordec/core/schema/simhier.py
@@ -11,6 +11,8 @@ from ..context import SimulationViewContext
 from ..simarray import SimArray
 from .schematic import Symbol, Schematic, Pin, Net, SchemPort, SchemInstance
 
+WIRE_DOMAIN = 5 << 16
+
 @public
 class SimType(Enum):
     OP = 'op'
@@ -93,9 +95,10 @@ class SimHierarchySubcursor(tuple):
 @public
 class SimHierarchy(SubgraphRoot):
     view_context = SimulationViewContext
+    wire_id = WIRE_DOMAIN | 1
 
     schematic = SubgraphRef(Schematic)
-    cell = Attr(Cell)
+    cell = LiveRef(Cell)
     sim_type = Attr(SimType)
     sim_data = Attr(SimArray) #: Packed simulation result data shared by all SimNet/SimInstance nodes.
     time_field = Attr(str) #: Column name in sim_data for the time axis (transient), or None.
@@ -329,6 +332,7 @@ class SimHierarchy(SubgraphRoot):
 @public
 class SimNet(Node):
     in_subgraphs = [SimHierarchy]
+    wire_id = WIRE_DOMAIN | 2
 
     parent_inst = LocalRef('SimInstance', optional=True,
         refcheck_custom=lambda val: issubclass(val, SimInstance))
@@ -359,6 +363,7 @@ class SimNet(Node):
 @public
 class SimPin(Node):
     in_subgraphs = [SimHierarchy]
+    wire_id = WIRE_DOMAIN | 3
 
     instance = LocalRef('SimInstance', optional=False,
         refcheck_custom=lambda val: issubclass(val, SimInstance))
@@ -381,6 +386,7 @@ class SimPin(Node):
 @public
 class SimParam(Node):
     in_subgraphs = [SimHierarchy]
+    wire_id = WIRE_DOMAIN | 4
 
     instance = LocalRef('SimInstance', optional=False,
         refcheck_custom=lambda val: issubclass(val, SimInstance))
@@ -419,6 +425,7 @@ class SimInstanceParamCursor(tuple):
 @public
 class SimInstance(Node):
     in_subgraphs = [SimHierarchy]
+    wire_id = WIRE_DOMAIN | 5
 
     parent_inst = LocalRef('SimInstance', optional=True,
         refcheck_custom=lambda val: issubclass(val, SimInstance))

--- a/src/ordec/core/schema/simhier.py
+++ b/src/ordec/core/schema/simhier.py
@@ -185,7 +185,7 @@ class SimHierarchy(SubgraphRoot):
         add_sch(schematic, None)
         return simhier
 
-    def webdata(self):
+    def webdata_static(self):
         from ...sim.webdata import webdata
         return webdata(self)
 

--- a/src/ordec/core/wire.py
+++ b/src/ordec/core/wire.py
@@ -228,13 +228,21 @@ def encode_subgraph(sg: FrozenSubgraph, ept: ExportTable) -> bytes:
         rows_by_wid.setdefault(wid, []).append(row)
     return cbor2.dumps([rows_by_wid, sg.nid_alloc.start], canonical=True)
 
+def hash_wire_bytes(data: bytes) -> bytes:
+    """
+    Domain-prefixed SHA-256 (32 bytes) over wire bytes. The wire hash is
+    purely a digest of the encoding, which is what allows
+    FrozenSubgraph.wire_encode() to memoize the hash as a side effect.
+    """
+    return hashlib.sha256(HASH_DOMAIN + data).digest()
+
 def compute_wire_hash(sg: FrozenSubgraph, ept: ExportTable) -> bytes:
     """
-    Domain-prefixed SHA-256 (32 bytes) over encode_subgraph(sg, ept).
-    Backend of FrozenSubgraph.wire_hash(), which memoizes it; always call
-    that instead.
+    Recompute the wire hash from scratch, bypassing the memo that
+    FrozenSubgraph.wire_hash()/wire_encode() maintain. Normal callers use
+    wire_hash(); this exists for memo-independent verification (tests).
     """
-    return hashlib.sha256(HASH_DOMAIN + encode_subgraph(sg, ept)).digest()
+    return hash_wire_bytes(encode_subgraph(sg, ept))
 
 def collect_wire_deps(sg: FrozenSubgraph,
         ept: ExportTable) -> dict[bytes, FrozenSubgraph]:
@@ -417,8 +425,10 @@ class WireSender:
 
     def root_block(self) -> tuple[bytes, bytes]:
         """The unconditionally transmitted first block: (hash, wire bytes)."""
-        return (self.sg.wire_hash(self.ept),
-            self.sg.wire_encode(self.ept))
+        # Encode first: wire_encode memoizes the wire hash as a side
+        # effect, so the wire_hash call below is free.
+        data = self.sg.wire_encode(self.ept)
+        return (self.sg.wire_hash(self.ept), data)
 
     def serve(self, want) -> list[tuple[bytes, bytes]]:
         """Blocks for a want list of hashes; all must have been announced."""

--- a/src/ordec/core/wire.py
+++ b/src/ordec/core/wire.py
@@ -22,6 +22,11 @@ bytes, wire hashes are endpoint-scoped identity: they do not converge
 across endpoints, by design. Wire data must never be stored in durable
 artifacts (.ord files, uistate).
 
+The want/have exchange (WireSender/WireReceiver) transfers a subgraph DAG
+between two endpoints while retransmitting only subgraphs the receiver does
+not already hold in its store; laziness exists on the wire only, in-memory
+SubgraphRefs always hold fully materialized subgraphs.
+
 Wire format (format version is the digit in HASH_DOMAIN):
 
     wire_bytes(sg) = canonical CBOR of [ {wire_id: [[nid, v0, ..., vN], ...]},
@@ -370,3 +375,151 @@ def wire_decode(data: bytes, ept: ExportTable, deps=None) -> Node:
         sg.mutate(sg.nodes, sg.index, range(nid_start, sg.nid_alloc.stop))
     return sg.freeze().root_cursor
 
+# Want/have exchange
+# ------------------
+#
+# Transfers one root subgraph per exchange while retransmitting only the
+# parts of its Merkle DAG that the receiver does not already hold. Message
+# shapes are plain Python values (a block is a (hash, bytes) pair, a want is
+# a list of hashes); framing them is the transport's job. The exchange is
+# lock-step: the sender pushes the root block unconditionally, the receiver
+# answers each delivery with the list of hashes to send next, and an empty
+# answer means the exchange is complete (sound because the sender holds the
+# full DAG and always serves a want list completely).
+
+def collect_child_hashes(data: bytes) -> list[bytes]:
+    """
+    Direct SubgraphRef child hashes occurring in wire bytes, deduplicated,
+    in encounter order. Pass-through CBOR scan; no values are reconstructed.
+    """
+    hashes = {}
+    def hook(tag, shareable):
+        if tag.tag == TAG_SUBGRAPHREF:
+            hashes[bytes(tag.value)] = None
+        return tag
+    try:
+        cbor2.loads(data, tag_hook=hook)
+    except cbor2.CBORDecodeError as e:
+        raise WireError(f"CBOR decode failed: {e}") from e
+    return list(hashes)
+
+@public
+class WireSender:
+    """
+    Sender side of the want/have exchange for one root subgraph. The sender
+    holds the fully materialized DAG in memory, so it can serve any hash it
+    announced (the root and its transitive closure).
+    """
+    def __init__(self, sg, ept: ExportTable):
+        self.ept = ept
+        self.sg = as_frozen(sg)
+        self._table = None # lazy wire_hash -> FrozenSubgraph, full closure
+
+    def root_block(self) -> tuple[bytes, bytes]:
+        """The unconditionally transmitted first block: (hash, wire bytes)."""
+        return (self.sg.wire_hash(self.ept),
+            self.sg.wire_encode(self.ept))
+
+    def serve(self, want) -> list[tuple[bytes, bytes]]:
+        """Blocks for a want list of hashes; all must have been announced."""
+        if self._table is None:
+            self._table = {self.sg.wire_hash(self.ept): self.sg}
+            self._table.update(self.sg.wire_deps(self.ept))
+        blocks = []
+        for h in want:
+            h = bytes(h)
+            try:
+                sg = self._table[h]
+            except KeyError:
+                raise WireError(f"Subgraph {h.hex()} was never announced"
+                    " (protocol violation).") from None
+            blocks.append((h, sg.wire_encode(self.ept)))
+        return blocks
+
+@public
+class WireReceiver:
+    """
+    Receiver side of the want/have exchange; one instance per transferred
+    root. Feed the sender's root block into receive(), serve each returned
+    want list, and repeat until receive() returns an empty list; the
+    materialized root is then available as .result.
+
+    The store is a plain dict of wire_hash -> FrozenSubgraph, created and
+    owned by the caller (no weak references; the owner's explicit lifetime
+    bounds how long received subgraphs stay available without
+    retransmission). Materialized subgraphs are added to it.
+    """
+    def __init__(self, ept: ExportTable, store: dict=None):
+        self.ept = ept
+        self.store = store if store is not None else {}
+        self._root_hash = None
+        self._outstanding = set() # wanted hashes not yet received
+        self._pending = {} # wire_hash -> (data, child hashes), undecoded
+        self._resolved = {} # wire_hash -> FrozenSubgraph
+        self._result = None
+
+    def receive(self, blocks) -> list[bytes]:
+        """
+        Ingest (hash, data) blocks; the first block of the exchange is the
+        root. Returns the hashes to request next; an empty list means the
+        exchange is complete.
+        """
+        if self._result is not None:
+            raise WireError("Exchange is already complete.")
+        new_children = []
+        for h, data in blocks:
+            h = bytes(h)
+            if self._root_hash is None:
+                self._root_hash = h
+            elif h in self._outstanding:
+                self._outstanding.discard(h)
+            else:
+                raise WireError(f"Received block {h.hex()} that was never"
+                    " wanted (protocol violation).")
+            if hashlib.sha256(HASH_DOMAIN + data).digest() != h:
+                raise WireError(
+                    f"Block does not match its announced hash {h.hex()}.")
+            if h in self.store:
+                self._resolved[h] = self.store[h]
+                continue
+            children = collect_child_hashes(data)
+            self._pending[h] = (data, children)
+            new_children.extend(children)
+        want = []
+        for c in dict.fromkeys(new_children):
+            if (c in self._resolved or c in self._pending
+                    or c in self._outstanding):
+                continue
+            if c in self.store:
+                self._resolved[c] = self.store[c]
+                continue
+            want.append(c)
+        self._outstanding.update(want)
+        if not want and not self._outstanding:
+            self._result = self._materialize(self._root_hash).root_cursor
+        return want
+
+    def _materialize(self, h) -> FrozenSubgraph:
+        # Bottom-up (post-order) over the pending blocks; acyclic by Merkle
+        # construction. Recursion depth is the DAG depth, which is shallow
+        # for design data.
+        sg = self._resolved.get(h)
+        if sg is None:
+            data, children = self._pending.pop(h)
+            deps = {c: self._materialize(c) for c in children}
+            sg = wire_decode(data, self.ept, deps).subgraph
+            # The bytes were verified against h on receipt and re-encoding
+            # is deterministic (FarRefs relay verbatim, own-endpoint refs
+            # re-export to their memoized ids), so pre-seed the hash memo
+            # instead of re-encoding the whole subgraph.
+            sg._cached_wire_hash = (self.ept, h)
+            self._resolved[h] = sg
+            self.store[h] = sg
+        return sg
+
+    @property
+    def result(self) -> Node:
+        """Root cursor of the transferred subgraph, once complete."""
+        if self._result is None:
+            raise WireError("Exchange is not complete.")
+        return self._result

--- a/src/ordec/core/wire.py
+++ b/src/ordec/core/wire.py
@@ -27,7 +27,7 @@ between two endpoints while retransmitting only subgraphs the receiver does
 not already hold in its store; laziness exists on the wire only, in-memory
 SubgraphRefs always hold fully materialized subgraphs.
 
-Wire format (format version is the digit in HASH_DOMAIN):
+Wire format (format version is the digit in HASH_DOMAIN)::
 
     wire_bytes(sg) = canonical CBOR of [ {wire_id: [[nid, v0, ..., vN], ...]},
                                          nid_alloc.start ]

--- a/src/ordec/core/wire.py
+++ b/src/ordec/core/wire.py
@@ -4,6 +4,10 @@
 """
 Session-scoped wire serialization for ORDB subgraphs.
 
+The user-facing API is on FrozenSubgraph (ordb/base.py): wire_encode(),
+wire_hash() and wire_deps(); this module provides their backends plus the
+decoder, wire_decode().
+
 Subgraphs are encoded to canonical CBOR and identified by the SHA-256 hash of
 their encoding (wire_hash). Nested SubgraphRefs are encoded as the wire_hash
 of the referenced subgraph (Merkle-style), so a subgraph's hash covers its
@@ -184,7 +188,7 @@ def encode_row_value(val, attr):
     if isinstance(attr, ExternalRef):
         return cbor2.CBORTag(TAG_EXTERNALREF, val)
     if isinstance(attr, SubgraphRef):
-        return cbor2.CBORTag(TAG_SUBGRAPHREF, wire_hash(val))
+        return cbor2.CBORTag(TAG_SUBGRAPHREF, val.wire_hash())
     if isinstance(attr, LiveRef):
         # Must precede plain-value dispatch: the stored value is an arbitrary
         # live object (or an already-opaque FarRef relayed onward).
@@ -194,14 +198,13 @@ def encode_row_value(val, attr):
         return cbor2.CBORTag(TAG_LIVEREF, list(export_table.export(val)))
     return encode_plain(val)
 
-@public
-def subgraph_to_wire(x) -> bytes:
+def encode_subgraph(sg: FrozenSubgraph) -> bytes:
     """
-    Encode a subgraph to canonical CBOR wire bytes. Nested SubgraphRefs are
-    represented by their wire_hash; use wire_deps() to collect the referenced
-    subgraphs for transmission.
+    Encode a frozen subgraph to canonical CBOR wire bytes. Nested
+    SubgraphRefs are represented by their wire_hash; collect the referenced
+    subgraphs for transmission via FrozenSubgraph.wire_deps(). Backend of
+    FrozenSubgraph.wire_encode().
     """
-    sg = as_frozen(x)
     rows_by_wid = {}
     for nid in sorted(sg.nodes):
         node = sg.nodes[nid]
@@ -219,24 +222,17 @@ def subgraph_to_wire(x) -> bytes:
         rows_by_wid.setdefault(wid, []).append(row)
     return cbor2.dumps([rows_by_wid, sg.nid_alloc.start], canonical=True)
 
-@public
-def wire_hash(x) -> bytes:
+def compute_wire_hash(sg: FrozenSubgraph) -> bytes:
     """
-    SHA-256 wire hash (32 bytes) of a subgraph, memoized on FrozenSubgraph.
-    Mutable input is hashed via a temporary freeze without memoization.
+    Domain-prefixed SHA-256 (32 bytes) over encode_subgraph(sg). Backend of
+    FrozenSubgraph.wire_hash(), which memoizes it; always call that instead.
     """
-    sg = as_frozen(x)
-    h = sg._cached_wire_hash
-    if h is None:
-        h = hashlib.sha256(HASH_DOMAIN + subgraph_to_wire(sg)).digest()
-        sg._cached_wire_hash = h
-    return h
+    return hashlib.sha256(HASH_DOMAIN + encode_subgraph(sg)).digest()
 
-@public
-def wire_deps(x) -> dict[bytes, FrozenSubgraph]:
+def collect_wire_deps(sg: FrozenSubgraph) -> dict[bytes, FrozenSubgraph]:
     """
-    Collect the transitive SubgraphRef dependencies of a subgraph, keyed by
-    their wire_hash. Suitable as the deps argument of subgraph_from_wire.
+    Collect the transitive SubgraphRef dependencies of a frozen subgraph,
+    keyed by their wire_hash. Backend of FrozenSubgraph.wire_deps().
     """
     deps = {}
     def collect(sg):
@@ -248,11 +244,11 @@ def wire_deps(x) -> dict[bytes, FrozenSubgraph]:
                 child = node[ad.index]
                 if child is None:
                     continue
-                h = wire_hash(child)
+                h = child.wire_hash()
                 if h not in deps:
                     deps[h] = child
                     collect(child)
-    collect(as_frozen(x))
+    collect(sg)
     return deps
 
 # Decoding
@@ -322,15 +318,16 @@ def resolve_row_value(val, deps):
     return fix_plain(val)
 
 @public
-def subgraph_from_wire(data: bytes, deps=None) -> Node:
+def wire_decode(data: bytes, deps=None) -> Node:
     """
     Decode wire bytes into a new FrozenSubgraph, returned as its root cursor.
 
     Args:
-        data: Bytes produced by subgraph_to_wire.
+        data: Bytes produced by FrozenSubgraph.wire_encode().
         deps: Mapping of wire_hash to already-materialized subgraph for every
-            SubgraphRef occurring in data (see wire_deps). All dependencies
-            must be present; laziness exists only on the wire.
+            SubgraphRef occurring in data (see FrozenSubgraph.wire_deps()).
+            All dependencies must be present; laziness exists only on the
+            wire.
     """
     if deps is None:
         deps = {}

--- a/src/ordec/core/wire.py
+++ b/src/ordec/core/wire.py
@@ -1,0 +1,369 @@
+# SPDX-FileCopyrightText: 2026 ORDeC contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Session-scoped wire serialization for ORDB subgraphs.
+
+Subgraphs are encoded to canonical CBOR and identified by the SHA-256 hash of
+their encoding (wire_hash). Nested SubgraphRefs are encoded as the wire_hash
+of the referenced subgraph (Merkle-style), so a subgraph's hash covers its
+transitive dependencies. LiveRef attributes (live objects such as Cells) are
+encoded as (endpoint_id, obj_id, name) export references minted by the
+process-global export_table; refs minted by a foreign endpoint decode to
+opaque FarRef placeholders. Because export references participate in the
+hashed bytes, wire hashes are session-scoped identity: they do not converge
+across processes, by design. Wire data must never be stored in durable
+artifacts (.ord files, uistate).
+
+Wire format (format version is the digit in HASH_DOMAIN):
+
+    wire_bytes(sg) = canonical CBOR of [ {wire_id: [[nid, v0, ..., vN], ...]},
+                                         nid_alloc.start ]
+                     with rows ascending by nid and row values in
+                     NodeTuple._layout order
+    wire_hash(sg)  = SHA256(HASH_DOMAIN + wire_bytes(sg))
+
+This module imports ordb and the schema modules; it must never be imported by
+them (or by core/__init__), so its top-level schema imports stay cycle-free.
+"""
+
+from fractions import Fraction
+import hashlib
+import os
+import threading
+
+import cbor2
+from public import public
+
+from .ordb.base import (
+    LocalRef, ExternalRef, SubgraphRef, LiveRef, FarRef, Node, Subgraph,
+    FrozenSubgraph, MutableSubgraph, OrdbException, wire_registry,
+)
+from .rational import R
+from .geoprim import Vec2R, Vec2I, Rect4R, Rect4I, TD4R, TD4I, D4
+from .simarray import SimArray, SimArrayField
+from .schema.base import PathEndType, SourceLocInfo, GdsLayer, RGBColor
+from .schema.schematic import PinType, SchemErrorType
+from .schema.report import ScaleType
+from .schema.simhier import SimType
+from .schema.lvs import LvsStatus, LvsItemType
+
+HASH_DOMAIN = b'ordec-sg-0:'
+
+# CBOR tag assignments. Tag 30 is the standard rational tag, used for R
+# (Fraction invariant guarantees reduced form). The 3900xx block is
+# ORDeC-private: 3900{01..2x} value types, 3900{30..3x} attr-kind wrappers.
+TAG_VEC2R = 390001
+TAG_VEC2I = 390002
+TAG_RECT4R = 390003
+TAG_RECT4I = 390004
+TAG_TD4R = 390005
+TAG_TD4I = 390006
+TAG_SIMARRAY = 390020
+TAG_SOURCELOC = 390021
+TAG_GDSLAYER = 390022
+TAG_RGBCOLOR = 390023
+TAG_LOCALREF = 390030
+TAG_EXTERNALREF = 390031
+TAG_SUBGRAPHREF = 390032
+TAG_LIVEREF = 390033
+
+# Enums are encoded by member name, one tag per enum class.
+ENUM_TAGS = {
+    D4: 390007,
+    PathEndType: 390010,
+    PinType: 390011,
+    SchemErrorType: 390012,
+    ScaleType: 390013,
+    SimType: 390014,
+    LvsStatus: 390015,
+    LvsItemType: 390016,
+}
+ENUM_BY_TAG = {tag: cls for cls, tag in ENUM_TAGS.items()}
+
+@public
+class WireError(OrdbException):
+    """Raised on wire encoding/decoding protocol violations."""
+    pass
+
+class ExportTable:
+    """
+    Process-global table of live objects that have crossed the wire inside
+    LiveRef attributes. Export references are minted lazily at serialization
+    time and memoized per object identity, so hashing is deterministic within
+    the process. Exported objects are pinned (strong refs) for the process
+    lifetime so that returning references always resolve.
+    """
+    def __init__(self):
+        self.endpoint_id = os.urandom(16)
+        self._lock = threading.Lock()
+        self._entry_of_pyid = {} # id(obj) -> (obj, obj_id, name); pins obj
+        self._obj_of_id = {}
+
+    def export(self, obj) -> tuple[bytes, int, str]:
+        """Returns (endpoint_id, obj_id, name) for obj, minting if needed."""
+        with self._lock:
+            entry = self._entry_of_pyid.get(id(obj))
+            if entry is None:
+                obj_id = len(self._obj_of_id) + 1
+                entry = (obj, obj_id, repr(obj))
+                self._entry_of_pyid[id(obj)] = entry
+                self._obj_of_id[obj_id] = obj
+            return (self.endpoint_id, entry[1], entry[2])
+
+    def resolve(self, obj_id: int):
+        """Returns the live object for an own-endpoint obj_id."""
+        with self._lock:
+            try:
+                return self._obj_of_id[obj_id]
+            except KeyError:
+                raise WireError(
+                    f"Unknown obj_id {obj_id} for own endpoint"
+                    " (protocol violation)."
+                ) from None
+
+#: The process-wide ExportTable singleton.
+export_table = ExportTable()
+public(export_table=export_table)
+
+def as_frozen(x) -> FrozenSubgraph:
+    if isinstance(x, Node):
+        x = x.subgraph
+    if isinstance(x, MutableSubgraph):
+        x = x.freeze()
+    if not isinstance(x, FrozenSubgraph):
+        raise TypeError(f"Expected subgraph or cursor, got {type(x).__name__}.")
+    return x
+
+# Encoding
+# --------
+
+def encode_plain(val):
+    t = type(val)
+    if val is None or t in (bool, int, str, bytes, float):
+        return val
+    if t is R:
+        return cbor2.CBORTag(30, [val.numerator, val.denominator])
+    if t is Vec2R:
+        return cbor2.CBORTag(TAG_VEC2R, [encode_plain(val.x), encode_plain(val.y)])
+    if t is Vec2I:
+        return cbor2.CBORTag(TAG_VEC2I, [val.x, val.y])
+    if t is Rect4R:
+        return cbor2.CBORTag(TAG_RECT4R,
+            [encode_plain(v) for v in (val.lx, val.ly, val.ux, val.uy)])
+    if t is Rect4I:
+        return cbor2.CBORTag(TAG_RECT4I, [val.lx, val.ly, val.ux, val.uy])
+    if t is TD4R:
+        return cbor2.CBORTag(TAG_TD4R,
+            [encode_plain(val.transl), encode_plain(val.d4)])
+    if t is TD4I:
+        return cbor2.CBORTag(TAG_TD4I,
+            [encode_plain(val.transl), encode_plain(val.d4)])
+    if t in ENUM_TAGS:
+        return cbor2.CBORTag(ENUM_TAGS[t], val.name)
+    if t is SimArray:
+        # data may be a memoryview (SimArray permits it); force bytes so the
+        # encoding is a CBOR byte string either way.
+        return cbor2.CBORTag(TAG_SIMARRAY,
+            [[[f.fid, f.dtype] for f in val.fields], bytes(val.data)])
+    if t is SourceLocInfo:
+        return cbor2.CBORTag(TAG_SOURCELOC, list(val))
+    if t is GdsLayer:
+        return cbor2.CBORTag(TAG_GDSLAYER, list(val))
+    if t is RGBColor:
+        return cbor2.CBORTag(TAG_RGBCOLOR, list(val))
+    if t is tuple:
+        return [encode_plain(v) for v in val]
+    raise TypeError(f"Type {t.__name__} is not wire-serializable.")
+
+def encode_row_value(val, attr):
+    if val is None:
+        return None
+    if isinstance(attr, LocalRef):
+        return cbor2.CBORTag(TAG_LOCALREF, val)
+    if isinstance(attr, ExternalRef):
+        return cbor2.CBORTag(TAG_EXTERNALREF, val)
+    if isinstance(attr, SubgraphRef):
+        return cbor2.CBORTag(TAG_SUBGRAPHREF, wire_hash(val))
+    if isinstance(attr, LiveRef):
+        # Must precede plain-value dispatch: the stored value is an arbitrary
+        # live object (or an already-opaque FarRef relayed onward).
+        if isinstance(val, FarRef):
+            return cbor2.CBORTag(TAG_LIVEREF,
+                [val.endpoint_id, val.obj_id, val.name])
+        return cbor2.CBORTag(TAG_LIVEREF, list(export_table.export(val)))
+    return encode_plain(val)
+
+@public
+def subgraph_to_wire(x) -> bytes:
+    """
+    Encode a subgraph to canonical CBOR wire bytes. Nested SubgraphRefs are
+    represented by their wire_hash; use wire_deps() to collect the referenced
+    subgraphs for transmission.
+    """
+    sg = as_frozen(x)
+    rows_by_wid = {}
+    for nid in sorted(sg.nodes):
+        node = sg.nodes[nid]
+        cls = node._cursor_type
+        wid = cls.__dict__.get('wire_id')
+        if wid is None:
+            raise WireError(f"{cls.__name__} declares no wire_id;"
+                " cannot serialize.")
+        row = [nid]
+        for ad in node._layout:
+            try:
+                row.append(encode_row_value(node[ad.index], ad.attr))
+            except TypeError as e:
+                raise TypeError(f"{cls.__name__}.{ad.name}: {e}") from None
+        rows_by_wid.setdefault(wid, []).append(row)
+    return cbor2.dumps([rows_by_wid, sg.nid_alloc.start], canonical=True)
+
+@public
+def wire_hash(x) -> bytes:
+    """
+    SHA-256 wire hash (32 bytes) of a subgraph, memoized on FrozenSubgraph.
+    Mutable input is hashed via a temporary freeze without memoization.
+    """
+    sg = as_frozen(x)
+    h = sg._cached_wire_hash
+    if h is None:
+        h = hashlib.sha256(HASH_DOMAIN + subgraph_to_wire(sg)).digest()
+        sg._cached_wire_hash = h
+    return h
+
+@public
+def wire_deps(x) -> dict[bytes, FrozenSubgraph]:
+    """
+    Collect the transitive SubgraphRef dependencies of a subgraph, keyed by
+    their wire_hash. Suitable as the deps argument of subgraph_from_wire.
+    """
+    deps = {}
+    def collect(sg):
+        for nid in sorted(sg.nodes):
+            node = sg.nodes[nid]
+            for ad in node._layout:
+                if not isinstance(ad.attr, SubgraphRef):
+                    continue
+                child = node[ad.index]
+                if child is None:
+                    continue
+                h = wire_hash(child)
+                if h not in deps:
+                    deps[h] = child
+                    collect(child)
+    collect(as_frozen(x))
+    return deps
+
+# Decoding
+# --------
+
+class RefMarker:
+    """Wraps ref-tag payloads between tag_hook and row reconstruction."""
+    __slots__ = ('tag', 'value')
+    def __init__(self, tag, value):
+        self.tag = tag
+        self.value = value
+
+def tag_hook(tag, shareable):
+    t = tag.tag
+    v = tag.value
+    if t in (TAG_LOCALREF, TAG_EXTERNALREF, TAG_SUBGRAPHREF, TAG_LIVEREF):
+        return RefMarker(t, v)
+    if t == TAG_VEC2R:
+        return Vec2R(R(v[0]), R(v[1]))
+    if t == TAG_VEC2I:
+        return Vec2I(v[0], v[1])
+    if t == TAG_RECT4R:
+        return Rect4R(*[R(c) for c in v])
+    if t == TAG_RECT4I:
+        return Rect4I(*v)
+    if t == TAG_TD4R:
+        return TD4R(transl=v[0], d4=v[1])
+    if t == TAG_TD4I:
+        return TD4I(transl=v[0], d4=v[1])
+    if t in ENUM_BY_TAG:
+        return ENUM_BY_TAG[t][v]
+    if t == TAG_SIMARRAY:
+        return SimArray([SimArrayField(*f) for f in v[0]], v[1])
+    if t == TAG_SOURCELOC:
+        return SourceLocInfo(*v)
+    if t == TAG_GDSLAYER:
+        return GdsLayer(*v)
+    if t == TAG_RGBCOLOR:
+        return RGBColor(*v)
+    raise WireError(f"Unknown wire tag {t}.")
+
+def fix_plain(val):
+    # cbor2 auto-decodes tag 30 to Fraction before the tag_hook runs, and
+    # plain CBOR arrays (encoded tuples) decode as lists.
+    if type(val) is Fraction:
+        return R(val)
+    if type(val) in (list, tuple):
+        return tuple(fix_plain(v) for v in val)
+    return val
+
+def resolve_row_value(val, deps):
+    if isinstance(val, RefMarker):
+        if val.tag in (TAG_LOCALREF, TAG_EXTERNALREF):
+            return val.value # stored nid
+        if val.tag == TAG_SUBGRAPHREF:
+            try:
+                return as_frozen(deps[bytes(val.value)])
+            except KeyError:
+                raise WireError(
+                    f"Missing dependency subgraph {bytes(val.value).hex()}."
+                ) from None
+        endpoint_id, obj_id, name = val.value
+        endpoint_id = bytes(endpoint_id)
+        if endpoint_id == export_table.endpoint_id:
+            return export_table.resolve(obj_id)
+        return FarRef(endpoint_id, obj_id, name)
+    return fix_plain(val)
+
+@public
+def subgraph_from_wire(data: bytes, deps=None) -> Node:
+    """
+    Decode wire bytes into a new FrozenSubgraph, returned as its root cursor.
+
+    Args:
+        data: Bytes produced by subgraph_to_wire.
+        deps: Mapping of wire_hash to already-materialized subgraph for every
+            SubgraphRef occurring in data (see wire_deps). All dependencies
+            must be present; laziness exists only on the wire.
+    """
+    if deps is None:
+        deps = {}
+    try:
+        tree = cbor2.loads(data, tag_hook=tag_hook)
+    except cbor2.CBORDecodeError as e:
+        raise WireError(f"CBOR decode failed: {e}") from e
+    if not (isinstance(tree, list) and len(tree) == 2
+            and isinstance(tree[0], dict) and isinstance(tree[1], int)):
+        raise WireError("Malformed wire data (expected [rows, nid_start]).")
+    rows_by_wid, nid_start = tree
+
+    items = []
+    for wid, rows in rows_by_wid.items():
+        cls = wire_registry.get(wid)
+        if cls is None:
+            raise WireError(f"Unknown wire_id {wid:#x}.")
+        layout = cls.Tuple._layout
+        for row in rows:
+            if not isinstance(row, list) or len(row) != len(layout) + 1:
+                raise WireError(f"Malformed row for {cls.__name__}.")
+            items.append((row[0], cls, row[1:]))
+    items.sort(key=lambda item: item[0])
+
+    sg = MutableSubgraph()
+    with sg.updater() as u:
+        for nid, cls, values in items:
+            kwargs = {}
+            for ad, val in zip(cls.Tuple._layout, values):
+                kwargs[ad.name] = resolve_row_value(val, deps)
+            u.add_single(cls.Tuple(**kwargs), nid=nid)
+    # The updater clamps nid_alloc.start to max_nid+1; restore the encoded
+    # start (they differ when top nids were deleted before serialization).
+    if sg.nid_alloc.start != nid_start:
+        sg.mutate(sg.nodes, sg.index, range(nid_start, sg.nid_alloc.stop))
+    return sg.freeze().root_cursor

--- a/src/ordec/core/wire.py
+++ b/src/ordec/core/wire.py
@@ -12,11 +12,14 @@ Subgraphs are encoded to canonical CBOR and identified by the SHA-256 hash of
 their encoding (wire_hash). Nested SubgraphRefs are encoded as the wire_hash
 of the referenced subgraph (Merkle-style), so a subgraph's hash covers its
 transitive dependencies. LiveRef attributes (live objects such as Cells) are
-encoded as (endpoint_id, obj_id, name) export references minted by the
-process-global export_table; refs minted by a foreign endpoint decode to
-opaque FarRef placeholders. Because export references participate in the
-hashed bytes, wire hashes are session-scoped identity: they do not converge
-across processes, by design. Wire data must never be stored in durable
+encoded as (endpoint_id, obj_id, name) export references minted by a
+caller-supplied ExportTable; refs minted by a foreign endpoint decode to
+opaque FarRef placeholders. There is deliberately no ambient/global table:
+every encode, hash and decode operation takes the table as an explicit
+parameter, and the table's owner decides its scope and lifetime (e.g. one
+table per server). Because export references participate in the hashed
+bytes, wire hashes are endpoint-scoped identity: they do not converge
+across endpoints, by design. Wire data must never be stored in durable
 artifacts (.ord files, uistate).
 
 Wire format (format version is the digit in HASH_DOMAIN):
@@ -90,13 +93,15 @@ class WireError(OrdbException):
     """Raised on wire encoding/decoding protocol violations."""
     pass
 
+@public
 class ExportTable:
     """
-    Process-global table of live objects that have crossed the wire inside
-    LiveRef attributes. Export references are minted lazily at serialization
-    time and memoized per object identity, so hashing is deterministic within
-    the process. Exported objects are pinned (strong refs) for the process
-    lifetime so that returning references always resolve.
+    Table of live objects that have crossed the wire inside LiveRef
+    attributes; one per endpoint, created and owned by the API user (no
+    global instance exists). Export references are minted lazily at
+    serialization time and memoized per object identity, so hashing is
+    deterministic per table. Exported objects are pinned (strong refs) for
+    the table's lifetime so that returning references always resolve.
     """
     def __init__(self):
         self.endpoint_id = os.urandom(16)
@@ -125,10 +130,6 @@ class ExportTable:
                     f"Unknown obj_id {obj_id} for own endpoint"
                     " (protocol violation)."
                 ) from None
-
-#: The process-wide ExportTable singleton.
-export_table = ExportTable()
-public(export_table=export_table)
 
 def as_frozen(x) -> FrozenSubgraph:
     if isinstance(x, Node):
@@ -180,7 +181,7 @@ def encode_plain(val):
         return [encode_plain(v) for v in val]
     raise TypeError(f"Type {t.__name__} is not wire-serializable.")
 
-def encode_row_value(val, attr):
+def encode_row_value(val, attr, ept: ExportTable):
     if val is None:
         return None
     if isinstance(attr, LocalRef):
@@ -188,17 +189,17 @@ def encode_row_value(val, attr):
     if isinstance(attr, ExternalRef):
         return cbor2.CBORTag(TAG_EXTERNALREF, val)
     if isinstance(attr, SubgraphRef):
-        return cbor2.CBORTag(TAG_SUBGRAPHREF, val.wire_hash())
+        return cbor2.CBORTag(TAG_SUBGRAPHREF, val.wire_hash(ept))
     if isinstance(attr, LiveRef):
         # Must precede plain-value dispatch: the stored value is an arbitrary
         # live object (or an already-opaque FarRef relayed onward).
         if isinstance(val, FarRef):
             return cbor2.CBORTag(TAG_LIVEREF,
                 [val.endpoint_id, val.obj_id, val.name])
-        return cbor2.CBORTag(TAG_LIVEREF, list(export_table.export(val)))
+        return cbor2.CBORTag(TAG_LIVEREF, list(ept.export(val)))
     return encode_plain(val)
 
-def encode_subgraph(sg: FrozenSubgraph) -> bytes:
+def encode_subgraph(sg: FrozenSubgraph, ept: ExportTable) -> bytes:
     """
     Encode a frozen subgraph to canonical CBOR wire bytes. Nested
     SubgraphRefs are represented by their wire_hash; collect the referenced
@@ -216,20 +217,22 @@ def encode_subgraph(sg: FrozenSubgraph) -> bytes:
         row = [nid]
         for ad in node._layout:
             try:
-                row.append(encode_row_value(node[ad.index], ad.attr))
+                row.append(encode_row_value(node[ad.index], ad.attr, ept))
             except TypeError as e:
                 raise TypeError(f"{cls.__name__}.{ad.name}: {e}") from None
         rows_by_wid.setdefault(wid, []).append(row)
     return cbor2.dumps([rows_by_wid, sg.nid_alloc.start], canonical=True)
 
-def compute_wire_hash(sg: FrozenSubgraph) -> bytes:
+def compute_wire_hash(sg: FrozenSubgraph, ept: ExportTable) -> bytes:
     """
-    Domain-prefixed SHA-256 (32 bytes) over encode_subgraph(sg). Backend of
-    FrozenSubgraph.wire_hash(), which memoizes it; always call that instead.
+    Domain-prefixed SHA-256 (32 bytes) over encode_subgraph(sg, ept).
+    Backend of FrozenSubgraph.wire_hash(), which memoizes it; always call
+    that instead.
     """
-    return hashlib.sha256(HASH_DOMAIN + encode_subgraph(sg)).digest()
+    return hashlib.sha256(HASH_DOMAIN + encode_subgraph(sg, ept)).digest()
 
-def collect_wire_deps(sg: FrozenSubgraph) -> dict[bytes, FrozenSubgraph]:
+def collect_wire_deps(sg: FrozenSubgraph,
+        ept: ExportTable) -> dict[bytes, FrozenSubgraph]:
     """
     Collect the transitive SubgraphRef dependencies of a frozen subgraph,
     keyed by their wire_hash. Backend of FrozenSubgraph.wire_deps().
@@ -244,7 +247,7 @@ def collect_wire_deps(sg: FrozenSubgraph) -> dict[bytes, FrozenSubgraph]:
                 child = node[ad.index]
                 if child is None:
                     continue
-                h = child.wire_hash()
+                h = child.wire_hash(ept)
                 if h not in deps:
                     deps[h] = child
                     collect(child)
@@ -299,7 +302,7 @@ def fix_plain(val):
         return tuple(fix_plain(v) for v in val)
     return val
 
-def resolve_row_value(val, deps):
+def resolve_row_value(val, deps, ept):
     if isinstance(val, RefMarker):
         if val.tag in (TAG_LOCALREF, TAG_EXTERNALREF):
             return val.value # stored nid
@@ -312,18 +315,20 @@ def resolve_row_value(val, deps):
                 ) from None
         endpoint_id, obj_id, name = val.value
         endpoint_id = bytes(endpoint_id)
-        if endpoint_id == export_table.endpoint_id:
-            return export_table.resolve(obj_id)
+        if endpoint_id == ept.endpoint_id:
+            return ept.resolve(obj_id)
         return FarRef(endpoint_id, obj_id, name)
     return fix_plain(val)
 
 @public
-def wire_decode(data: bytes, deps=None) -> Node:
+def wire_decode(data: bytes, ept: ExportTable, deps=None) -> Node:
     """
     Decode wire bytes into a new FrozenSubgraph, returned as its root cursor.
 
     Args:
         data: Bytes produced by FrozenSubgraph.wire_encode().
+        ept: The decoding endpoint's ExportTable; refs minted by it resolve
+            to the identical live objects, foreign refs decode to FarRefs.
         deps: Mapping of wire_hash to already-materialized subgraph for every
             SubgraphRef occurring in data (see FrozenSubgraph.wire_deps()).
             All dependencies must be present; laziness exists only on the
@@ -357,10 +362,11 @@ def wire_decode(data: bytes, deps=None) -> Node:
         for nid, cls, values in items:
             kwargs = {}
             for ad, val in zip(cls.Tuple._layout, values):
-                kwargs[ad.name] = resolve_row_value(val, deps)
+                kwargs[ad.name] = resolve_row_value(val, deps, ept)
             u.add_single(cls.Tuple(**kwargs), nid=nid)
     # The updater clamps nid_alloc.start to max_nid+1; restore the encoded
     # start (they differ when top nids were deleted before serialization).
     if sg.nid_alloc.start != nid_start:
         sg.mutate(sg.nodes, sg.index, range(nid_start, sg.nid_alloc.stop))
     return sg.freeze().root_cursor
+

--- a/src/ordec/layout/drc.py
+++ b/src/ordec/layout/drc.py
@@ -5,6 +5,7 @@ from ..core.schema import (
     DrcReport, DrcItem, DrcCategory, DrcCell, DrcBox, DrcEdge, DrcEdgePair,
     DrcPoly, DrcPath, DrcText,
 )
+from ..core.wire import wire_hash
 
 
 def webdata(report: DrcReport):
@@ -16,6 +17,11 @@ def webdata(report: DrcReport):
             'has_layout_ref': cell.ref_layout is not None,
             'is_top': cell.ref_layout is not None
                 and cell.ref_layout == report.ref_layout,
+            # Wire hash of the cell's layout: highlight events use it to
+            # target viewers that show the same subgraph under a different
+            # view name (see hash-based dedup in web/src/main.js).
+            'layout_hash': wire_hash(cell.ref_layout).hex()
+                if cell.ref_layout is not None else None,
         })
 
     items_dict = {}
@@ -82,4 +88,8 @@ def webdata(report: DrcReport):
         'cells': cells,
         'items': list(items_dict.values()),
         'unit': float(report.ref_layout.ref_layers.unit),
+        # Report-level wire hash, used for top-cell item selections (their
+        # view is addressed relative to the report, not a DrcCell).
+        'layout_hash': wire_hash(report.ref_layout).hex()
+            if report.ref_layout is not None else None,
     }

--- a/src/ordec/layout/drc.py
+++ b/src/ordec/layout/drc.py
@@ -7,7 +7,15 @@ from ..core.schema import (
 )
 
 
-def webdata(report: DrcReport):
+def webdata(report: DrcReport, ept):
+    def sg_hash(cursor):
+        # Wire hashes exist only relative to an endpoint's export table;
+        # this is why DrcReport overrides webdata() and has no
+        # endpoint-independent webdata_static().
+        if cursor is None:
+            return None
+        return cursor.subgraph.wire_hash(ept).hex()
+
     cells = []
     for cell in report.all(DrcCell):
         cells.append({
@@ -19,8 +27,7 @@ def webdata(report: DrcReport):
             # Wire hash of the cell's layout: highlight events use it to
             # target viewers that show the same subgraph under a different
             # view name (see hash-based dedup in web/src/main.js).
-            'layout_hash': cell.ref_layout.subgraph.wire_hash().hex()
-                if cell.ref_layout is not None else None,
+            'layout_hash': sg_hash(cell.ref_layout),
         })
 
     items_dict = {}
@@ -89,6 +96,5 @@ def webdata(report: DrcReport):
         'unit': float(report.ref_layout.ref_layers.unit),
         # Report-level wire hash, used for top-cell item selections (their
         # view is addressed relative to the report, not a DrcCell).
-        'layout_hash': report.ref_layout.subgraph.wire_hash().hex()
-            if report.ref_layout is not None else None,
+        'layout_hash': sg_hash(report.ref_layout),
     }

--- a/src/ordec/layout/drc.py
+++ b/src/ordec/layout/drc.py
@@ -8,7 +8,7 @@ from ..core.schema import (
 
 
 def webdata(report: DrcReport, ept):
-    def sg_hash(cursor):
+    def wire_hash_hex(cursor):
         # Wire hashes exist only relative to an endpoint's export table;
         # this is why DrcReport overrides webdata() and has no
         # endpoint-independent webdata_static().
@@ -27,7 +27,7 @@ def webdata(report: DrcReport, ept):
             # Wire hash of the cell's layout: highlight events use it to
             # target viewers that show the same subgraph under a different
             # view name (see hash-based dedup in web/src/main.js).
-            'layout_hash': sg_hash(cell.ref_layout),
+            'layout_wire_hash': wire_hash_hex(cell.ref_layout),
         })
 
     items_dict = {}
@@ -96,5 +96,5 @@ def webdata(report: DrcReport, ept):
         'unit': float(report.ref_layout.ref_layers.unit),
         # Report-level wire hash, used for top-cell item selections (their
         # view is addressed relative to the report, not a DrcCell).
-        'layout_hash': sg_hash(report.ref_layout),
+        'layout_wire_hash': wire_hash_hex(report.ref_layout),
     }

--- a/src/ordec/layout/drc.py
+++ b/src/ordec/layout/drc.py
@@ -5,7 +5,6 @@ from ..core.schema import (
     DrcReport, DrcItem, DrcCategory, DrcCell, DrcBox, DrcEdge, DrcEdgePair,
     DrcPoly, DrcPath, DrcText,
 )
-from ..core.wire import wire_hash
 
 
 def webdata(report: DrcReport):
@@ -20,7 +19,7 @@ def webdata(report: DrcReport):
             # Wire hash of the cell's layout: highlight events use it to
             # target viewers that show the same subgraph under a different
             # view name (see hash-based dedup in web/src/main.js).
-            'layout_hash': wire_hash(cell.ref_layout).hex()
+            'layout_hash': cell.ref_layout.subgraph.wire_hash().hex()
                 if cell.ref_layout is not None else None,
         })
 
@@ -90,6 +89,6 @@ def webdata(report: DrcReport):
         'unit': float(report.ref_layout.ref_layers.unit),
         # Report-level wire hash, used for top-cell item selections (their
         # view is addressed relative to the report, not a DrcCell).
-        'layout_hash': wire_hash(report.ref_layout).hex()
+        'layout_hash': report.ref_layout.subgraph.wire_hash().hex()
             if report.ref_layout is not None else None,
     }

--- a/src/ordec/layout/lvs.py
+++ b/src/ordec/layout/lvs.py
@@ -29,7 +29,7 @@ def item_schem_name(item: LvsItem):
 
 
 def webdata(report: LvsReport, ept):
-    def sg_hash(cursor):
+    def wire_hash_hex(cursor):
         # Wire hashes exist only relative to an endpoint's export table;
         # this is why LvsReport overrides webdata() and has no
         # endpoint-independent webdata_static().
@@ -68,8 +68,8 @@ def webdata(report: LvsReport, ept):
             # Wire hashes of the referenced subgraphs: highlight events use
             # them to target viewers that show the same subgraph under a
             # different view name (see hash-based dedup in web/src/main.js).
-            'layout_hash': sg_hash(circuit.ref_layout),
-            'schem_hash': sg_hash(circuit.ref_schematic),
+            'layout_wire_hash': wire_hash_hex(circuit.ref_layout),
+            'schem_wire_hash': wire_hash_hex(circuit.ref_schematic),
             # Top-level circuit pair (refs the same layout/schematic as the
             # report itself). Item selections of subcircuit pairs must target
             # the pair's own views instead of the report-level ones.
@@ -103,6 +103,6 @@ def webdata(report: LvsReport, ept):
         'unit': float(report.ref_layout.ref_layers.unit) if report.ref_layout else 1.0,
         # Report-level wire hashes, used for top-pair item selections (their
         # views are addressed relative to the report, not a circuit pair).
-        'layout_hash': sg_hash(report.ref_layout),
-        'schem_hash': sg_hash(report.ref_schematic),
+        'layout_wire_hash': wire_hash_hex(report.ref_layout),
+        'schem_wire_hash': wire_hash_hex(report.ref_schematic),
     }

--- a/src/ordec/layout/lvs.py
+++ b/src/ordec/layout/lvs.py
@@ -3,6 +3,7 @@
 
 from ..core.directory import Directory
 from ..core.schema import LvsReport, LvsCircuitPair, LvsItem
+from ..core.wire import wire_hash
 
 
 def circuit_layout_name(circuit: LvsCircuitPair):
@@ -57,6 +58,13 @@ def webdata(report: LvsReport):
             # offers opening the layout/schematic of a circuit pair if so.
             'has_layout_ref': circuit.ref_layout is not None,
             'has_schem_ref': circuit.ref_schematic is not None,
+            # Wire hashes of the referenced subgraphs: highlight events use
+            # them to target viewers that show the same subgraph under a
+            # different view name (see hash-based dedup in web/src/main.js).
+            'layout_hash': wire_hash(circuit.ref_layout).hex()
+                if circuit.ref_layout is not None else None,
+            'schem_hash': wire_hash(circuit.ref_schematic).hex()
+                if circuit.ref_schematic is not None else None,
             # Top-level circuit pair (refs the same layout/schematic as the
             # report itself). Item selections of subcircuit pairs must target
             # the pair's own views instead of the report-level ones.
@@ -88,4 +96,10 @@ def webdata(report: LvsReport):
         'circuits': circuits,
         'items': items,
         'unit': float(report.ref_layout.ref_layers.unit) if report.ref_layout else 1.0,
+        # Report-level wire hashes, used for top-pair item selections (their
+        # views are addressed relative to the report, not a circuit pair).
+        'layout_hash': wire_hash(report.ref_layout).hex()
+            if report.ref_layout is not None else None,
+        'schem_hash': wire_hash(report.ref_schematic).hex()
+            if report.ref_schematic is not None else None,
     }

--- a/src/ordec/layout/lvs.py
+++ b/src/ordec/layout/lvs.py
@@ -28,7 +28,15 @@ def item_schem_name(item: LvsItem):
     return item.schem_name
 
 
-def webdata(report: LvsReport):
+def webdata(report: LvsReport, ept):
+    def sg_hash(cursor):
+        # Wire hashes exist only relative to an endpoint's export table;
+        # this is why LvsReport overrides webdata() and has no
+        # endpoint-independent webdata_static().
+        if cursor is None:
+            return None
+        return cursor.subgraph.wire_hash(ept).hex()
+
     # KLayout emits circuit pairs in bottom-up topological order (every callee
     # precedes its callers); report.all() preserves that insertion order.
     # Reversing yields top-down order (top cell first, leaves last), which is
@@ -60,10 +68,8 @@ def webdata(report: LvsReport):
             # Wire hashes of the referenced subgraphs: highlight events use
             # them to target viewers that show the same subgraph under a
             # different view name (see hash-based dedup in web/src/main.js).
-            'layout_hash': circuit.ref_layout.subgraph.wire_hash().hex()
-                if circuit.ref_layout is not None else None,
-            'schem_hash': circuit.ref_schematic.subgraph.wire_hash().hex()
-                if circuit.ref_schematic is not None else None,
+            'layout_hash': sg_hash(circuit.ref_layout),
+            'schem_hash': sg_hash(circuit.ref_schematic),
             # Top-level circuit pair (refs the same layout/schematic as the
             # report itself). Item selections of subcircuit pairs must target
             # the pair's own views instead of the report-level ones.
@@ -97,8 +103,6 @@ def webdata(report: LvsReport):
         'unit': float(report.ref_layout.ref_layers.unit) if report.ref_layout else 1.0,
         # Report-level wire hashes, used for top-pair item selections (their
         # views are addressed relative to the report, not a circuit pair).
-        'layout_hash': report.ref_layout.subgraph.wire_hash().hex()
-            if report.ref_layout is not None else None,
-        'schem_hash': report.ref_schematic.subgraph.wire_hash().hex()
-            if report.ref_schematic is not None else None,
+        'layout_hash': sg_hash(report.ref_layout),
+        'schem_hash': sg_hash(report.ref_schematic),
     }

--- a/src/ordec/layout/lvs.py
+++ b/src/ordec/layout/lvs.py
@@ -3,7 +3,6 @@
 
 from ..core.directory import Directory
 from ..core.schema import LvsReport, LvsCircuitPair, LvsItem
-from ..core.wire import wire_hash
 
 
 def circuit_layout_name(circuit: LvsCircuitPair):
@@ -61,9 +60,9 @@ def webdata(report: LvsReport):
             # Wire hashes of the referenced subgraphs: highlight events use
             # them to target viewers that show the same subgraph under a
             # different view name (see hash-based dedup in web/src/main.js).
-            'layout_hash': wire_hash(circuit.ref_layout).hex()
+            'layout_hash': circuit.ref_layout.subgraph.wire_hash().hex()
                 if circuit.ref_layout is not None else None,
-            'schem_hash': wire_hash(circuit.ref_schematic).hex()
+            'schem_hash': circuit.ref_schematic.subgraph.wire_hash().hex()
                 if circuit.ref_schematic is not None else None,
             # Top-level circuit pair (refs the same layout/schematic as the
             # report itself). Item selections of subcircuit pairs must target
@@ -98,8 +97,8 @@ def webdata(report: LvsReport):
         'unit': float(report.ref_layout.ref_layers.unit) if report.ref_layout else 1.0,
         # Report-level wire hashes, used for top-pair item selections (their
         # views are addressed relative to the report, not a circuit pair).
-        'layout_hash': wire_hash(report.ref_layout).hex()
+        'layout_hash': report.ref_layout.subgraph.wire_hash().hex()
             if report.ref_layout is not None else None,
-        'schem_hash': wire_hash(report.ref_schematic).hex()
+        'schem_hash': report.ref_schematic.subgraph.wire_hash().hex()
             if report.ref_schematic is not None else None,
     }

--- a/src/ordec/server.py
+++ b/src/ordec/server.py
@@ -91,7 +91,6 @@ from . import importer, language
 from .hub import HubIntegration, HubAuthError
 from .version import version, doc_url
 from .core import Cell, generate, generate_func, SubgraphRoot
-from .core.wire import wire_hash
 from .language import compile_ord
 from .extlibrary import ExtLibrary
 from .jobrunner import ThreadedJobRunner
@@ -394,7 +393,7 @@ class ConnectionHandler:
                 # Best-effort: user-defined Node classes may lack a wire_id;
                 # a hashing failure must not break view delivery.
                 try:
-                    msg_ret['sg_hash'] = wire_hash(view).hex()
+                    msg_ret['sg_hash'] = view.subgraph.wire_hash().hex()
                 except Exception:
                     pass
         except Exception as e:

--- a/src/ordec/server.py
+++ b/src/ordec/server.py
@@ -91,6 +91,7 @@ from . import importer, language
 from .hub import HubIntegration, HubAuthError
 from .version import version, doc_url
 from .core import Cell, generate, generate_func, SubgraphRoot
+from .core.wire import wire_hash
 from .language import compile_ord
 from .extlibrary import ExtLibrary
 from .jobrunner import ThreadedJobRunner
@@ -389,11 +390,17 @@ class ConnectionHandler:
                 viewtype, data = view.webdata()
             msg_ret['type'] = viewtype
             msg_ret['data'] = data
+            if isinstance(view, SubgraphRoot):
+                # Best-effort: user-defined Node classes may lack a wire_id;
+                # a hashing failure must not break view delivery.
+                try:
+                    msg_ret['sg_hash'] = wire_hash(view).hex()
+                except Exception:
+                    pass
         except Exception as e:
             msg_ret['exception'] = format_user_exception(e)
 
         return msg_ret
-
 
     def build_cells(self, source_type: str, source_data: str,
             check_src: str=None) -> (dict, dict):

--- a/src/ordec/server.py
+++ b/src/ordec/server.py
@@ -394,7 +394,7 @@ class ConnectionHandler:
                 # Best-effort: user-defined Node classes may lack a wire_id;
                 # a hashing failure must not break view delivery.
                 try:
-                    msg_ret['sg_hash'] = view.subgraph.wire_hash(ept).hex()
+                    msg_ret['wire_hash'] = view.subgraph.wire_hash(ept).hex()
                 except Exception:
                     pass
         except Exception as e:

--- a/src/ordec/server.py
+++ b/src/ordec/server.py
@@ -91,6 +91,7 @@ from . import importer, language
 from .hub import HubIntegration, HubAuthError
 from .version import version, doc_url
 from .core import Cell, generate, generate_func, SubgraphRoot
+from .core.wire import ExportTable
 from .language import compile_ord
 from .extlibrary import ExtLibrary
 from .jobrunner import ThreadedJobRunner
@@ -371,7 +372,7 @@ class ConnectionHandler:
         # In RWLock's logic, query_view is the resource reader and the initial
         # build_cells / build_localmodule phase is the resource writer. 
 
-    def query_view(self, view_name, conn_globals):
+    def query_view(self, view_name, conn_globals, ept):
         msg_ret = {
             'msg':'view',
             'view':view_name,
@@ -386,14 +387,14 @@ class ConnectionHandler:
                     report = Report()
                     report.pre(view)
                     view = report
-                viewtype, data = view.webdata()
+                viewtype, data = view.webdata(ept)
             msg_ret['type'] = viewtype
             msg_ret['data'] = data
             if isinstance(view, SubgraphRoot):
                 # Best-effort: user-defined Node classes may lack a wire_id;
                 # a hashing failure must not break view delivery.
                 try:
-                    msg_ret['sg_hash'] = view.subgraph.wire_hash().hex()
+                    msg_ret['sg_hash'] = view.subgraph.wire_hash(ept).hex()
                 except Exception:
                     pass
         except Exception as e:
@@ -559,6 +560,12 @@ class ConnectionHandler:
                 except ConnectionClosed:
                     pass  # late progress/terminal after disconnect
 
+        # Per-connection export table: wire hashes are only ever compared
+        # client-locally, so their scope is the websocket connection, and
+        # the objects the table pins are released when the connection ends
+        # (see ordec.core.wire).
+        ept = ExportTable()
+
         # In-flight view-generation jobs of this connection: req id -> Job.
         # Entries are inserted as None before submit so that an on_done
         # firing during submit (InlineJobRunner) pops the key first and
@@ -587,7 +594,7 @@ class ConnectionHandler:
             with jobs_lock:
                 jobs[req] = None
             job = self.jobrunner.submit(
-                lambda: self.query_view(view_name, conn_globals),
+                lambda: self.query_view(view_name, conn_globals, ept),
                 on_progress=progress_sender(send_msg, req, view_name),
                 on_done=on_done)
             with jobs_lock:

--- a/src/ordec/sim/webdata.py
+++ b/src/ordec/sim/webdata.py
@@ -88,7 +88,7 @@ def _plot_signals(sh: SimHierarchy, x, xlabel):
             height=None,
             group=report.sim,
         )
-    return report.webdata()
+    return report.webdata_static()
 
 
 def webdata_tran(sh: SimHierarchy):
@@ -97,7 +97,7 @@ def webdata_tran(sh: SimHierarchy):
 
 def webdata_dcsweep(sh: SimHierarchy):
     if sh.sim_data is None or sh.sweep_field is None:
-        return Report(fill_height=True).webdata()
+        return Report(fill_height=True).webdata_static()
     return _plot_signals(sh, tuple(sh.sim_data.column(sh.sweep_field)), sh.sweep_field)
 
 
@@ -107,7 +107,7 @@ def webdata_ac(sh: SimHierarchy):
     report = Report(fill_height=True)
     if signals:
         bode_plot(report, *signals, height=None)
-    return report.webdata()
+    return report.webdata_static()
 
 
 def webdata_op(sh: SimHierarchy):
@@ -171,13 +171,13 @@ def webdata_op(sh: SimHierarchy):
             rows.append(f"| {inst_path} | {cells_str} |")
         report.markdown("\n".join(rows))
 
-    return report.webdata()
+    return report.webdata_static()
 
 
 def webdata_nosim(sh: SimHierarchy):
     report = Report()
     report.markdown("No simulation was run.")
-    return report.webdata()
+    return report.webdata_static()
 
 
 @public

--- a/tests/test_ord_runtime.ord
+++ b/tests/test_ord_runtime.ord
@@ -4,6 +4,7 @@
 from ordec.core import *
 from ordec.lib import Res
 from ordec.lib.ihp130 import SG13G2
+from ordec.core.wire import ExportTable
 
 def test_symbol_dot():
     root=Symbol()
@@ -245,12 +246,12 @@ def test_empty_schematic():
 
     sch = EmptySchematic().schematic
     assert sch.symbol is None
-    sch.webdata()
+    sch.webdata(ExportTable())
 
 def test_report_viewgen_uses_schema_runtime():
     view = ReportTestCell().report
     assert isinstance(view, Report)
-    assert "hello" in view.webdata()[1]["elements"][0]["html"]
+    assert "hello" in view.webdata(ExportTable())[1]["elements"][0]["html"]
 
 def test_minimal_layout():
     c = LayoutTestCell()
@@ -359,7 +360,7 @@ def test_toplevel_viewgen_report():
 
     view = toplevel_report()
     assert isinstance(view, Report)
-    assert "toplevel hello" in view.webdata()[1]["elements"][0]["html"]
+    assert "toplevel hello" in view.webdata(ExportTable())[1]["elements"][0]["html"]
     # Cached: repeated calls return the identical view.
     assert toplevel_report() is view
     assert toplevel_report.__doc__ == "A report viewgen outside of a cell."
@@ -449,7 +450,7 @@ def test_viewgen_in_function():
         return inner
 
     view = make_report_view("factory hello")()
-    assert "factory hello" in view.webdata()[1]["elements"][0]["html"]
+    assert "factory hello" in view.webdata(ExportTable())[1]["elements"][0]["html"]
 
 def test_toplevel_viewgen_sim_rejected():
     # Simulation views require a cell's schematic; module-level sim

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -5,6 +5,7 @@ import pytest
 
 from ordec.core.ordb import SubgraphRoot
 from ordec.core.schema import Markdown, PlotGroup, Report
+from ordec.core.wire import ExportTable
 
 
 def test_report_is_ordb_subgraph_root():
@@ -18,7 +19,8 @@ def test_report_is_ordb_subgraph_root():
     frozen = report.freeze()
     assert isinstance(frozen, SubgraphRoot)
     assert frozen.mutable is False
-    assert frozen.webdata() == report.webdata()
+    ept = ExportTable()
+    assert frozen.webdata(ept) == report.webdata(ept)
 
 
 def test_plot2d_webdata():
@@ -32,7 +34,7 @@ def test_plot2d_webdata():
         height=180,
         group=report.tran,
     )
-    _, data = report.webdata()
+    _, data = report.webdata(ExportTable())
     plot_data = data["elements"][0]
     assert plot_data["element_type"] == "plot2d"
     assert plot_data["x"] == [1.0, 2.0, 3.0]
@@ -57,7 +59,7 @@ def test_plot2d_height_none():
         series={"v(out)": [0.1, 0.2, 0.3]},
         height=None,
     )
-    _, data = report.webdata()
+    _, data = report.webdata(ExportTable())
     assert data["elements"][0]["height"] is None
 
 
@@ -68,7 +70,7 @@ def test_passfail_webdata():
         hint="Try harder.")
     report.passfail("Check B", False, instructions="Do the thing.",
         hint="Try harder.")
-    _, data = report.webdata()
+    _, data = report.webdata(ExportTable())
     assert data["elements"][0] == {
         "element_type": "passfail",
         "label": "Check A",
@@ -86,7 +88,7 @@ def test_passfail_webdata():
 def test_markdown_docs_links():
     report = Report()
     report.markdown("See [WebUI](docs:webui.html#local-mode) for details.")
-    _, data = report.webdata()
+    _, data = report.webdata(ExportTable())
     html = data["elements"][0]["html"]
     assert 'target="_blank" rel="noopener" ' \
         'href="https://ordec.readthedocs.io/en/' in html
@@ -99,7 +101,7 @@ def test_markdown_math():
     report.markdown(
         "At $f = \\frac{1}{2*\\pi*\\sqrt{L C}}$ with `.$r=1k` code, "
         "$a<b$ and display: $$x^2 * y$$ Prices like 5 $ stay text.")
-    _, data = report.webdata()
+    _, data = report.webdata(ExportTable())
     html = data["elements"][0]["html"]
     # Math spans reach the client verbatim (markdown2 must not parse the
     # *...* as emphasis), HTML-escaped:
@@ -116,7 +118,7 @@ def test_report_fill_height():
     report = Report(fill_height=True)
     report.markdown("hello")
     assert report.fill_height is True
-    view_type, data = report.webdata()
+    view_type, data = report.webdata(ExportTable())
     assert view_type == "report"
     assert data["fill_height"] is True
 
@@ -124,5 +126,5 @@ def test_report_fill_height():
 def test_report_fill_height_default():
     report = Report()
     assert report.fill_height is False
-    _, data = report.webdata()
+    _, data = report.webdata(ExportTable())
     assert data["fill_height"] is False

--- a/tests/test_server_protocol.py
+++ b/tests/test_server_protocol.py
@@ -41,6 +41,11 @@ def with_progress():
     for i in range(4):
         progress(f"phase {i}", i/4)
     return "progressed"
+
+@generate_func
+def sym():
+    from ordec.lib import Res
+    return Res(r=100).symbol
 '''
 
 @pytest.fixture(scope="module")
@@ -171,6 +176,21 @@ def test_cancel_infinite_loop(proto_server):
         assert 'type' in terminal
     finally:
         c2.close()
+
+def test_view_sg_hash(proto_server):
+    """Subgraph views carry a stable wire hash on the terminal message."""
+    url, key = proto_server
+    c = Client(url, key)
+    try:
+        c.getview('sym()', req=50)
+        _, terminal1 = c.recv_until_terminal(50)
+        c.getview('sym()', req=51)
+        _, terminal2 = c.recv_until_terminal(51)
+        assert len(terminal1['sg_hash']) == 64
+        int(terminal1['sg_hash'], 16)
+        assert terminal1['sg_hash'] == terminal2['sg_hash']
+    finally:
+        c.close()
 
 def test_cancel_unknown_req_ignored(proto_server):
     url, key = proto_server

--- a/tests/test_server_protocol.py
+++ b/tests/test_server_protocol.py
@@ -177,7 +177,7 @@ def test_cancel_infinite_loop(proto_server):
     finally:
         c2.close()
 
-def test_view_sg_hash(proto_server):
+def test_view_wire_hash(proto_server):
     """Subgraph views carry a stable wire hash on the terminal message."""
     url, key = proto_server
     c = Client(url, key)
@@ -186,9 +186,9 @@ def test_view_sg_hash(proto_server):
         _, terminal1 = c.recv_until_terminal(50)
         c.getview('sym()', req=51)
         _, terminal2 = c.recv_until_terminal(51)
-        assert len(terminal1['sg_hash']) == 64
-        int(terminal1['sg_hash'], 16)
-        assert terminal1['sg_hash'] == terminal2['sg_hash']
+        assert len(terminal1['wire_hash']) == 64
+        int(terminal1['wire_hash'], 16)
+        assert terminal1['wire_hash'] == terminal2['wire_hash']
     finally:
         c.close()
 

--- a/tests/test_sim_hierarchy.py
+++ b/tests/test_sim_hierarchy.py
@@ -323,7 +323,8 @@ def test_bode_plot():
     h = lib_test.AcRC().sim_ac_batch
     report = Report()
     report.bode_plot(h.inp, h.out)
-    _, data = report.webdata()
+    from ordec.core.wire import ExportTable
+    _, data = report.webdata(ExportTable())
 
     mag, phase = data["elements"]
     assert mag["ylabel"] == "Magnitude (dB)"
@@ -351,7 +352,8 @@ def test_bode_plot_ref():
     h = lib_test.AcRC().sim_ac_batch
     report = Report()
     bode_plot(report, h.out, ref=h.inp)
-    _, data = report.webdata()
+    from ordec.core.wire import ExportTable
+    _, data = report.webdata(ExportTable())
 
     mag = data["elements"][0]
     expected = [

--- a/tests/test_web_eventbus.py
+++ b/tests/test_web_eventbus.py
@@ -743,3 +743,6 @@ def test_lvs_stale_report_links_inert(web):
     assert not web.driver.execute_script(
         "return document.querySelectorAll('.lvs-item-row.selected').length;"), \
         "Stale report clicks must not select items"
+    assert web.driver.execute_script(
+        "return !!document.querySelector('.refreshbar-flash');"), \
+        "Clicking a stale report must flash the refresh bar"

--- a/tests/test_web_eventbus.py
+++ b/tests/test_web_eventbus.py
@@ -581,6 +581,59 @@ def test_lvs_circuit_links_open_views(web):
 
 
 @pytest.mark.web
+def test_lvs_layout_link_dedup(web):
+    """A circuit-row layout link must focus an already-open panel showing the
+    same subgraph under a different view name instead of opening a duplicate
+    (hash-based fetch-before-open dedup)."""
+    load_lvs_report_view(web)
+
+    # Open the same Layout under its plain view name first.
+    web.driver.execute_script(
+        "window.viewEventBus.emit('layout:request-open', {view: 'layout()'});")
+    web.wait_for_ready()
+    time.sleep(0.5)
+
+    views_before = web.driver.execute_script(
+        "return window.ordecClient.resultViewers.map(rv => rv.viewSelected);")
+    assert 'layout()' in views_before
+    hashes = web.driver.execute_script(
+        "return window.ordecClient.resultViewers.map(rv => rv.viewHash);")
+    assert any(hashes), f"Expected wire hashes on open panels, got {hashes}"
+
+    # The link addresses the same subgraph as an lvs_report()-derived name.
+    web.driver.execute_script(
+        'document.querySelector(\'.lvs-circuit-link[data-kind="layout"]\').click();')
+    time.sleep(0.5)
+    web.wait_for_ready()
+
+    views_after = web.driver.execute_script(
+        "return window.ordecClient.resultViewers.map(rv => rv.viewSelected);")
+    assert views_after == views_before, \
+        f"Layout link must not open a duplicate panel: {views_after}"
+
+    # Selecting an item must land its highlight in the hash-matched layout
+    # panel (highlight events target by name or wire hash) and must not open
+    # a duplicate ref_layout panel either. The item's schematic view is not
+    # open yet, so a new panel for it is expected.
+    web.driver.execute_script("""
+        document.querySelector(
+            '.lvs-item-link[title="Highlight in layout and schematic"]')
+            .closest('.lvs-item-row').click();
+    """)
+    time.sleep(0.5)
+    web.wait_for_ready()
+
+    views = web.driver.execute_script(
+        "return window.ordecClient.resultViewers.map(rv => rv.viewSelected);")
+    assert not any(v and v.endswith('.ref_layout') for v in views), \
+        f"Item select must not open a duplicate layout panel: {views}"
+    state = get_layout_state(web)
+    assert state is not None, "Layout viewer not found"
+    assert state['highlightNumVertices'] > 0, \
+        "Item highlight should land in the hash-matched layout panel"
+
+
+@pytest.mark.web
 def test_lvs_subcircuit_item_select(web):
     """Selecting an LvsItem of a subcircuit pair opens the pair's own
     layout/schematic views and highlights the item there."""

--- a/tests/test_web_eventbus.py
+++ b/tests/test_web_eventbus.py
@@ -707,3 +707,39 @@ def test_lvs_subcircuit_item_select(web):
         "Item should be highlighted in the report-level layout view"
     assert states[sub_views[0]]['highlightNumVertices'] == 0, \
         "Top-level selection must not leave a highlight in the subcircuit's view"
+
+
+@pytest.mark.web
+def test_lvs_stale_report_links_inert(web):
+    """Links and item rows of an outdated report view must not open views
+    or emit selections: stale nids/positions/hashes may not match the
+    regenerated views."""
+    load_lvs_report_view(web)
+
+    views_before = web.driver.execute_script(
+        "return window.ordecClient.resultViewers.map(rv => rv.viewSelected);")
+
+    # Mark the report view outdated, as after a source change.
+    web.driver.execute_script("""
+        const rv = window.ordecClient.resultViewers.find(
+            rv => rv.viewSelected === 'lvs_report()');
+        rv.invalidate();
+    """)
+
+    web.driver.execute_script(
+        'document.querySelector(\'.lvs-circuit-link[data-kind="layout"]\').click();')
+    web.driver.execute_script("""
+        const link = document.querySelector(
+            '.lvs-item-link[title="Highlight in layout and schematic"]');
+        link.closest('.lvs-item-row').click();
+    """)
+    time.sleep(0.5)
+    web.wait_for_ready()
+
+    views = web.driver.execute_script(
+        "return window.ordecClient.resultViewers.map(rv => rv.viewSelected);")
+    assert views == views_before, \
+        f"Stale report clicks must not open views: {views}"
+    assert not web.driver.execute_script(
+        "return document.querySelectorAll('.lvs-item-row.selected').length;"), \
+        "Stale report clicks must not select items"

--- a/tests/test_web_eventbus.py
+++ b/tests/test_web_eventbus.py
@@ -597,7 +597,7 @@ def test_lvs_layout_link_dedup(web):
         "return window.ordecClient.resultViewers.map(rv => rv.viewSelected);")
     assert 'layout()' in views_before
     hashes = web.driver.execute_script(
-        "return window.ordecClient.resultViewers.map(rv => rv.viewHash);")
+        "return window.ordecClient.resultViewers.map(rv => rv.wireHash);")
     assert any(hashes), f"Expected wire hashes on open panels, got {hashes}"
 
     # The link addresses the same subgraph as an lvs_report()-derived name.

--- a/tests/test_wire.py
+++ b/tests/test_wire.py
@@ -6,10 +6,7 @@ from ordec.core import *
 from ordec.core import ordb
 from ordec.core.ordb.base import FarRef, LiveRef, wire_registry
 from ordec.core.schema.base import SourceLocInfo
-from ordec.core.wire import (
-    WireError, export_table, subgraph_from_wire, subgraph_to_wire, wire_deps,
-    wire_hash,
-)
+from ordec.core.wire import WireError, export_table, wire_decode
 
 @pytest.fixture(autouse=True, params=ordb.available_backends())
 def ordb_backend(request):
@@ -66,17 +63,18 @@ def build_head(sub=None, loc_line=1):
 
 def test_determinism():
     a, b = build_head(), build_head()
-    assert subgraph_to_wire(a) == subgraph_to_wire(b)
-    assert wire_hash(a) == wire_hash(b)
+    assert a.subgraph.wire_encode() == b.subgraph.wire_encode()
+    assert a.subgraph.wire_hash() == b.subgraph.wire_hash()
 
 def test_cross_backend_hash():
-    h = wire_hash(build_head())
+    h = build_head().subgraph.wire_hash()
     with ordb.use_backend(ordb.available_backends()[0]):
-        assert wire_hash(build_head()) == h
+        assert build_head().subgraph.wire_hash() == h
 
 def test_hash_sensitivity():
     # SourceLocInfo data (src_loc) participates in the hash:
-    assert wire_hash(build_head(loc_line=2)) != wire_hash(build_head())
+    assert build_head(loc_line=2).subgraph.wire_hash() != \
+        build_head().subgraph.wire_hash()
 
 def test_nid_alloc_sensitivity():
     # nid_alloc.start participates: adding and removing a node leaves the
@@ -91,13 +89,14 @@ def test_nid_alloc_sensitivity():
     temp.remove()
     scarred = scarred.freeze()
     assert dict(scarred.subgraph.nodes) == dict(plain.subgraph.nodes)
-    assert wire_hash(scarred) != wire_hash(plain)
+    assert scarred.subgraph.wire_hash() != plain.subgraph.wire_hash()
 
 def test_roundtrip():
     orig = build_head()
-    back = subgraph_from_wire(subgraph_to_wire(orig), wire_deps(orig))
+    back = wire_decode(orig.subgraph.wire_encode(),
+        orig.subgraph.wire_deps())
     assert back.subgraph == orig.subgraph
-    assert wire_hash(back) == wire_hash(orig)
+    assert back.subgraph.wire_hash() == orig.subgraph.wire_hash()
     # NPath navigation and value types survive:
     assert back.first.pos == Vec2R(1, 2)
     assert back.first.tup == ('a', 1, R(1, 3), Vec2R(5, 6))
@@ -107,26 +106,26 @@ def test_roundtrip():
 
 def test_merkle():
     sub = build_sub()
-    h1 = wire_hash(build_head(sub=sub))
-    assert wire_hash(build_head(sub=sub)) == h1
+    h1 = build_head(sub=sub).subgraph.wire_hash()
+    assert build_head(sub=sub).subgraph.wire_hash() == h1
     # Changed dependency content propagates into the parent hash:
-    assert wire_hash(build_head(sub=build_sub(label='other'))) != h1
+    assert build_head(sub=build_sub(label='other')).subgraph.wire_hash() != h1
 
 def test_roundtrip_real_schematic():
     from ordec.examples.voltagedivider_py import VoltageDivider
     cell = VoltageDivider()
     sch = cell.schematic
-    deps = wire_deps(sch)
-    back = subgraph_from_wire(subgraph_to_wire(sch), deps)
+    deps = sch.subgraph.wire_deps()
+    back = wire_decode(sch.subgraph.wire_encode(), deps)
     assert back.subgraph == sch.subgraph
-    assert wire_hash(back) == wire_hash(sch)
+    assert back.subgraph.wire_hash() == sch.subgraph.wire_hash()
     assert back.cell is cell
     assert back.I1.pos == sch.I1.pos
 
 def test_farref():
     foreign = FarRef(b'\xaa' * 16, 42, name='foreign')
     orig = WHead(obj=foreign).freeze()
-    back = subgraph_from_wire(subgraph_to_wire(orig))
+    back = wire_decode(orig.subgraph.wire_encode())
     assert back.obj == foreign
     assert isinstance(back.obj, FarRef)
     # eq/hash ignore the name metadata:
@@ -136,20 +135,20 @@ def test_farref():
 
 def test_own_endpoint_unknown_objid():
     bogus = FarRef(export_table.endpoint_id, 2**62, name='bogus')
-    data = subgraph_to_wire(WHead(obj=bogus).freeze())
+    data = WHead(obj=bogus).freeze().subgraph.wire_encode()
     with pytest.raises(WireError, match="obj_id"):
-        subgraph_from_wire(data)
+        wire_decode(data)
 
 def test_missing_dep():
     orig = build_head()
     with pytest.raises(WireError, match="dependency"):
-        subgraph_from_wire(subgraph_to_wire(orig), deps={})
+        wire_decode(orig.subgraph.wire_encode(), deps={})
 
 def test_missing_wire_id():
     h = WHead(obj=live_obj)
     h % WNoWire(label='x')
     with pytest.raises(WireError, match="WNoWire"):
-        subgraph_to_wire(h.freeze())
+        h.freeze().subgraph.wire_encode()
 
 def test_wire_id_uniqueness():
     class WFresh(Node):
@@ -162,4 +161,4 @@ def test_wire_id_uniqueness():
 def test_unsupported_value():
     orig = WHead(obj=live_obj, blob=frozenset({1})).freeze()
     with pytest.raises(TypeError, match="WHead.blob"):
-        subgraph_to_wire(orig)
+        orig.subgraph.wire_encode()

--- a/tests/test_wire.py
+++ b/tests/test_wire.py
@@ -6,7 +6,10 @@ from ordec.core import *
 from ordec.core import ordb
 from ordec.core.ordb.base import FarRef, LiveRef, wire_registry
 from ordec.core.schema.base import SourceLocInfo
-from ordec.core.wire import WireError, ExportTable, wire_decode
+from ordec.core.wire import (
+    WireError, ExportTable, wire_decode, WireSender, WireReceiver,
+    compute_wire_hash,
+)
 
 @pytest.fixture(autouse=True, params=ordb.available_backends())
 def ordb_backend(request):
@@ -50,6 +53,12 @@ class WItem(Node):
 class WNoWire(Node):
     in_subgraphs = [WHead]
     label = Attr(str)
+
+class WPair(SubgraphRoot):
+    wire_id = WIRE_DOMAIN | 4
+    label = Attr(str)
+    a = SubgraphRef(WSub)
+    b = SubgraphRef(SubgraphRoot) # WSub or a nested WPair
 
 # One shared live object so repeated builds export the same reference:
 live_obj = object()
@@ -178,3 +187,122 @@ def test_unsupported_value(ept):
     with pytest.raises(TypeError, match="WHead.blob"):
         orig.subgraph.wire_encode(ept)
 
+# Want/have exchange
+# ------------------
+
+def exchange(root, ept_s, ept_r, store=None):
+    """Lock-step pump; returns (result, per-round want lists)."""
+    s = WireSender(root, ept_s)
+    r = WireReceiver(ept_r, store)
+    wants = [r.receive([s.root_block()])]
+    while wants[-1]:
+        wants.append(r.receive(s.serve(wants[-1])))
+    return r.result, wants
+
+def test_exchange_empty_store(ept):
+    orig = build_head()
+    store = {}
+    back, wants = exchange(orig, ept, ept, store)
+    assert back.subgraph == orig.subgraph
+    assert back.obj is live_obj
+    assert back.second.ref == back.first
+    # Exactly one round: only the child is missing.
+    sub_hash = orig.sub.subgraph.wire_hash(ept)
+    assert wants == [[sub_hash], []]
+    assert set(store) == {orig.subgraph.wire_hash(ept), sub_hash}
+    # The pre-seeded hash memo matches an actual recomputation
+    # (encode/decode asymmetry guard):
+    assert back.subgraph.wire_hash(ept) == orig.subgraph.wire_hash(ept)
+    assert compute_wire_hash(back.subgraph, ept) == \
+        back.subgraph.wire_hash(ept)
+
+def test_exchange_store_hit(ept):
+    store = {}
+    orig = build_head()
+    back1, _ = exchange(orig, ept, ept, store)
+    # Everything is in the store now; the root block alone completes the
+    # exchange and yields the identical stored object.
+    back2, wants = exchange(orig, ept, ept, store)
+    assert wants == [[]]
+    assert back2.subgraph is back1.subgraph
+
+def test_exchange_partial_store(ept):
+    sub1, sub2 = build_sub('one'), build_sub('two')
+    pair = WPair(a=sub1, b=sub2).freeze()
+    store = {}
+    exchange(sub1, ept, ept, store)
+    # Only the missing child is requested:
+    back, wants = exchange(pair, ept, ept, store)
+    assert wants[0] == [sub2.subgraph.wire_hash(ept)]
+    assert back.a.subgraph is store[sub1.subgraph.wire_hash(ept)]
+
+def test_exchange_depth_rounds(ept):
+    mid = WPair(a=build_sub('m'), b=build_sub('leaf')).freeze()
+    top = WPair(a=build_sub('t'), b=mid).freeze()
+    # Round trips scale with the depth of the missing part of the DAG:
+    back, wants = exchange(top, ept, ept)
+    assert len(wants) == 3 # top's children; mid's children; done
+    assert back.b.b.label == 'leaf'
+
+def test_exchange_diamond(ept):
+    sub = build_sub()
+    inner = WPair(a=sub, b=build_sub('x')).freeze()
+    outer = WPair(a=sub, b=inner).freeze()
+    # The shared child is wanted once and materializes as one object:
+    back, wants = exchange(outer, ept, ept)
+    sub_hash = sub.subgraph.wire_hash(ept)
+    assert [h for w in wants for h in w].count(sub_hash) == 1
+    assert back.a.subgraph is back.b.a.subgraph
+
+def test_exchange_two_endpoints(ept):
+    ept2 = ExportTable()
+    orig = build_head()
+    back, _ = exchange(orig, ept, ept2)
+    # The live object decodes to an opaque FarRef of the sender's endpoint:
+    assert isinstance(back.obj, FarRef)
+    assert back.obj.endpoint_id == ept.endpoint_id
+    # FarRefs relay verbatim, so re-encoding under the receiver's table
+    # reproduces the sender's bytes and hash:
+    assert compute_wire_hash(back.subgraph, ept2) == \
+        orig.subgraph.wire_hash(ept)
+
+def test_exchange_real_schematic(ept):
+    from ordec.examples.voltagedivider_py import VoltageDivider
+    cell = VoltageDivider()
+    sch = cell.schematic
+    back, wants = exchange(sch, ept, ept)
+    assert back.subgraph == sch.subgraph
+    assert back.cell is cell
+    assert len(wants) >= 2 # symbol children were actually transferred
+
+def test_exchange_corrupt_block(ept):
+    s = WireSender(build_head(), ept)
+    r = WireReceiver(ept)
+    h, data = s.root_block()
+    with pytest.raises(WireError, match="announced hash"):
+        r.receive([(h, data + b'\x00')])
+
+def test_exchange_unrequested_block(ept):
+    s = WireSender(build_head(), ept)
+    r = WireReceiver(ept)
+    r.receive([s.root_block()])
+    stray = build_sub('stray').subgraph
+    with pytest.raises(WireError, match="never wanted"):
+        r.receive([(stray.wire_hash(ept), stray.wire_encode(ept))])
+
+def test_exchange_serve_unknown(ept):
+    s = WireSender(build_head(), ept)
+    with pytest.raises(WireError, match="never announced"):
+        s.serve([b'\x00' * 32])
+
+def test_exchange_state_misuse(ept):
+    s = WireSender(build_head(), ept)
+    r = WireReceiver(ept)
+    assert r.receive([s.root_block()]) # incomplete: child missing
+    with pytest.raises(WireError, match="not complete"):
+        r.result
+    sub = build_sub()
+    r2 = WireReceiver(ept)
+    assert r2.receive([WireSender(sub, ept).root_block()]) == []
+    with pytest.raises(WireError, match="already complete"):
+        r2.receive([])

--- a/tests/test_wire.py
+++ b/tests/test_wire.py
@@ -1,0 +1,165 @@
+# SPDX-FileCopyrightText: 2026 ORDeC contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from ordec.core import *
+from ordec.core import ordb
+from ordec.core.ordb.base import FarRef, LiveRef, wire_registry
+from ordec.core.schema.base import SourceLocInfo
+from ordec.core.wire import (
+    WireError, export_table, subgraph_from_wire, subgraph_to_wire, wire_deps,
+    wire_hash,
+)
+
+@pytest.fixture(autouse=True, params=ordb.available_backends())
+def ordb_backend(request):
+    """Wire bytes and hashes must be identical across storage backends."""
+    with ordb.use_backend(request.param):
+        yield request.param
+
+# Custom test schema (wire_id domain 15<<16 is reserved for tests):
+WIRE_DOMAIN = 15 << 16
+
+class WSub(SubgraphRoot):
+    wire_id = WIRE_DOMAIN | 1
+    label = Attr(str)
+
+class WHead(SubgraphRoot):
+    wire_id = WIRE_DOMAIN | 2
+    sub = SubgraphRef(WSub)
+    obj = LiveRef(object)
+    blob = Attr(object)
+
+class WItem(Node):
+    in_subgraphs = [WHead]
+    wire_id = WIRE_DOMAIN | 3
+    ref = LocalRef('WItem', refcheck_custom=lambda val: issubclass(val, WItem))
+    label = Attr(str|int, typecheck_custom=lambda v: isinstance(v, (str, int)))
+    pos = Attr(Vec2R)
+    rect = Attr(Rect4R)
+    d4 = Attr(D4)
+    r = Attr(R)
+    f = Attr(float)
+    b = Attr(bool)
+    raw = Attr(bytes)
+    tup = Attr(tuple)
+    loc = Attr(SourceLocInfo)
+
+class WNoWire(Node):
+    in_subgraphs = [WHead]
+    label = Attr(str)
+
+# One shared live object so repeated builds export the same reference:
+live_obj = object()
+
+def build_sub(label='sub'):
+    return WSub(label=label).freeze()
+
+def build_head(sub=None, loc_line=1):
+    h = WHead(sub=sub or build_sub(), obj=live_obj)
+    h.first = WItem(label='first', pos=Vec2R(1, 2),
+        rect=Rect4R(0, 0, 3, 4), d4=D4.MY90, r=R('1k'), f=1.5, b=True,
+        raw=b'\x00\xff', tup=('a', 1, R(1, 3), Vec2R(5, 6)),
+        loc=SourceLocInfo('x.ord', loc_line, 0))
+    h.second = WItem(label=7, ref=h.first)
+    return h.freeze()
+
+def test_determinism():
+    a, b = build_head(), build_head()
+    assert subgraph_to_wire(a) == subgraph_to_wire(b)
+    assert wire_hash(a) == wire_hash(b)
+
+def test_cross_backend_hash():
+    h = wire_hash(build_head())
+    with ordb.use_backend(ordb.available_backends()[0]):
+        assert wire_hash(build_head()) == h
+
+def test_hash_sensitivity():
+    # SourceLocInfo data (src_loc) participates in the hash:
+    assert wire_hash(build_head(loc_line=2)) != wire_hash(build_head())
+
+def test_nid_alloc_sensitivity():
+    # nid_alloc.start participates: adding and removing a node leaves the
+    # same nodes but different allocation state than never adding it.
+    def head_with_first():
+        h = WHead(obj=live_obj)
+        h.first = WItem(label='first')
+        return h
+    plain = head_with_first().freeze()
+    scarred = head_with_first()
+    temp = scarred % WItem(label='temp')
+    temp.remove()
+    scarred = scarred.freeze()
+    assert dict(scarred.subgraph.nodes) == dict(plain.subgraph.nodes)
+    assert wire_hash(scarred) != wire_hash(plain)
+
+def test_roundtrip():
+    orig = build_head()
+    back = subgraph_from_wire(subgraph_to_wire(orig), wire_deps(orig))
+    assert back.subgraph == orig.subgraph
+    assert wire_hash(back) == wire_hash(orig)
+    # NPath navigation and value types survive:
+    assert back.first.pos == Vec2R(1, 2)
+    assert back.first.tup == ('a', 1, R(1, 3), Vec2R(5, 6))
+    assert back.second.ref == back.first
+    # The live object comes back as the identical object:
+    assert back.obj is live_obj
+
+def test_merkle():
+    sub = build_sub()
+    h1 = wire_hash(build_head(sub=sub))
+    assert wire_hash(build_head(sub=sub)) == h1
+    # Changed dependency content propagates into the parent hash:
+    assert wire_hash(build_head(sub=build_sub(label='other'))) != h1
+
+def test_roundtrip_real_schematic():
+    from ordec.examples.voltagedivider_py import VoltageDivider
+    cell = VoltageDivider()
+    sch = cell.schematic
+    deps = wire_deps(sch)
+    back = subgraph_from_wire(subgraph_to_wire(sch), deps)
+    assert back.subgraph == sch.subgraph
+    assert wire_hash(back) == wire_hash(sch)
+    assert back.cell is cell
+    assert back.I1.pos == sch.I1.pos
+
+def test_farref():
+    foreign = FarRef(b'\xaa' * 16, 42, name='foreign')
+    orig = WHead(obj=foreign).freeze()
+    back = subgraph_from_wire(subgraph_to_wire(orig))
+    assert back.obj == foreign
+    assert isinstance(back.obj, FarRef)
+    # eq/hash ignore the name metadata:
+    assert back.obj == FarRef(b'\xaa' * 16, 42, name='renamed')
+    assert hash(foreign) == hash(FarRef(b'\xaa' * 16, 42))
+    assert foreign != FarRef(b'\xbb' * 16, 42)
+
+def test_own_endpoint_unknown_objid():
+    bogus = FarRef(export_table.endpoint_id, 2**62, name='bogus')
+    data = subgraph_to_wire(WHead(obj=bogus).freeze())
+    with pytest.raises(WireError, match="obj_id"):
+        subgraph_from_wire(data)
+
+def test_missing_dep():
+    orig = build_head()
+    with pytest.raises(WireError, match="dependency"):
+        subgraph_from_wire(subgraph_to_wire(orig), deps={})
+
+def test_missing_wire_id():
+    h = WHead(obj=live_obj)
+    h % WNoWire(label='x')
+    with pytest.raises(WireError, match="WNoWire"):
+        subgraph_to_wire(h.freeze())
+
+def test_wire_id_uniqueness():
+    class WFresh(Node):
+        wire_id = WIRE_DOMAIN | 999
+    assert wire_registry[WIRE_DOMAIN | 999] is WFresh
+    with pytest.raises(TypeError, match="already used"):
+        class WCollision(Node):
+            wire_id = WIRE_DOMAIN | 999
+
+def test_unsupported_value():
+    orig = WHead(obj=live_obj, blob=frozenset({1})).freeze()
+    with pytest.raises(TypeError, match="WHead.blob"):
+        subgraph_to_wire(orig)

--- a/tests/test_wire.py
+++ b/tests/test_wire.py
@@ -6,13 +6,18 @@ from ordec.core import *
 from ordec.core import ordb
 from ordec.core.ordb.base import FarRef, LiveRef, wire_registry
 from ordec.core.schema.base import SourceLocInfo
-from ordec.core.wire import WireError, export_table, wire_decode
+from ordec.core.wire import WireError, ExportTable, wire_decode
 
 @pytest.fixture(autouse=True, params=ordb.available_backends())
 def ordb_backend(request):
     """Wire bytes and hashes must be identical across storage backends."""
     with ordb.use_backend(request.param):
         yield request.param
+
+@pytest.fixture
+def ept():
+    """Fresh endpoint (export table) per test; there is no global one."""
+    return ExportTable()
 
 # Custom test schema (wire_id domain 15<<16 is reserved for tests):
 WIRE_DOMAIN = 15 << 16
@@ -61,22 +66,22 @@ def build_head(sub=None, loc_line=1):
     h.second = WItem(label=7, ref=h.first)
     return h.freeze()
 
-def test_determinism():
+def test_determinism(ept):
     a, b = build_head(), build_head()
-    assert a.subgraph.wire_encode() == b.subgraph.wire_encode()
-    assert a.subgraph.wire_hash() == b.subgraph.wire_hash()
+    assert a.subgraph.wire_encode(ept) == b.subgraph.wire_encode(ept)
+    assert a.subgraph.wire_hash(ept) == b.subgraph.wire_hash(ept)
 
-def test_cross_backend_hash():
-    h = build_head().subgraph.wire_hash()
+def test_cross_backend_hash(ept):
+    h = build_head().subgraph.wire_hash(ept)
     with ordb.use_backend(ordb.available_backends()[0]):
-        assert build_head().subgraph.wire_hash() == h
+        assert build_head().subgraph.wire_hash(ept) == h
 
-def test_hash_sensitivity():
+def test_hash_sensitivity(ept):
     # SourceLocInfo data (src_loc) participates in the hash:
-    assert build_head(loc_line=2).subgraph.wire_hash() != \
-        build_head().subgraph.wire_hash()
+    assert build_head(loc_line=2).subgraph.wire_hash(ept) != \
+        build_head().subgraph.wire_hash(ept)
 
-def test_nid_alloc_sensitivity():
+def test_nid_alloc_sensitivity(ept):
     # nid_alloc.start participates: adding and removing a node leaves the
     # same nodes but different allocation state than never adding it.
     def head_with_first():
@@ -89,14 +94,14 @@ def test_nid_alloc_sensitivity():
     temp.remove()
     scarred = scarred.freeze()
     assert dict(scarred.subgraph.nodes) == dict(plain.subgraph.nodes)
-    assert scarred.subgraph.wire_hash() != plain.subgraph.wire_hash()
+    assert scarred.subgraph.wire_hash(ept) != plain.subgraph.wire_hash(ept)
 
-def test_roundtrip():
+def test_roundtrip(ept):
     orig = build_head()
-    back = wire_decode(orig.subgraph.wire_encode(),
-        orig.subgraph.wire_deps())
+    back = wire_decode(orig.subgraph.wire_encode(ept), ept,
+        orig.subgraph.wire_deps(ept))
     assert back.subgraph == orig.subgraph
-    assert back.subgraph.wire_hash() == orig.subgraph.wire_hash()
+    assert back.subgraph.wire_hash(ept) == orig.subgraph.wire_hash(ept)
     # NPath navigation and value types survive:
     assert back.first.pos == Vec2R(1, 2)
     assert back.first.tup == ('a', 1, R(1, 3), Vec2R(5, 6))
@@ -104,28 +109,38 @@ def test_roundtrip():
     # The live object comes back as the identical object:
     assert back.obj is live_obj
 
-def test_merkle():
+def test_merkle(ept):
     sub = build_sub()
-    h1 = build_head(sub=sub).subgraph.wire_hash()
-    assert build_head(sub=sub).subgraph.wire_hash() == h1
+    h1 = build_head(sub=sub).subgraph.wire_hash(ept)
+    assert build_head(sub=sub).subgraph.wire_hash(ept) == h1
     # Changed dependency content propagates into the parent hash:
-    assert build_head(sub=build_sub(label='other')).subgraph.wire_hash() != h1
+    assert build_head(sub=build_sub(label='other')) \
+        .subgraph.wire_hash(ept) != h1
 
-def test_roundtrip_real_schematic():
+def test_hash_endpoint_scoped(ept):
+    # The same subgraph hashes differently under different endpoints
+    # (export refs participate in the hashed bytes), and the single-entry
+    # memo recomputes rather than leaking a stale table's hash.
+    head = build_head()
+    h1 = head.subgraph.wire_hash(ept)
+    assert head.subgraph.wire_hash(ExportTable()) != h1
+    assert head.subgraph.wire_hash(ept) == h1
+
+def test_roundtrip_real_schematic(ept):
     from ordec.examples.voltagedivider_py import VoltageDivider
     cell = VoltageDivider()
     sch = cell.schematic
-    deps = sch.subgraph.wire_deps()
-    back = wire_decode(sch.subgraph.wire_encode(), deps)
+    deps = sch.subgraph.wire_deps(ept)
+    back = wire_decode(sch.subgraph.wire_encode(ept), ept, deps)
     assert back.subgraph == sch.subgraph
-    assert back.subgraph.wire_hash() == sch.subgraph.wire_hash()
+    assert back.subgraph.wire_hash(ept) == sch.subgraph.wire_hash(ept)
     assert back.cell is cell
     assert back.I1.pos == sch.I1.pos
 
-def test_farref():
+def test_farref(ept):
     foreign = FarRef(b'\xaa' * 16, 42, name='foreign')
     orig = WHead(obj=foreign).freeze()
-    back = wire_decode(orig.subgraph.wire_encode())
+    back = wire_decode(orig.subgraph.wire_encode(ept), ept)
     assert back.obj == foreign
     assert isinstance(back.obj, FarRef)
     # eq/hash ignore the name metadata:
@@ -133,22 +148,22 @@ def test_farref():
     assert hash(foreign) == hash(FarRef(b'\xaa' * 16, 42))
     assert foreign != FarRef(b'\xbb' * 16, 42)
 
-def test_own_endpoint_unknown_objid():
-    bogus = FarRef(export_table.endpoint_id, 2**62, name='bogus')
-    data = WHead(obj=bogus).freeze().subgraph.wire_encode()
+def test_own_endpoint_unknown_objid(ept):
+    bogus = FarRef(ept.endpoint_id, 2**62, name='bogus')
+    data = WHead(obj=bogus).freeze().subgraph.wire_encode(ept)
     with pytest.raises(WireError, match="obj_id"):
-        wire_decode(data)
+        wire_decode(data, ept)
 
-def test_missing_dep():
+def test_missing_dep(ept):
     orig = build_head()
     with pytest.raises(WireError, match="dependency"):
-        wire_decode(orig.subgraph.wire_encode(), deps={})
+        wire_decode(orig.subgraph.wire_encode(ept), ept, deps={})
 
-def test_missing_wire_id():
+def test_missing_wire_id(ept):
     h = WHead(obj=live_obj)
     h % WNoWire(label='x')
     with pytest.raises(WireError, match="WNoWire"):
-        h.freeze().subgraph.wire_encode()
+        h.freeze().subgraph.wire_encode(ept)
 
 def test_wire_id_uniqueness():
     class WFresh(Node):
@@ -158,7 +173,8 @@ def test_wire_id_uniqueness():
         class WCollision(Node):
             wire_id = WIRE_DOMAIN | 999
 
-def test_unsupported_value():
+def test_unsupported_value(ept):
     orig = WHead(obj=live_obj, blob=frozenset({1})).freeze()
     with pytest.raises(TypeError, match="WHead.blob"):
-        orig.subgraph.wire_encode()
+        orig.subgraph.wire_encode(ept)
+

--- a/tests/test_wire_subprocess.py
+++ b/tests/test_wire_subprocess.py
@@ -1,0 +1,160 @@
+# SPDX-FileCopyrightText: 2026 ORDeC contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Demo: wire exchange with a cold subprocess over pipes.
+
+The main process assembles a current-mirror schematic (instances, nets,
+conns — everything except wiring), transfers it to a freshly spawned
+Python subprocess via the want/have exchange over stdin/stdout pipes, and
+receives back the auto_wire()d schematic. This exercises the full wire
+stack end to end without any RPC machinery: Merkle deps (symbols travel
+as separate blocks), the receiver store (symbols are not retransmitted on
+the return trip), LiveRef export (the schematic's cell decodes to an
+opaque FarRef in the subprocess, relays verbatim, and resolves back to
+the identical live object at home).
+
+This file doubles as the worker: run as a script, it acts as the
+subprocess side (receive, auto_wire, send back).
+"""
+
+import struct
+import subprocess
+import sys
+
+import cbor2
+
+from ordec.core import *
+from ordec.core.wire import ExportTable, WireSender, WireReceiver
+
+
+# Message framing: 4-byte little-endian length prefix, CBOR [kind, payload].
+# Wire blocks/wants are plain bytes values, so CBOR carries them natively.
+
+def read_exact(f, n):
+    buf = b''
+    while len(buf) < n:
+        chunk = f.read(n - len(buf))
+        if not chunk:
+            raise EOFError("peer closed the pipe")
+        buf += chunk
+    return buf
+
+
+def send_msg(f, kind, payload):
+    data = cbor2.dumps([kind, payload])
+    f.write(struct.pack("<I", len(data)))
+    f.write(data)
+    f.flush()
+
+
+def recv_msg(f, expect):
+    n, = struct.unpack("<I", read_exact(f, 4))
+    kind, payload = cbor2.loads(read_exact(f, n))
+    if kind != expect:
+        raise ValueError(f"expected {expect!r} message, got {kind!r}")
+    return payload
+
+
+def send_subgraph(fin, fout, root, ept):
+    """Drive a WireSender against the peer's receiver (lock-step)."""
+    sender = WireSender(root, ept)
+    send_msg(fout, "blocks", [list(sender.root_block())])
+    while True:
+        want = [bytes(h) for h in recv_msg(fin, "want")]
+        if not want:
+            return
+        send_msg(fout, "blocks", [list(b) for b in sender.serve(want)])
+
+
+def recv_subgraph(fin, fout, ept, store):
+    """Drive a WireReceiver against the peer's sender (lock-step)."""
+    receiver = WireReceiver(ept, store)
+    while True:
+        blocks = [(bytes(h), bytes(d)) for h, d in recv_msg(fin, "blocks")]
+        want = receiver.receive(blocks)
+        send_msg(fout, "want", want)
+        if not want:
+            return receiver.result
+
+
+class MirrorDemo(Cell):
+    pass
+
+
+def build_unwired_mirror():
+    """The currentmirror.ord schematic, stopped right before auto_wire."""
+    from ordec.lib.generic_mos import Nmos
+    from ordec.lib import Res, Vdc, Idc, Gnd
+
+    cell = MirrorDemo()
+    s = Schematic(cell=cell)
+    s.vss = Net()
+    s.vdd = Net()
+    s.l = Net()
+    s.r = Net()
+    s.n0 = SchemInstance(
+        Nmos(w=R('500n')).symbol.portmap(d=s.l, g=s.l, s=s.vss, b=s.vss),
+        pos=Vec2R(10, 6), orientation=D4.FlippedSouth)
+    s.n1 = SchemInstance(
+        Nmos(w=R('1500n')).symbol.portmap(d=s.r, g=s.l, s=s.vss, b=s.vss),
+        pos=Vec2R(14, 6))
+    s.gnd = SchemInstance(Gnd().symbol.portmap(p=s.vss), pos=Vec2R(0, 0))
+    s.isrc = SchemInstance(Idc(dc=R('10u')).symbol.portmap(p=s.vdd, n=s.l),
+        pos=Vec2R(6, 12))
+    s.vsrc = SchemInstance(Vdc(dc=R(5)).symbol.portmap(p=s.vdd, n=s.vss),
+        pos=Vec2R(0, 9))
+    s.r0 = SchemInstance(Res(r=R('10k')).symbol.portmap(p=s.vdd, n=s.r),
+        pos=Vec2R(14, 12))
+    return s.freeze(), cell
+
+
+def wire_schematic(frozen_root):
+    """The tail of SchematicViewContext.postprocess: auto_wire + check."""
+    root = frozen_root.thaw()
+    root.auto_wire()
+    root.check(add_conn_points=True, add_terminal_taps=True)
+    return root.freeze()
+
+
+def worker():
+    fin, fout = sys.stdin.buffer, sys.stdout.buffer
+    ept = ExportTable()
+    sch = recv_subgraph(fin, fout, ept, store={})
+    send_subgraph(fin, fout, wire_schematic(sch), ept)
+
+
+def test_autowire_in_subprocess():
+    orig, cell = build_unwired_mirror()
+    ept = ExportTable()
+    proc = subprocess.Popen([sys.executable, __file__],
+        stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+    try:
+        send_subgraph(proc.stdout, proc.stdin, orig, ept)
+        # Receiver store pre-seeded with everything this endpoint already
+        # holds, so the return trip transfers only the wired schematic.
+        store = dict(orig.subgraph.wire_deps(ept))
+        store[orig.subgraph.wire_hash(ept)] = orig.subgraph
+        back = recv_subgraph(proc.stdout, proc.stdin, ept, store)
+    finally:
+        proc.stdin.close()
+        proc.stdout.close()
+        assert proc.wait(timeout=30) == 0
+
+    # The subprocess produced the same wiring the local router computes:
+    assert back.subgraph == wire_schematic(orig).subgraph
+    assert len(list(back.all(SchemWire))) > 0
+    # LiveRef round trip: opaque FarRef in the subprocess, relayed
+    # verbatim, resolved back to the identical live object at home.
+    assert back.cell is cell
+    # Symbols came from the local store, not from retransmission:
+    assert back.n0.symbol.subgraph is orig.n0.symbol.subgraph
+
+
+# Dual purpose: under pytest this file is the main-process side (test +
+# builders); executed as a script (which is how the test spawns it), it is
+# the worker side. Keeping both in one file lets them share the framing,
+# the pumps, and wire_schematic(), and the spawn can never point at a
+# stale worker path.
+if __name__ == "__main__":
+    worker()

--- a/web/src/client.js
+++ b/web/src/client.js
@@ -211,7 +211,7 @@ export class OrdecClient {
                 rv.currentReq = req;
                 // Displayed content is stale from here until the terminal
                 // view message arrives; do not hash-match against it.
-                rv.viewHash = null;
+                rv.wireHash = null;
                 this.inflight.set(req, rv);
                 this.sock.send(JSON.stringify({
                     msg: 'getview',

--- a/web/src/client.js
+++ b/web/src/client.js
@@ -209,6 +209,9 @@ export class OrdecClient {
                 }
                 const req = ++this.reqCounter;
                 rv.currentReq = req;
+                // Displayed content is stale from here until the terminal
+                // view message arrives; do not hash-match against it.
+                rv.viewHash = null;
                 this.inflight.set(req, rv);
                 this.sock.send(JSON.stringify({
                     msg: 'getview',

--- a/web/src/layout-gl.js
+++ b/web/src/layout-gl.js
@@ -211,7 +211,7 @@ export class LayoutGL {
             // wire hash for a viewer showing the same subgraph under a
             // different view name.
             if (data && data.layoutView && data.layoutView !== this.viewName
-                    && !(data.layoutHash && data.layoutHash === this.viewHash)) {
+                    && !(data.layoutWireHash && data.layoutWireHash === this.wireHash)) {
                 return;
             }
             this.setHighlight(data.shapes);
@@ -225,7 +225,7 @@ export class LayoutGL {
             // subcircuit pairs) apply to viewers showing that view, matched
             // by name or by wire hash.
             if (data && data.layoutView && data.layoutView !== this.viewName
-                    && !(data.layoutHash && data.layoutHash === this.viewHash)) {
+                    && !(data.layoutWireHash && data.layoutWireHash === this.wireHash)) {
                 return;
             }
             this.highlightPos(data.pos);
@@ -312,7 +312,7 @@ export class LayoutGL {
             const pendingDrc = this._pendingDrc;
             this._pendingDrc = null;
             if (!pendingDrc.layoutView || pendingDrc.layoutView === this.viewName
-                    || (pendingDrc.layoutHash && pendingDrc.layoutHash === this.viewHash)) {
+                    || (pendingDrc.layoutWireHash && pendingDrc.layoutWireHash === this.wireHash)) {
                 // Zoom to the highlight instead of the full view below.
                 this._pendingHighlight = pendingDrc.shapes;
                 this.setHighlight(pendingDrc.shapes, false); // Don't zoom yet
@@ -323,7 +323,7 @@ export class LayoutGL {
             const pendingLvs = this._pendingLvs;
             this._pendingLvs = null;
             if (!pendingLvs.layoutView || pendingLvs.layoutView === this.viewName
-                    || (pendingLvs.layoutHash && pendingLvs.layoutHash === this.viewHash)) {
+                    || (pendingLvs.layoutWireHash && pendingLvs.layoutWireHash === this.wireHash)) {
                 this.highlightPos(pendingLvs.pos, false);
             }
         }

--- a/web/src/layout-gl.js
+++ b/web/src/layout-gl.js
@@ -207,8 +207,11 @@ export class LayoutGL {
 
         this._onDrcSelect = (data) => {
             // DRC selections target the view of the violation's cell; they
-            // only apply to the viewer showing exactly that view.
-            if (data && data.layoutView && data.layoutView !== this.viewName) {
+            // apply to viewers showing that view: matched by name, or by
+            // wire hash for a viewer showing the same subgraph under a
+            // different view name.
+            if (data && data.layoutView && data.layoutView !== this.viewName
+                    && !(data.layoutHash && data.layoutHash === this.viewHash)) {
                 return;
             }
             this.setHighlight(data.shapes);
@@ -219,8 +222,10 @@ export class LayoutGL {
 
         this._onLvsSelect = (data) => {
             // Selections targeted at a specific layout view (items of LVS
-            // subcircuit pairs) only apply to that view.
-            if (data && data.layoutView && data.layoutView !== this.viewName) {
+            // subcircuit pairs) apply to viewers showing that view, matched
+            // by name or by wire hash.
+            if (data && data.layoutView && data.layoutView !== this.viewName
+                    && !(data.layoutHash && data.layoutHash === this.viewHash)) {
                 return;
             }
             this.highlightPos(data.pos);
@@ -306,7 +311,8 @@ export class LayoutGL {
         if (this._pendingDrc) {
             const pendingDrc = this._pendingDrc;
             this._pendingDrc = null;
-            if (!pendingDrc.layoutView || pendingDrc.layoutView === this.viewName) {
+            if (!pendingDrc.layoutView || pendingDrc.layoutView === this.viewName
+                    || (pendingDrc.layoutHash && pendingDrc.layoutHash === this.viewHash)) {
                 // Zoom to the highlight instead of the full view below.
                 this._pendingHighlight = pendingDrc.shapes;
                 this.setHighlight(pendingDrc.shapes, false); // Don't zoom yet
@@ -316,7 +322,8 @@ export class LayoutGL {
         if (this._pendingLvs) {
             const pendingLvs = this._pendingLvs;
             this._pendingLvs = null;
-            if (!pendingLvs.layoutView || pendingLvs.layoutView === this.viewName) {
+            if (!pendingLvs.layoutView || pendingLvs.layoutView === this.viewName
+                    || (pendingLvs.layoutHash && pendingLvs.layoutHash === this.viewHash)) {
                 this.highlightPos(pendingLvs.pos, false);
             }
         }

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -215,6 +215,26 @@ function findResultViewerByView(viewName) {
     return null;
 }
 
+function findResultViewerByHash(hash) {
+    for (const item of layout.root.getAllContentItems()) {
+        if (!item.isComponent || item.componentName !== 'result') continue;
+        if (item.component.viewHash === hash) {
+            return item;
+        }
+    }
+    return null;
+}
+
+function resolveExistingViewer(viewName, hash) {
+    // Name match first; otherwise match by subgraph wire hash: the same
+    // subgraph is often reachable under several names (e.g. X().layout vs
+    // X().lvs.ref_layout), and opening it twice should be avoided. The hash
+    // comes with the requesting view's data (e.g. layout_hash in report
+    // webdata), so the lookup is purely local.
+    return findResultViewerByView(viewName)
+        || (hash ? findResultViewerByHash(hash) : null);
+}
+
 function getEditor() {
     let ret;
     layout.root.getAllContentItems().forEach(e => {
@@ -437,7 +457,7 @@ function openOrActivateView(data) {
     const view = data.view;
 
     if (view) {
-        const existing = findResultViewerByView(view);
+        const existing = resolveExistingViewer(view, data.hash);
         if (existing) {
             existing.focus();
             return;
@@ -491,14 +511,18 @@ viewEventBus.on('editor:goto-source', (data) => {
 });
 
 viewEventBus.on('lvs:request-open-views', (data) => {
-    const { layoutView, schemView, sourceContainer } = data;
+    const { layoutView, schemView, layoutHash, schemHash, sourceContainer } = data;
+
+    const layoutExisting = layoutView
+        ? resolveExistingViewer(layoutView, layoutHash) : null;
+    const schemExisting = schemView
+        ? resolveExistingViewer(schemView, schemHash) : null;
 
     const columnContent = [];
 
     if (layoutView) {
-        const existing = findResultViewerByView(layoutView);
-        if (existing) {
-            existing.focus();
+        if (layoutExisting) {
+            layoutExisting.focus();
         } else {
             columnContent.push({
                 type: 'component',
@@ -510,9 +534,8 @@ viewEventBus.on('lvs:request-open-views', (data) => {
     }
 
     if (schemView) {
-        const existing = findResultViewerByView(schemView);
-        if (existing) {
-            existing.focus();
+        if (schemExisting) {
+            schemExisting.focus();
         } else {
             columnContent.push({
                 type: 'component',

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -215,24 +215,24 @@ function findResultViewerByView(viewName) {
     return null;
 }
 
-function findResultViewerByHash(hash) {
+function findResultViewerByWireHash(wireHash) {
     for (const item of layout.root.getAllContentItems()) {
         if (!item.isComponent || item.componentName !== 'result') continue;
-        if (item.component.viewHash === hash) {
+        if (item.component.wireHash === wireHash) {
             return item;
         }
     }
     return null;
 }
 
-function resolveExistingViewer(viewName, hash) {
+function resolveExistingViewer(viewName, wireHash) {
     // Name match first; otherwise match by subgraph wire hash: the same
     // subgraph is often reachable under several names (e.g. X().layout vs
     // X().lvs.ref_layout), and opening it twice should be avoided. The hash
-    // comes with the requesting view's data (e.g. layout_hash in report
+    // comes with the requesting view's data (e.g. layout_wire_hash in report
     // webdata), so the lookup is purely local.
     return findResultViewerByView(viewName)
-        || (hash ? findResultViewerByHash(hash) : null);
+        || (wireHash ? findResultViewerByWireHash(wireHash) : null);
 }
 
 function getEditor() {
@@ -457,7 +457,7 @@ function openOrActivateView(data) {
     const view = data.view;
 
     if (view) {
-        const existing = resolveExistingViewer(view, data.hash);
+        const existing = resolveExistingViewer(view, data.wireHash);
         if (existing) {
             existing.focus();
             return;
@@ -511,12 +511,12 @@ viewEventBus.on('editor:goto-source', (data) => {
 });
 
 viewEventBus.on('lvs:request-open-views', (data) => {
-    const { layoutView, schemView, layoutHash, schemHash, sourceContainer } = data;
+    const { layoutView, schemView, layoutWireHash, schemWireHash, sourceContainer } = data;
 
     const layoutExisting = layoutView
-        ? resolveExistingViewer(layoutView, layoutHash) : null;
+        ? resolveExistingViewer(layoutView, layoutWireHash) : null;
     const schemExisting = schemView
-        ? resolveExistingViewer(schemView, schemHash) : null;
+        ? resolveExistingViewer(schemView, schemWireHash) : null;
 
     const columnContent = [];
 

--- a/web/src/resultviewer.js
+++ b/web/src/resultviewer.js
@@ -804,6 +804,11 @@ const viewClassOf = {
 
             this.el.querySelectorAll('.drc-item').forEach(itemEl => {
                 itemEl.addEventListener('click', () => {
+                    // An outdated report must not drive navigation or
+                    // highlights: its nids, positions and hashes may not
+                    // match the regenerated views (the overlay already
+                    // shows the refresh state).
+                    if (this.resultViewer && !this.resultViewer.viewUpToDate) return;
                     const nid = parseInt(itemEl.dataset.nid, 10);
                     const item = itemMap.get(nid);
                     if (!item) return;
@@ -1097,6 +1102,8 @@ const viewClassOf = {
             this.el.querySelectorAll('.lvs-circuit-link').forEach(linkEl => {
                 linkEl.addEventListener('click', (e) => {
                     e.stopPropagation();  // don't toggle circuit expansion
+                    // See the drc-item guard: outdated reports are inert.
+                    if (this.resultViewer && !this.resultViewer.viewUpToDate) return;
                     if (!this.viewName) return;
                     const nid = parseInt(linkEl.dataset.nid, 10);
                     const kind = linkEl.dataset.kind;
@@ -1135,6 +1142,8 @@ const viewClassOf = {
             this.el.querySelectorAll('.lvs-item-row').forEach(itemEl => {
                 itemEl.addEventListener('click', (e) => {
                     e.stopPropagation();
+                    // See the drc-item guard: outdated reports are inert.
+                    if (this.resultViewer && !this.resultViewer.viewUpToDate) return;
                     this.el.querySelectorAll('.lvs-item-row.selected').forEach(el => {
                         el.classList.remove('selected');
                     });
@@ -1679,11 +1688,13 @@ export class ResultViewer {
                     this.resContent.replaceChildren(pre);
                 } else if(this.view instanceof viewClass) {
                     this.view.viewHash = this.viewHash;
+                    this.view.resultViewer = this;
                     this.view.update(msg.data);
                 } else {
                     this.view = new viewClass(this.resContent);
                     this.view.viewName = this.viewSelected;
                     this.view.viewHash = this.viewHash;
+                    this.view.resultViewer = this;
                     this.view.glContainer = this.container;
                     this.view.update(msg.data);
                 }

--- a/web/src/resultviewer.js
+++ b/web/src/resultviewer.js
@@ -295,8 +295,11 @@ const viewClassOf = {
 
             this._onLvsSelect = (data) => {
                 // Selections targeted at a specific schematic view (items of
-                // LVS subcircuit pairs) only apply to that view.
-                if (data && data.schemView && data.schemView !== this.viewName) {
+                // LVS subcircuit pairs) only apply to viewers showing that
+                // view: matched by name, or by wire hash for a viewer that
+                // shows the same subgraph under a different view name.
+                if (data && data.schemView && data.schemView !== this.viewName
+                        && !(data.schemHash && data.schemHash === this.viewHash)) {
                     return;
                 }
                 this.setHighlight(data);
@@ -586,7 +589,8 @@ const viewClassOf = {
                 this._pendingHighlight = null;
                 // viewName is only assigned after construction, so targeted
                 // pending selections are filtered here instead.
-                if (!pending.schemView || pending.schemView === this.viewName) {
+                if (!pending.schemView || pending.schemView === this.viewName
+                        || (pending.schemHash && pending.schemHash === this.viewHash)) {
                     this.setHighlight(pending);
                 }
             }
@@ -678,7 +682,8 @@ const viewClassOf = {
     // DRC Report viewer.
     //
     // Event bus protocol:
-    //   drc:select {shapes, layoutView} - sent when an item is selected
+    //   drc:select {shapes, layoutView, layoutHash} - sent when an item is
+    //     selected
     //   drc:clear - sent on deselect or destroy
     //
     // Pending mechanism: setPending('drc:select', payload) stores the
@@ -690,8 +695,10 @@ const viewClassOf = {
     // View naming: items of the top cell target "<viewName>.ref_layout",
     // items of subcells target
     // "<viewName>.subgraph.cursor_at(<cell_nid>).ref_layout", addressing
-    // the DrcCell node by nid. Every payload carries its layoutView, so
-    // only the viewer showing exactly that view highlights: shape
+    // the DrcCell node by nid. Every payload carries its layoutView plus
+    // the cell's subgraph wire hash (layoutHash), so only viewers showing
+    // that view highlight - matched by name, or by hash for a viewer
+    // showing the same subgraph under a different view name: shape
     // coordinates are only meaningful in the item's own cell, and an
     // untargeted broadcast would paint them into unrelated layout views.
     // Subcell items whose DrcCell has no resolved ref_layout (e.g. KLayout
@@ -819,16 +826,19 @@ const viewClassOf = {
                             ? `${this.viewName}.ref_layout`
                             : `${this.viewName}.subgraph.cursor_at(${item.cell_nid}).ref_layout`)
                         : null;
+                    const layoutHash = (isTop ? data.layout_hash : cell.layout_hash) || null;
                     // Clear the previous selection everywhere: its highlight
                     // may sit in a viewer the new selection does not target.
                     viewEventBus.emit('drc:clear');
-                    const payload = { shapes: item.shapes, layoutView };
+                    const payload = { shapes: item.shapes, layoutView, layoutHash };
                     viewEventBus.setPending('drc:select', payload);
                     viewEventBus.emit('drc:select', payload);
                     if (layoutView) {
-                        // Focuses the target view if open, opens it otherwise.
+                        // Focuses the target view if open (matched by name
+                        // or wire hash), opens it otherwise.
                         viewEventBus.emit('layout:request-open', {
                             view: layoutView,
+                            hash: layoutHash,
                             sourceContainer: this.glContainer,
                         });
                     }
@@ -846,10 +856,10 @@ const viewClassOf = {
     // LVS Report viewer.
     //
     // Event bus protocol:
-    //   lvs:layout-select {pos, layoutView} - sent when item with layout_pos selected
-    //   lvs:schem-select {schem_nid, item_type, schemView} - sent when item with schem_nid selected
+    //   lvs:layout-select {pos, layoutView, layoutHash} - sent when item with layout_pos selected
+    //   lvs:schem-select {schem_nid, item_type, schemView, schemHash} - sent when item with schem_nid selected
     //   lvs:clear - sent on deselect or destroy
-    //   lvs:request-open-views {layoutView, schemView} - requests new viewer panels
+    //   lvs:request-open-views {layoutView, schemView, layoutHash, schemHash} - requests new viewer panels
     //
     // Pending mechanism: setPending('lvs:select', payload) stores selection for
     // viewers opened later. Layout/schematic viewers call getPending on init.
@@ -860,10 +870,12 @@ const viewClassOf = {
     // subcircuit pairs use the per-pair views
     // "<viewName>.subgraph.cursor_at(<nid>).ref_layout|ref_schematic",
     // addressing the LvsCircuitPair node by nid. Every select payload
-    // carries its target views, so only the viewers showing exactly those
-    // views highlight: nids/positions are only meaningful in the pair's own
-    // subgraphs, and an untargeted broadcast would paint them into
-    // unrelated layout/schematic views.
+    // carries its target views plus their subgraph wire hashes
+    // (layoutHash/schemHash), so only the viewers showing those views
+    // highlight - matched by name, or by hash for a viewer showing the
+    // same subgraph under a different view name: nids/positions are only
+    // meaningful in the pair's own subgraphs, and an untargeted broadcast
+    // would paint them into unrelated layout/schematic views.
     lvs_report: class {
         constructor(resContent) {
             this.resContent = resContent;
@@ -992,7 +1004,7 @@ const viewClassOf = {
             html += '</div>';
             this.el.innerHTML = html;
 
-            this._attachEventHandlers(itemMap, circuitMap);
+            this._attachEventHandlers(itemMap, circuitMap, data);
             this.itemMap = itemMap;
         }
 
@@ -1066,7 +1078,7 @@ const viewClassOf = {
             });
         }
 
-        _attachEventHandlers(itemMap, circuitMap) {
+        _attachEventHandlers(itemMap, circuitMap, data) {
             this._setupColumnResize();
 
             this.el.querySelectorAll('.lvs-circuit-header').forEach(header => {
@@ -1080,17 +1092,21 @@ const viewClassOf = {
             // Open the circuit pair's layout/schematic view (without
             // selecting/highlighting anything in it). The view expression
             // addresses the LvsCircuitPair node by nid relative to this
-            // report view.
+            // report view; the wire hash lets the open request focus a
+            // panel showing the same subgraph under a different name.
             this.el.querySelectorAll('.lvs-circuit-link').forEach(linkEl => {
                 linkEl.addEventListener('click', (e) => {
                     e.stopPropagation();  // don't toggle circuit expansion
                     if (!this.viewName) return;
-                    const nid = linkEl.dataset.nid;
+                    const nid = parseInt(linkEl.dataset.nid, 10);
                     const kind = linkEl.dataset.kind;
+                    const circuit = circuitMap.get(nid);
                     const ref = kind === 'layout' ? 'ref_layout' : 'ref_schematic';
                     const event = kind === 'layout' ? 'layout:request-open' : 'schematic:request-open';
                     viewEventBus.emit(event, {
                         view: `${this.viewName}.subgraph.cursor_at(${nid}).${ref}`,
+                        hash: (circuit && (kind === 'layout'
+                            ? circuit.layout_hash : circuit.schem_hash)) || null,
                         sourceContainer: this.glContainer,
                     });
                 });
@@ -1141,6 +1157,8 @@ const viewClassOf = {
                             : null;
                         const layoutView = viewBase ? `${viewBase}.ref_layout` : null;
                         const schemView = viewBase ? `${viewBase}.ref_schematic` : null;
+                        const layoutHash = (isTop ? data.layout_hash : circuit.layout_hash) || null;
+                        const schemHash = (isTop ? data.schem_hash : circuit.schem_hash) || null;
 
                         const payload = {
                             pos: item.layout_pos,
@@ -1149,6 +1167,8 @@ const viewClassOf = {
                             schem_name: item.schem_name || '',
                             layoutView,
                             schemView,
+                            layoutHash,
+                            schemHash,
                         };
                         const hasLayoutPos = item.layout_pos !== null && item.layout_pos !== undefined;
                         const hasSchemNid = item.schem_nid !== undefined && item.schem_nid !== null;
@@ -1166,12 +1186,14 @@ const viewClassOf = {
                             viewEventBus.emit('lvs:schem-select', payload);
                         }
 
-                        // Focuses the target views if open, opens them
-                        // otherwise.
+                        // Focuses the target views if open (matched by name
+                        // or wire hash), opens them otherwise.
                         if ((hasLayoutPos && layoutView) || (hasSchemNid && schemView)) {
                             viewEventBus.emit('lvs:request-open-views', {
                                 layoutView: hasLayoutPos ? layoutView : null,
                                 schemView: hasSchemNid ? schemView : null,
+                                layoutHash: hasLayoutPos ? layoutHash : null,
+                                schemHash: hasSchemNid ? schemHash : null,
                                 sourceContainer: this.glContainer,
                             });
                         }
@@ -1242,6 +1264,10 @@ export class ResultViewer {
         this.resViewHead = container.element.querySelector(".resviewhead");
         this.viewUpToDate = false;
         this.viewSelected = null;
+        // Wire hash (sg_hash) of the currently displayed subgraph view, for
+        // hash-based open dedup (see main.js). Runtime state only: it must
+        // never be written into componentState/uistate.
+        this.viewHash = null;
         this.refreshRequestedByUser = false;
         this.directView = state && state.directView;
         // Course mode: the special "Course" panel (see course.js). It shows a
@@ -1629,6 +1655,7 @@ export class ResultViewer {
 
         //this.resContent.replaceChildren();
         this.viewUpToDate = true;
+        this.viewHash = msg.exception ? null : (msg.sg_hash || null);
         this.showRefreshOverlay(null);
 
         try {
@@ -1651,10 +1678,12 @@ export class ResultViewer {
                     pre.innerText = 'no handler found for type ' + msg.type;
                     this.resContent.replaceChildren(pre);
                 } else if(this.view instanceof viewClass) {
+                    this.view.viewHash = this.viewHash;
                     this.view.update(msg.data);
                 } else {
                     this.view = new viewClass(this.resContent);
                     this.view.viewName = this.viewSelected;
+                    this.view.viewHash = this.viewHash;
                     this.view.glContainer = this.container;
                     this.view.update(msg.data);
                 }

--- a/web/src/resultviewer.js
+++ b/web/src/resultviewer.js
@@ -299,7 +299,7 @@ const viewClassOf = {
                 // view: matched by name, or by wire hash for a viewer that
                 // shows the same subgraph under a different view name.
                 if (data && data.schemView && data.schemView !== this.viewName
-                        && !(data.schemHash && data.schemHash === this.viewHash)) {
+                        && !(data.schemWireHash && data.schemWireHash === this.wireHash)) {
                     return;
                 }
                 this.setHighlight(data);
@@ -590,7 +590,7 @@ const viewClassOf = {
                 // viewName is only assigned after construction, so targeted
                 // pending selections are filtered here instead.
                 if (!pending.schemView || pending.schemView === this.viewName
-                        || (pending.schemHash && pending.schemHash === this.viewHash)) {
+                        || (pending.schemWireHash && pending.schemWireHash === this.wireHash)) {
                     this.setHighlight(pending);
                 }
             }
@@ -682,7 +682,7 @@ const viewClassOf = {
     // DRC Report viewer.
     //
     // Event bus protocol:
-    //   drc:select {shapes, layoutView, layoutHash} - sent when an item is
+    //   drc:select {shapes, layoutView, layoutWireHash} - sent when an item is
     //     selected
     //   drc:clear - sent on deselect or destroy
     //
@@ -696,7 +696,7 @@ const viewClassOf = {
     // items of subcells target
     // "<viewName>.subgraph.cursor_at(<cell_nid>).ref_layout", addressing
     // the DrcCell node by nid. Every payload carries its layoutView plus
-    // the cell's subgraph wire hash (layoutHash), so only viewers showing
+    // the cell's subgraph wire hash (layoutWireHash), so only viewers showing
     // that view highlight - matched by name, or by hash for a viewer
     // showing the same subgraph under a different view name: shape
     // coordinates are only meaningful in the item's own cell, and an
@@ -833,11 +833,11 @@ const viewClassOf = {
                             ? `${this.viewName}.ref_layout`
                             : `${this.viewName}.subgraph.cursor_at(${item.cell_nid}).ref_layout`)
                         : null;
-                    const layoutHash = (isTop ? data.layout_hash : cell.layout_hash) || null;
+                    const layoutWireHash = (isTop ? data.layout_wire_hash : cell.layout_wire_hash) || null;
                     // Clear the previous selection everywhere: its highlight
                     // may sit in a viewer the new selection does not target.
                     viewEventBus.emit('drc:clear');
-                    const payload = { shapes: item.shapes, layoutView, layoutHash };
+                    const payload = { shapes: item.shapes, layoutView, layoutWireHash };
                     viewEventBus.setPending('drc:select', payload);
                     viewEventBus.emit('drc:select', payload);
                     if (layoutView) {
@@ -845,7 +845,7 @@ const viewClassOf = {
                         // or wire hash), opens it otherwise.
                         viewEventBus.emit('layout:request-open', {
                             view: layoutView,
-                            hash: layoutHash,
+                            wireHash: layoutWireHash,
                             sourceContainer: this.glContainer,
                         });
                     }
@@ -863,10 +863,10 @@ const viewClassOf = {
     // LVS Report viewer.
     //
     // Event bus protocol:
-    //   lvs:layout-select {pos, layoutView, layoutHash} - sent when item with layout_pos selected
-    //   lvs:schem-select {schem_nid, item_type, schemView, schemHash} - sent when item with schem_nid selected
+    //   lvs:layout-select {pos, layoutView, layoutWireHash} - sent when item with layout_pos selected
+    //   lvs:schem-select {schem_nid, item_type, schemView, schemWireHash} - sent when item with schem_nid selected
     //   lvs:clear - sent on deselect or destroy
-    //   lvs:request-open-views {layoutView, schemView, layoutHash, schemHash} - requests new viewer panels
+    //   lvs:request-open-views {layoutView, schemView, layoutWireHash, schemWireHash} - requests new viewer panels
     //
     // Pending mechanism: setPending('lvs:select', payload) stores selection for
     // viewers opened later. Layout/schematic viewers call getPending on init.
@@ -878,7 +878,7 @@ const viewClassOf = {
     // "<viewName>.subgraph.cursor_at(<nid>).ref_layout|ref_schematic",
     // addressing the LvsCircuitPair node by nid. Every select payload
     // carries its target views plus their subgraph wire hashes
-    // (layoutHash/schemHash), so only the viewers showing those views
+    // (layoutWireHash/schemWireHash), so only the viewers showing those views
     // highlight - matched by name, or by hash for a viewer showing the
     // same subgraph under a different view name: nids/positions are only
     // meaningful in the pair's own subgraphs, and an untargeted broadcast
@@ -1117,8 +1117,8 @@ const viewClassOf = {
                     const event = kind === 'layout' ? 'layout:request-open' : 'schematic:request-open';
                     viewEventBus.emit(event, {
                         view: `${this.viewName}.subgraph.cursor_at(${nid}).${ref}`,
-                        hash: (circuit && (kind === 'layout'
-                            ? circuit.layout_hash : circuit.schem_hash)) || null,
+                        wireHash: (circuit && (kind === 'layout'
+                            ? circuit.layout_wire_hash : circuit.schem_wire_hash)) || null,
                         sourceContainer: this.glContainer,
                     });
                 });
@@ -1174,8 +1174,8 @@ const viewClassOf = {
                             : null;
                         const layoutView = viewBase ? `${viewBase}.ref_layout` : null;
                         const schemView = viewBase ? `${viewBase}.ref_schematic` : null;
-                        const layoutHash = (isTop ? data.layout_hash : circuit.layout_hash) || null;
-                        const schemHash = (isTop ? data.schem_hash : circuit.schem_hash) || null;
+                        const layoutWireHash = (isTop ? data.layout_wire_hash : circuit.layout_wire_hash) || null;
+                        const schemWireHash = (isTop ? data.schem_wire_hash : circuit.schem_wire_hash) || null;
 
                         const payload = {
                             pos: item.layout_pos,
@@ -1184,8 +1184,8 @@ const viewClassOf = {
                             schem_name: item.schem_name || '',
                             layoutView,
                             schemView,
-                            layoutHash,
-                            schemHash,
+                            layoutWireHash,
+                            schemWireHash,
                         };
                         const hasLayoutPos = item.layout_pos !== null && item.layout_pos !== undefined;
                         const hasSchemNid = item.schem_nid !== undefined && item.schem_nid !== null;
@@ -1209,8 +1209,8 @@ const viewClassOf = {
                             viewEventBus.emit('lvs:request-open-views', {
                                 layoutView: hasLayoutPos ? layoutView : null,
                                 schemView: hasSchemNid ? schemView : null,
-                                layoutHash: hasLayoutPos ? layoutHash : null,
-                                schemHash: hasSchemNid ? schemHash : null,
+                                layoutWireHash: hasLayoutPos ? layoutWireHash : null,
+                                schemWireHash: hasSchemNid ? schemWireHash : null,
                                 sourceContainer: this.glContainer,
                             });
                         }
@@ -1281,10 +1281,11 @@ export class ResultViewer {
         this.resViewHead = container.element.querySelector(".resviewhead");
         this.viewUpToDate = false;
         this.viewSelected = null;
-        // Wire hash (sg_hash) of the currently displayed subgraph view, for
-        // hash-based open dedup (see main.js). Runtime state only: it must
-        // never be written into componentState/uistate.
-        this.viewHash = null;
+        // Wire hash of the currently displayed subgraph view (wire_hash
+        // field of the view message), for hash-based open dedup (see
+        // main.js). Runtime state only: it must never be written into
+        // componentState/uistate.
+        this.wireHash = null;
         this.refreshRequestedByUser = false;
         this.directView = state && state.directView;
         // Course mode: the special "Course" panel (see course.js). It shows a
@@ -1684,7 +1685,7 @@ export class ResultViewer {
 
         //this.resContent.replaceChildren();
         this.viewUpToDate = true;
-        this.viewHash = msg.exception ? null : (msg.sg_hash || null);
+        this.wireHash = msg.exception ? null : (msg.wire_hash || null);
         this.showRefreshOverlay(null);
 
         try {
@@ -1707,13 +1708,13 @@ export class ResultViewer {
                     pre.innerText = 'no handler found for type ' + msg.type;
                     this.resContent.replaceChildren(pre);
                 } else if(this.view instanceof viewClass) {
-                    this.view.viewHash = this.viewHash;
+                    this.view.wireHash = this.wireHash;
                     this.view.resultViewer = this;
                     this.view.update(msg.data);
                 } else {
                     this.view = new viewClass(this.resContent);
                     this.view.viewName = this.viewSelected;
-                    this.view.viewHash = this.viewHash;
+                    this.view.wireHash = this.wireHash;
                     this.view.resultViewer = this;
                     this.view.glContainer = this.container;
                     this.view.update(msg.data);

--- a/web/src/resultviewer.js
+++ b/web/src/resultviewer.js
@@ -806,9 +806,11 @@ const viewClassOf = {
                 itemEl.addEventListener('click', () => {
                     // An outdated report must not drive navigation or
                     // highlights: its nids, positions and hashes may not
-                    // match the regenerated views (the overlay already
-                    // shows the refresh state).
-                    if (this.resultViewer && !this.resultViewer.viewUpToDate) return;
+                    // match the regenerated views.
+                    if (this.resultViewer && !this.resultViewer.viewUpToDate) {
+                        this.resultViewer.flashRefreshBar();
+                        return;
+                    }
                     const nid = parseInt(itemEl.dataset.nid, 10);
                     const item = itemMap.get(nid);
                     if (!item) return;
@@ -1103,7 +1105,10 @@ const viewClassOf = {
                 linkEl.addEventListener('click', (e) => {
                     e.stopPropagation();  // don't toggle circuit expansion
                     // See the drc-item guard: outdated reports are inert.
-                    if (this.resultViewer && !this.resultViewer.viewUpToDate) return;
+                    if (this.resultViewer && !this.resultViewer.viewUpToDate) {
+                        this.resultViewer.flashRefreshBar();
+                        return;
+                    }
                     if (!this.viewName) return;
                     const nid = parseInt(linkEl.dataset.nid, 10);
                     const kind = linkEl.dataset.kind;
@@ -1143,7 +1148,10 @@ const viewClassOf = {
                 itemEl.addEventListener('click', (e) => {
                     e.stopPropagation();
                     // See the drc-item guard: outdated reports are inert.
-                    if (this.resultViewer && !this.resultViewer.viewUpToDate) return;
+                    if (this.resultViewer && !this.resultViewer.viewUpToDate) {
+                        this.resultViewer.flashRefreshBar();
+                        return;
+                    }
                     this.el.querySelectorAll('.lvs-item-row.selected').forEach(el => {
                         el.classList.remove('selected');
                     });
@@ -1346,6 +1354,18 @@ export class ResultViewer {
         this.refreshStatus.textContent = 'Cancelling…';
         this.refreshCancel.disabled = true;
         this.client.cancelView(this);
+    }
+
+    flashRefreshBar() {
+        // Draws attention to the refresh state when the user interacts with
+        // an out-of-date view (see the stale guards in the report viewers):
+        // the click does nothing, and the flashing bar says why.
+        const bar = [this.resOverlayRefreshing, this.resOverlayRefreshable,
+            this.resOverlayError].find(el => el.style.display !== 'none');
+        if (!bar) return;
+        bar.classList.remove('refreshbar-flash');
+        void bar.offsetWidth; // reflow, so a running animation restarts
+        bar.classList.add('refreshbar-flash');
     }
 
     showRefreshOverlay(config) {

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -574,6 +574,19 @@ body.theme-dark .resviewhead button:hover {
     --overlay-bg: var(--color-fail-bg);
     --overlay-fg: var(--color-fail-fg);
 }
+/* Attention flash when a link in an out-of-date view is clicked (see
+   ResultViewer.flashRefreshBar, which puts the class on the strip): the
+   strip's button blinks red twice (a single-pulse animation run twice);
+   everything else stays put. */
+.refreshbar-flash button {
+    animation: refreshbar-flash-btn 0.2s linear 2;
+}
+@keyframes refreshbar-flash-btn {
+    50% {
+        background-color: var(--color-fail-fg);
+        color: var(--color-fail-bg);
+    }
+}
 /* Like the course callout, the bar has no top border of its own: its top edge
    is the view selector's bottom border, recoloured to the overlay colour. */
 .resview:has(.reswrapper.refreshbar-active) .resviewhead {


### PR DESCRIPTION
- Using canonical CBOR serialization for subgraphs (wire_encode)
- each subgraph is identified using the SHA256 hash of its wire_encode bytes (wire_hash)
- `LiveRef` / `FarRef` attributes for "live" Python objects such as `cell`, either at the current endpoint (`LiveRef`) or at a remote endpoint (`FarRef`)
- want/have exchange through `WireSender` and `WireReceiver`, retransmitting only subgraphs that are not present already at the other side.
- demo/test for `WireSender` and `WireReceiver` with subprocess running auto_wire for main process
- Adds `wire_id` to schema
- webui: prevent opening duplicate result viewers through wire_hash hashes
- webui: make sure subgraph links in outdated result viewers are not clickable (here the wire_hash mechanism cannot work)