### PR TITLE
Refactor unresolved instances

### DIFF
--- a/docs/dev/ordb_benchmarks.rst
+++ b/docs/dev/ordb_benchmarks.rst
@@ -121,12 +121,11 @@ Transactions, index snapshots and immutability
 
 While a :class:`~ordec.core.ordb.SubgraphUpdater` transaction is open, the
 subgraph's own ``nodes``/``index`` keep showing the pre-transaction state;
-only the updater's views expose uncommitted changes. Real code (e.g.
-``resolve_instances`` in ``src/ordec/schematic/helpers.py``) queries the
-subgraph mid-transaction and depends on this. Additionally, ``index[key]``
-returns an immutable snapshot of the bucket, so callers may iterate a
-query result while removing exactly those nodes (the ``expand_rects``
-pattern). Backends have to get both right
+only the updater's views expose uncommitted changes. Code may query the
+subgraph mid-transaction and rely on seeing the pre-transaction snapshot.
+Additionally, ``index[key]`` returns an immutable snapshot of the bucket,
+so callers may iterate a query result while removing exactly those nodes
+(the ``expand_rects`` pattern). Backends have to get both right
 (:mod:`ordec.core.ordb.backend`); the differential fuzz checks them.
 
 The state mappings a subgraph hands out via ``.nodes``/``.index`` must

--- a/docs/ord_tutorial.py
+++ b/docs/ord_tutorial.py
@@ -259,6 +259,11 @@ cell MultibitReg_ArrayOfStructs:
 # In this example, we set the length of the transistors `l` to 100n and the width `w` to 200n.
 # ORD supports all common SI suffixes for cell parameters that use the `Rational` class type {doc}`ref/rational`.
 # (a=atto, f=femto, n=nano, u=micro, m=milli, k=kilo, M=Mega, G=Giga, T=Tera)
+# The `$` operator works the same way in layout viewgens. Parameters can be
+# assigned multiple times (the last assignment wins) until the instance is
+# resolved, which happens on the first access that needs the resolved
+# subcell (e.g. reading its geometry) or at the end of the viewgen;
+# assigning parameters after that raises an error.
 
 # +
 %%ord

--- a/docs/ref/ord.rst
+++ b/docs/ref/ord.rst
@@ -286,8 +286,10 @@ so ``inst.d -- vss`` and ``vss -- inst.d`` are equivalent.
 
 Internally, the negation step returns a ``NegatedWireOperand`` and the
 subtraction step detects this sentinel and calls ``__wire_op__`` to create the
-actual connection node (``SchemInstanceConn`` or
-``SchemInstanceUnresolvedConn``).
+actual connection. For resolved instances, this inserts a
+``SchemInstanceConn`` node directly; for unresolved instances (created from a
+Cell class, symbol not yet resolved), the connection is recorded in the view
+context and inserted when the instance is resolved.
 
 .. code-block::
 

--- a/docs/ref/schema.rst
+++ b/docs/ref/schema.rst
@@ -87,24 +87,13 @@ Schematics
    :members:
    :undoc-members:
 
-Unresolved schematic instances
-------------------------------
+.. note::
 
-During schematic construction, instances may reference a Symbol that is not
-determined yet. These nodes hold the pending placement, connections and
-parameters until the referenced Symbol is resolved into a :class:`SchemInstance`.
-
-.. autoclass:: SchemInstanceUnresolved
-   :members:
-   :undoc-members:
-
-.. autoclass:: SchemInstanceUnresolvedConn
-   :members:
-   :undoc-members:
-
-.. autoclass:: SchemInstanceUnresolvedParameter
-   :members:
-   :undoc-members:
+   During view construction, an instance created from a Cell class
+   (``MyCell x:`` in ORD) may not have its ``symbol``/``ref`` resolved yet.
+   The deferred state (cell, parameters, unresolved pin connections) is managed
+   by the view context, not by schema nodes; it is resolved at the latest
+   when the view context exits.
 
 Simulation hierarchy
 --------------------

--- a/docs/ref/schema.rst
+++ b/docs/ref/schema.rst
@@ -87,13 +87,14 @@ Schematics
    :members:
    :undoc-members:
 
-.. note::
+Unresolved instances during construction
+----------------------------------------
 
-   During view construction, an instance created from a Cell class
-   (``MyCell x:`` in ORD) may not have its ``symbol``/``ref`` resolved yet.
-   The deferred state (cell, parameters, unresolved pin connections) is managed
-   by the view context, not by schema nodes; it is resolved at the latest
-   when the view context exits.
+During view construction, an instance created from a Cell class
+(``MyCell x:`` in ORD) may not have its ``symbol`` (:class:`SchemInstance`)
+or ``ref`` (:class:`LayoutInstance`) resolved yet. The deferred state (cell,
+parameters, unresolved pin connections) is managed by the view context, not
+by schema nodes; it is resolved at the latest when the view context exits.
 
 Simulation hierarchy
 --------------------

--- a/src/ordec/core/arrange.py
+++ b/src/ordec/core/arrange.py
@@ -482,20 +482,6 @@ class ConnectingGroup(ArrangementGroup):
         ordering contract).
         """
 
-    def child_symbol(self, inst) -> 'Symbol':
-        """
-        Returns the Symbol of an instance child. For unresolved
-        instances, it is generated from the recorded parameters.
-        """
-        from .schema import SchemInstance, SchemInstanceUnresolvedParameter
-        if isinstance(inst, SchemInstance):
-            return inst.symbol
-        params = {
-            p.name: p.value
-            for p in inst.root.all(SchemInstanceUnresolvedParameter.ref_idx.query(inst))
-        }
-        return inst.resolver(**params)
-
     def facing_pin(self, inst, side: D4) -> str:
         """
         Returns the name of the single pin of an instance child that
@@ -506,7 +492,7 @@ class ConnectingGroup(ArrangementGroup):
         override = self.pin_overrides[side]
         if override is not None:
             return override
-        candidates = [pin for pin in self.child_symbol(inst).all(Pin)
+        candidates = [pin for pin in inst.symbol.all(Pin)
             if (inst.orientation * pin.align).unflip() == side]
         if len(candidates) != 1:
             raise ValueError(
@@ -527,17 +513,11 @@ class ConnectingGroup(ArrangementGroup):
 
     def pin_net(self, inst, pin_name: str) -> 'Net | None':
         """Returns the net a pin of an instance child is connected to, or None."""
-        from .schema import (SchemInstance, SchemInstanceConn,
-            SchemInstanceUnresolvedConn)
-        if isinstance(inst, SchemInstance):
-            pin = getattr(inst.symbol, pin_name)
-            query = SchemInstanceConn.ref_pin_idx.query((inst, pin))
-            conn = next(iter(inst.root.all(query)), None)
-            return conn.here if conn is not None else None
-        for conn in inst.root.all(SchemInstanceUnresolvedConn.ref_idx.query(inst)):
-            if conn.there == (pin_name,):
-                return conn.here
-        return None
+        from .schema import SchemInstanceConn
+        pin = getattr(inst.symbol, pin_name)
+        query = SchemInstanceConn.ref_pin_idx.query((inst, pin))
+        conn = next(iter(inst.root.all(query)), None)
+        return conn.here if conn is not None else None
 
     def endpoint(self, child, side: D4) -> Endpoint:
         """Returns the Endpoint of a direct child on the given side."""

--- a/src/ordec/core/context.py
+++ b/src/ordec/core/context.py
@@ -9,6 +9,15 @@ _ctx_var = ContextVar("ctx", default=None)
 _view_ctx_var = ContextVar("view_ctx", default=None)
 
 
+class InstanceResolutionError(Exception):
+    """
+    Raised when an instance that should be resolved lacks its symbol or
+    layout reference. Errors that occur while resolving (bad parameters,
+    defective deferred wiring) raise their own exception types instead,
+    annotated with the instance and its source location.
+    """
+
+
 class NodeContext:
     """
     Class which represents the context where a specific
@@ -101,6 +110,9 @@ class ViewContext:
         )
 
     def register_unresolved(self, inst, cell_cls):
+        # Should be unreachable: for view types without unresolved-instance
+        # support, inserting the instance node fails on its in_subgraphs
+        # check before add_element() reaches register_unresolved().
         raise TypeError(
             "Deferred cell instantiation is only supported in schematic "
             "and layout viewgens."
@@ -133,17 +145,20 @@ class MixinUnresolvedInstances:
         super().__init__(root)
         self.unresolved_instances = {} #: nid -> UnresolvedInstance
 
+    def _entry(self, inst):
+        # The nid alone is ambiguous: a nested viewgen builds a different
+        # subgraph whose nids can collide with ours.
+        if inst.subgraph is not self.root.subgraph:
+            return None
+        return self.unresolved_instances.get(inst.nid)
+
     def unresolved_instance(self, inst):
         """
         Returns the still-unresolved UnresolvedInstance entry for inst, or
         None.
         """
-        entry = self.unresolved_instances.get(inst.nid)
-        # The nid alone is ambiguous: a nested viewgen builds a different
-        # subgraph whose nids can collide with ours.
-        if entry is None or entry.inst.subgraph is not inst.subgraph:
-            return None
-        if entry.resolved:
+        entry = self._entry(inst)
+        if entry is None or entry.resolved:
             return None
         return entry
 
@@ -151,9 +166,7 @@ class MixinUnresolvedInstances:
         self.unresolved_instances[inst.nid] = UnresolvedInstance(inst, cell_cls)
 
     def set_unresolved_param(self, inst, name, value):
-        entry = self.unresolved_instances.get(inst.nid)
-        if entry is not None and entry.inst.subgraph is not inst.subgraph:
-            entry = None
+        entry = self._entry(inst)
         if entry is None:
             raise TypeError(
                 f"Cannot set parameter {name!r} of {inst.full_path_label()}: "
@@ -252,8 +265,12 @@ class SchematicViewContext(MixinUnresolvedInstances, ViewContext):
     def _apply_resolution(self, inst, entry):
         from .schema import Pin, SchemInstanceConn
         from ..schematic.helpers import recursive_getitem, SchematicError
+        # Resolve all pin paths before mutating anything: a failure must
+        # leave the instance untouched, so that a retried resolution does
+        # not re-insert conns from the aborted attempt.
         symbol = entry.cell_cls(**entry.params).symbol
-        inst.symbol = symbol
+        pins = []
+        seen_nids = set()
         for here, path in entry.conns:
             pin = recursive_getitem(symbol, path)
             if not isinstance(pin, Pin):
@@ -261,6 +278,15 @@ class SchematicViewContext(MixinUnresolvedInstances, ViewContext):
                     f"Deferred connection path {path!r} on "
                     f"{inst.full_path_label()} did not resolve to a Pin."
                 )
+            if pin.nid in seen_nids:
+                raise SchematicError(
+                    f"Pin {pin.full_path_label()} of "
+                    f"{inst.full_path_label()} is connected more than once."
+                )
+            seen_nids.add(pin.nid)
+            pins.append((here, pin))
+        inst.symbol = symbol
+        for here, pin in pins:
             inst % SchemInstanceConn(here=here, there=pin)
 
     @classmethod
@@ -303,12 +329,11 @@ class SchematicViewContext(MixinUnresolvedInstances, ViewContext):
 
     def _check_instances_resolved(self):
         from .schema import SchemInstance
-        from ..schematic.helpers import SchematicError
         for inst in self.root.all(SchemInstance):
             if inst.symbol is None:
-                raise SchematicError(
+                raise InstanceResolutionError(
                     f"Instance {inst.full_path_label()} has no symbol: it "
-                    "was created without one and never registered as a "
+                    "was created without one and never registered as an "
                     "unresolved instance."
                 )
 
@@ -363,7 +388,7 @@ class LayoutViewContext(MixinUnresolvedInstances, ViewContext):
         for inst_type in (LayoutInstance, LayoutInstanceArray):
             for inst in self.root.all(inst_type):
                 if inst.ref is None:
-                    raise TypeError(
+                    raise InstanceResolutionError(
                         f"Instance {inst.full_path_label()} has no layout "
                         "reference: it was created without one and never "
                         "registered as an unresolved instance."

--- a/src/ordec/core/context.py
+++ b/src/ordec/core/context.py
@@ -163,6 +163,15 @@ class MixinUnresolvedInstances:
         return entry
 
     def register_unresolved(self, inst, cell_cls):
+        # Mirror the ownership check of _entry(): nids are only unique per
+        # subgraph, and a foreign entry (e.g. a Cell class instantiated
+        # under a nested `with other.ctx():`) would silently never resolve.
+        if inst.subgraph is not self.root.subgraph:
+            raise TypeError(
+                f"Cannot create unresolved instance {inst.full_path_label()}: "
+                "it does not belong to the view of the active view context; "
+                "instantiate the cell with its parameters instead."
+            )
         self.unresolved_instances[inst.nid] = UnresolvedInstance(inst, cell_cls)
 
     def set_unresolved_param(self, inst, name, value):

--- a/src/ordec/core/context.py
+++ b/src/ordec/core/context.py
@@ -175,7 +175,15 @@ class MixinUnresolvedInstances:
         entry = self.unresolved_instance(inst)
         if entry is None:
             return
-        self._apply_resolution(inst, entry)
+        try:
+            self._apply_resolution(inst, entry)
+        except Exception as e:
+            loc = inst.src_loc
+            e.add_note(
+                f"While resolving instance {inst.full_path_label()}"
+                + (f" ({loc.filename}:{loc.line}:{loc.column})" if loc else "")
+            )
+            raise
         entry.resolved = True
 
     def resolve_all_instances(self):
@@ -244,15 +252,7 @@ class SchematicViewContext(MixinUnresolvedInstances, ViewContext):
     def _apply_resolution(self, inst, entry):
         from .schema import Pin, SchemInstanceConn
         from ..schematic.helpers import recursive_getitem, SchematicError
-        try:
-            symbol = entry.cell_cls(**entry.params).symbol
-        except Exception as e:
-            loc = inst.src_loc
-            e.add_note(
-                f"While resolving instance {inst.full_path_label()}"
-                + (f" ({loc.filename}:{loc.line}:{loc.column})" if loc else "")
-            )
-            raise
+        symbol = entry.cell_cls(**entry.params).symbol
         inst.symbol = symbol
         for here, path in entry.conns:
             pin = recursive_getitem(symbol, path)
@@ -337,14 +337,7 @@ class SchematicViewContext(MixinUnresolvedInstances, ViewContext):
 
 class LayoutViewContext(MixinUnresolvedInstances, ViewContext):
     def _apply_resolution(self, inst, entry):
-        try:
-            layout = entry.cell_cls(**entry.params).layout
-        except Exception as e:
-            # TODO: Include the source location once LayoutInstance has a
-            # src_loc attribute (a node tuple layout change).
-            e.add_note(f"While resolving instance {inst.full_path_label()}")
-            raise
-        inst.ref = layout
+        inst.ref = entry.cell_cls(**entry.params).layout
 
     @classmethod
     def create_root(cls, cell, root_cls):

--- a/src/ordec/core/context.py
+++ b/src/ordec/core/context.py
@@ -66,10 +66,12 @@ class ViewContext:
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if exc_type is None:
-            self.postprocess()
-        _view_ctx_var.reset(self._token)
-        self._node_ctx.__exit__(exc_type, exc_val, exc_tb)
+        try:
+            if exc_type is None:
+                self.postprocess()
+        finally:
+            _view_ctx_var.reset(self._token)
+            self._node_ctx.__exit__(exc_type, exc_val, exc_tb)
 
     def postprocess(self):
         """Override in subclasses to perform finalization on context exit."""
@@ -98,6 +100,124 @@ class ViewContext:
             f"{type(self.root).__name__} views."
         )
 
+    def register_unresolved(self, inst, cell_cls):
+        raise TypeError(
+            "Deferred cell instantiation is only supported in schematic "
+            "and layout viewgens."
+        )
+
+
+class UnresolvedInstance:
+    """
+    Deferred state of an instance created from a Cell class (``MyCell x:``).
+    The instance node exists in the subgraph, but its symbol/layout reference
+    is unset until the parameters are complete. Parameters set via ``.$name``
+    accumulate here (last assignment wins). Once any access requires the
+    resolved sub-view, the instance is resolved; setting parameters
+    afterwards raises.
+    """
+    def __init__(self, inst, cell_cls):
+        self.inst = inst
+        self.cell_cls = cell_cls
+        self.params = {}
+        self.conns = [] #: (here Net, path tuple) pairs; schematic contexts only
+        self.resolved = False
+
+
+class MixinUnresolvedInstances:
+    """
+    Manages UnresolvedInstance state for view contexts that support deferred
+    cell instantiation (schematic and layout).
+    """
+    def __init__(self, root):
+        super().__init__(root)
+        self.unresolved_instances = {} #: nid -> UnresolvedInstance
+
+    def unresolved_instance(self, inst):
+        """
+        Returns the still-unresolved UnresolvedInstance entry for inst, or
+        None.
+        """
+        entry = self.unresolved_instances.get(inst.nid)
+        # The nid alone is ambiguous: a nested viewgen builds a different
+        # subgraph whose nids can collide with ours.
+        if entry is None or entry.inst.subgraph is not inst.subgraph:
+            return None
+        if entry.resolved:
+            return None
+        return entry
+
+    def register_unresolved(self, inst, cell_cls):
+        self.unresolved_instances[inst.nid] = UnresolvedInstance(inst, cell_cls)
+
+    def set_unresolved_param(self, inst, name, value):
+        entry = self.unresolved_instances.get(inst.nid)
+        if entry is not None and entry.inst.subgraph is not inst.subgraph:
+            entry = None
+        if entry is None:
+            raise TypeError(
+                f"Cannot set parameter {name!r} of {inst.full_path_label()}: "
+                "the instance was created from a fully parametrized cell; "
+                "pass parameters at instantiation instead."
+            )
+        if entry.resolved:
+            raise TypeError(
+                f"Cannot set parameter {name!r} of {inst.full_path_label()}: "
+                "the instance was already resolved by an earlier access."
+            )
+        entry.params[name] = value
+
+    def resolve_instance(self, inst):
+        """
+        Resolves inst from its recorded parameters. No-op if the instance
+        was already resolved.
+        """
+        entry = self.unresolved_instance(inst)
+        if entry is None:
+            return
+        self._apply_resolution(inst, entry)
+        entry.resolved = True
+
+    def resolve_all_instances(self):
+        for entry in list(self.unresolved_instances.values()):
+            if not entry.resolved:
+                self.resolve_instance(entry.inst)
+
+
+def unresolved_instance_ctx(inst):
+    """
+    Returns the active view context if it manages inst as a still-unresolved
+    instance, else None.
+    """
+    ctx = _view_ctx_var.get()
+    if not isinstance(ctx, MixinUnresolvedInstances):
+        return None
+    if ctx.unresolved_instance(inst) is None:
+        return None
+    return ctx
+
+
+class InstanceParams:
+    """
+    Write-only accessor for deferred instance parameters (``.$name = value``
+    in ORD), returned by the ``params`` property of SchemInstance and
+    LayoutInstance. Assignments are recorded in the active view context
+    until the instance is resolved.
+    """
+    def __init__(self, inst):
+        self._inst = inst
+
+    def __setattr__(self, name, value):
+        if name.startswith("_"):
+            return super().__setattr__(name, value)
+        ctx = _view_ctx_var.get()
+        if not isinstance(ctx, MixinUnresolvedInstances):
+            raise TypeError(
+                "Instance parameters can only be set inside a schematic or "
+                "layout viewgen body."
+            )
+        ctx.set_unresolved_param(self._inst, name, value)
+
 
 class SymbolViewContext(ViewContext):
     @classmethod
@@ -108,11 +228,40 @@ class SymbolViewContext(ViewContext):
         self.root.place_pins(vpadding=2, hpadding=2)
 
 
-class SchematicViewContext(ViewContext):
+class SchematicViewContext(MixinUnresolvedInstances, ViewContext):
     def __init__(self, root):
         super().__init__(root)
         self.arrangement_groups = [] #: top-level arrangement groups, emitted in postprocess
         self.group_stack = [] #: arrangement groups whose body is currently executing
+
+    def record_unresolved_conn(self, inst, here, path):
+        """
+        Records a connection of an unresolved instance's future pin (identified
+        by path) to Net here. Flushed as SchemInstanceConn on resolution.
+        """
+        self.unresolved_instance(inst).conns.append((here, path))
+
+    def _apply_resolution(self, inst, entry):
+        from .schema import Pin, SchemInstanceConn
+        from ..schematic.helpers import recursive_getitem, SchematicError
+        try:
+            symbol = entry.cell_cls(**entry.params).symbol
+        except Exception as e:
+            loc = inst.src_loc
+            e.add_note(
+                f"While resolving instance {inst.full_path_label()}"
+                + (f" ({loc.filename}:{loc.line}:{loc.column})" if loc else "")
+            )
+            raise
+        inst.symbol = symbol
+        for here, path in entry.conns:
+            pin = recursive_getitem(symbol, path)
+            if not isinstance(pin, Pin):
+                raise SchematicError(
+                    f"Deferred connection path {path!r} on "
+                    f"{inst.full_path_label()} did not resolve to a Pin."
+                )
+            inst % SchemInstanceConn(here=here, there=pin)
 
     @classmethod
     def create_root(cls, cell, root_cls):
@@ -152,14 +301,30 @@ class SchematicViewContext(ViewContext):
         if self.group_stack:
             self.group_stack[-1].add(ref)
 
+    def _check_instances_resolved(self):
+        from .schema import SchemInstance
+        from ..schematic.helpers import SchematicError
+        for inst in self.root.all(SchemInstance):
+            if inst.symbol is None:
+                raise SchematicError(
+                    f"Instance {inst.full_path_label()} has no symbol: it "
+                    "was created without one and never registered as a "
+                    "unresolved instance."
+                )
+
     def postprocess(self):
         from .arrange import emit_toplevel_groups
+
+        # Resolve unresolved instances first: all parameters are final once the
+        # body has run, and the rest of the pipeline (arrangement groups,
+        # placement, wiring, checks) only deals with resolved instances.
+        self.resolve_all_instances()
+        self._check_instances_resolved()
 
         emit_toplevel_groups(self.arrangement_groups, self.solver)
         self.solver.solve(allow_undefined=True)
 
         self.root.place_unplaced_instances()
-        self.root.resolve_instances() # (preserves nids)
         self.root.place_ports() # Places ports whose pos is None.
 
         # No position should be None anymore: unplaced instances and ports
@@ -170,7 +335,17 @@ class SchematicViewContext(ViewContext):
         self.root.check(add_conn_points=True, add_terminal_taps=True)
 
 
-class LayoutViewContext(ViewContext):
+class LayoutViewContext(MixinUnresolvedInstances, ViewContext):
+    def _apply_resolution(self, inst, entry):
+        try:
+            layout = entry.cell_cls(**entry.params).layout
+        except Exception as e:
+            # TODO: Include the source location once LayoutInstance has a
+            # src_loc attribute (a node tuple layout change).
+            e.add_note(f"While resolving instance {inst.full_path_label()}")
+            raise
+        inst.ref = layout
+
     @classmethod
     def create_root(cls, cell, root_cls):
         # A symbol is optional: a cell may define a layout without a
@@ -190,6 +365,16 @@ class LayoutViewContext(ViewContext):
         return self
 
     def postprocess(self):
+        from .schema import LayoutInstance, LayoutInstanceArray
+        self.resolve_all_instances()
+        for inst_type in (LayoutInstance, LayoutInstanceArray):
+            for inst in self.root.all(inst_type):
+                if inst.ref is None:
+                    raise TypeError(
+                        f"Instance {inst.full_path_label()} has no layout "
+                        "reference: it was created without one and never "
+                        "registered as an unresolved instance."
+                    )
         self.solver.solve()
 
     def constrain(self, constraint):
@@ -233,11 +418,14 @@ class AssignableViewContext(ViewContext):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if exc_type is None:
-            if self.root is None:
-                raise TypeError("viewgen body must assign the view root via `.`.")
-            self.postprocess()
-        _view_ctx_var.reset(self._token)
+        try:
+            if exc_type is None:
+                if self.root is None:
+                    raise TypeError(
+                        "viewgen body must assign the view root via `.`.")
+                self.postprocess()
+        finally:
+            _view_ctx_var.reset(self._token)
 
     def set_root(self, value):
         if self.root is not None:

--- a/src/ordec/core/context.py
+++ b/src/ordec/core/context.py
@@ -260,6 +260,17 @@ class SchematicViewContext(MixinUnresolvedInstances, ViewContext):
         Records a connection of an unresolved instance's future pin (identified
         by path) to Net here. Flushed as SchemInstanceConn on resolution.
         """
+        from .schema import Net, SchemPort
+        # Validate the operand now so that a wiring mistake fails at the --
+        # statement, as it does on resolved instances. This also keeps
+        # _apply_resolution all-or-nothing: an invalid here operand would
+        # only fail there after part of the conns have been inserted.
+        if not isinstance(here, (Net, SchemPort)):
+            raise TypeError(
+                f"Cannot connect {type(here).__name__} to "
+                f"{inst.full_path_label()}: the wire operand must be a "
+                "Net or SchemPort."
+            )
         self.unresolved_instance(inst).conns.append((here, path))
 
     def _apply_resolution(self, inst, entry):

--- a/src/ordec/core/ordb/backend.py
+++ b/src/ordec/core/ordb/backend.py
@@ -122,9 +122,8 @@ class StorageTxn(ABC):
     ISOLATION: the target subgraph's own state (subgraph.nodes /
     subgraph.index) must remain at the pre-transaction snapshot for as long
     as the transaction is open -- only txn.nodes/txn.index expose
-    uncommitted changes. Real ORDeC code depends on this: e.g.
-    ordec.schematic.helpers.resolve_instances queries the subgraph while
-    its updater is open and must see pre-transaction state.
+    uncommitted changes. Code querying a subgraph while an updater is open
+    relies on seeing pre-transaction state.
     """
     __slots__ = ()
 

--- a/src/ordec/core/schema/base.py
+++ b/src/ordec/core/schema/base.py
@@ -92,6 +92,16 @@ class SourceLocInfo(NamedTuple):
     line: int
     column: int
 
+
+class MixinSourceLoc:
+    """
+    Provides src_loc attribute for Nodes that support back link to source.
+    This enables click-to-source for ORD code in the web UI. Currently, src_loc
+    is None for nodes not built from ORD code.
+    """
+    __slots__=()
+    src_loc = Attr(SourceLocInfo)
+
 # Generic polygon machinery
 # -------------------------
 

--- a/src/ordec/core/schema/layout.py
+++ b/src/ordec/core/schema/layout.py
@@ -384,7 +384,12 @@ class LayoutInstance(Node, MixinSourceLoc):
         return self.subcursor()[name]
 
     def __getattr__(self, name):
-        return getattr(self.subcursor(), name)
+        try:
+            return getattr(self.subcursor(), name)
+        except InstanceResolutionError as e:
+            # __getattr__ must raise AttributeError: hasattr() and IPython's
+            # repr probing rely on it (see Node.__getattr__).
+            raise AttributeError(*e.args) from None
 
     def loc_transform(self):
         return self.pos.transl() * self.orientation

--- a/src/ordec/core/schema/layout.py
+++ b/src/ordec/core/schema/layout.py
@@ -13,7 +13,7 @@ from .base import (
     coerce_tuple, AttrProxy, _rect_proxy, GdsLayer, RGBColor, PathEndType,
     MixinPolygonalChain, MixinClosedPolygon, GenericPolyI, PolyVec2I,
 )
-from .schematic import Symbol, Pin
+from .schematic import Symbol, Pin, MixinSourceLoc
 
 WIRE_DOMAIN = 4 << 16
 
@@ -346,7 +346,7 @@ class LayoutInstanceSubcursor(tuple):
             return inner_ret
 
 @public
-class LayoutInstance(Node):
+class LayoutInstance(Node, MixinSourceLoc):
     """Hierarchical layout instance, equivalent to GDS SRef."""
     in_subgraphs = [Layout]
     wire_id = WIRE_DOMAIN | 10

--- a/src/ordec/core/schema/layout.py
+++ b/src/ordec/core/schema/layout.py
@@ -8,7 +8,7 @@ from ..geoprim import *
 from ..ordb import *
 from ..cell import Cell
 from ..constraints import *
-from ..context import LayoutViewContext
+from ..context import LayoutViewContext, InstanceParams, unresolved_instance_ctx
 from .base import (
     coerce_tuple, AttrProxy, _rect_proxy, GdsLayer, RGBColor, PathEndType,
     MixinPolygonalChain, MixinClosedPolygon, GenericPolyI, PolyVec2I,
@@ -354,9 +354,26 @@ class LayoutInstance(Node):
     pos = ConstrainableAttr(Vec2I, factory=coerce_tuple(Vec2I, 2),
         placeholder=Vec2LinearTerm)
     orientation = Attr(D4, default=D4.R0)
-    ref = SubgraphRef(Layout, optional=False) #: Can be a Layout or a frame (which is also a Layout)...
+    #: Can be a Layout or a frame (which is also a Layout). None only while
+    #: the instance is unresolved in its view context; resolved at the latest
+    #: in postprocess.
+    ref = SubgraphRef(Layout)
+
+    @property
+    def params(self):
+        return InstanceParams(self)
 
     def subcursor(self):
+        if self.ref is None:
+            ctx = unresolved_instance_ctx(self)
+            if ctx is None:
+                raise TypeError(
+                    f"Instance {self.full_path_label()} has no layout "
+                    "reference: it is not an unresolved instance of the active "
+                    "viewgen."
+                )
+            # Nothing on a layout instance is deferrable: resolve now.
+            ctx.resolve_instance(self)
         return LayoutInstanceSubcursor((self, self.ref))
 
     def __getitem__(self, name):

--- a/src/ordec/core/schema/layout.py
+++ b/src/ordec/core/schema/layout.py
@@ -8,12 +8,16 @@ from ..geoprim import *
 from ..ordb import *
 from ..cell import Cell
 from ..constraints import *
-from ..context import LayoutViewContext, InstanceParams, unresolved_instance_ctx
+from ..context import (
+    LayoutViewContext, InstanceParams, InstanceResolutionError,
+    unresolved_instance_ctx,
+)
 from .base import (
     coerce_tuple, AttrProxy, _rect_proxy, GdsLayer, RGBColor, PathEndType,
     MixinPolygonalChain, MixinClosedPolygon, GenericPolyI, PolyVec2I,
+    MixinSourceLoc,
 )
-from .schematic import Symbol, Pin, MixinSourceLoc
+from .schematic import Symbol, Pin
 
 WIRE_DOMAIN = 4 << 16
 
@@ -367,10 +371,10 @@ class LayoutInstance(Node, MixinSourceLoc):
         if self.ref is None:
             ctx = unresolved_instance_ctx(self)
             if ctx is None:
-                raise TypeError(
+                raise InstanceResolutionError(
                     f"Instance {self.full_path_label()} has no layout "
-                    "reference: it is not an unresolved instance of the active "
-                    "viewgen."
+                    "reference: it is not an unresolved instance of the "
+                    "active viewgen."
                 )
             # Nothing on a layout instance is deferrable: resolve now.
             ctx.resolve_instance(self)

--- a/src/ordec/core/schema/schematic.py
+++ b/src/ordec/core/schema/schematic.py
@@ -368,7 +368,12 @@ class SchemInstance(Node, MixinSourceLoc):
     def __getattr__(self, name):
         if self.symbol is None and unresolved_instance_ctx(self) is not None:
             return SchemInstanceUnresolvedSubcursor((self, name))
-        return getattr(self.subcursor(), name)
+        try:
+            return getattr(self.subcursor(), name)
+        except InstanceResolutionError as e:
+            # __getattr__ must raise AttributeError: hasattr() and IPython's
+            # repr probing rely on it (see Node.__getattr__).
+            raise AttributeError(*e.args) from None
 
     def conns(self):
         return self.subgraph.all(SchemInstanceConn.ref_idx.query(self))

--- a/src/ordec/core/schema/schematic.py
+++ b/src/ordec/core/schema/schematic.py
@@ -13,10 +13,11 @@ from ..cell import Cell
 from ..constraints import *
 from ..context import (
     SymbolViewContext, SchematicViewContext, InstanceParams,
-    unresolved_instance_ctx,
+    InstanceResolutionError, unresolved_instance_ctx,
 )
 from .base import (
-    coerce_tuple, SourceLocInfo, MixinPolygonalChain, GenericPolyR, PolyVec2R,
+    coerce_tuple, SourceLocInfo, MixinSourceLoc, MixinPolygonalChain,
+    GenericPolyR, PolyVec2R,
 )
 
 # wire_ids 11-13 were freed by the removal of the SchemInstanceUnresolved* node types.
@@ -317,16 +318,6 @@ class SchemInstanceSubcursor(tuple):
             return inner_ret
 
 
-class MixinSourceLoc:
-    """
-    Provides src_loc attribute for Nodes that support back link to source.
-    This enables click-to-source for ORD code in the web UI. Currently, src_loc
-    is None for nodes not built from ORD code.
-    """
-    __slots__=()
-    src_loc = Attr(SourceLocInfo)
-
-
 @public
 class SchemInstance(Node, MixinSourceLoc):
     """
@@ -363,7 +354,7 @@ class SchemInstance(Node, MixinSourceLoc):
 
     def subcursor(self):
         if self.symbol is None:
-            raise TypeError(
+            raise InstanceResolutionError(
                 f"Instance {self.full_path_label()} has no symbol: it is "
                 "not an unresolved instance of the active viewgen."
             )
@@ -391,7 +382,8 @@ class SchemInstanceConn(Node):
     ref = LocalRef(SchemInstance, optional=False)
     ref_idx = Index(ref)
 
-    here = LocalRef(Net, optional=False)
+    here = LocalRef(Net, optional=False,
+        factory=lambda v: v.ref if isinstance(v, SchemPort) else v)
     there = ExternalRef(Pin, of_subgraph=lambda c: c.ref.symbol, optional=False) # ExternalRef to Pin in SchemInstance.symbol
 
     ref_pin_idx = CombinedIndex([ref, there], unique=True)
@@ -448,8 +440,8 @@ class SchemInstanceUnresolvedSubcursor(tuple):
         return NegatedWireOperand(self)
 
     def __wire_op__(self, here):
-        if isinstance(here, SchemPort):
-            here = here.ref
+        # A SchemPort operand is coerced to its Net by the factory of
+        # SchemInstanceConn.here when the connection is created.
         inst = self._inst
         ctx = unresolved_instance_ctx(inst)
         if ctx is None:

--- a/src/ordec/core/schema/schematic.py
+++ b/src/ordec/core/schema/schematic.py
@@ -11,11 +11,15 @@ from ..geoprim import *
 from ..ordb import *
 from ..cell import Cell
 from ..constraints import *
-from ..context import SymbolViewContext, SchematicViewContext
+from ..context import (
+    SymbolViewContext, SchematicViewContext, InstanceParams,
+    unresolved_instance_ctx,
+)
 from .base import (
     coerce_tuple, SourceLocInfo, MixinPolygonalChain, GenericPolyR, PolyVec2R,
 )
 
+# wire_ids 11-13 were freed by the removal of the SchemInstanceUnresolved* node types.
 WIRE_DOMAIN = 3 << 16
 
 # Enums
@@ -163,10 +167,6 @@ class Schematic(MixinRenderable, SubgraphRoot):
     cell = LiveRef(Cell)
     default_supply = LocalRef('Net', refcheck_custom=lambda val: issubclass(val, Net))
     default_ground = LocalRef('Net', refcheck_custom=lambda val: issubclass(val, Net))
-
-    def resolve_instances(self):
-        from ...schematic import resolve_instances
-        resolve_instances(self)
 
     def auto_wire(self):
         from ...schematic import auto_wire
@@ -338,7 +338,10 @@ class SchemInstance(Node, MixinSourceLoc):
     pos = ConstrainableAttr(Vec2R, placeholder=Vec2LinearTerm,
         factory=coerce_tuple(Vec2R, 2))
     orientation = Attr(D4, default=D4.R0)
-    symbol = SubgraphRef(Symbol, optional=False)
+    #: None only while the instance is unresolved in its view context; must be
+    #: resolved before the schematic is finalized (checked in postprocess
+    #: and schem_check).
+    symbol = SubgraphRef(Symbol)
 
     def __new__(cls, connect=None, **kwargs):
         main = super().__new__(cls, **kwargs)
@@ -354,13 +357,26 @@ class SchemInstance(Node, MixinSourceLoc):
         else:
             return pos.transl() * self.orientation
 
+    @property
+    def params(self):
+        return InstanceParams(self)
+
     def subcursor(self):
+        if self.symbol is None:
+            raise TypeError(
+                f"Instance {self.full_path_label()} has no symbol: it is "
+                "not an unresolved instance of the active viewgen."
+            )
         return SchemInstanceSubcursor((self, self.symbol))
 
     def __getitem__(self, name):
+        if self.symbol is None and unresolved_instance_ctx(self) is not None:
+            return SchemInstanceUnresolvedSubcursor((self, name))
         return self.subcursor()[name]
 
     def __getattr__(self, name):
+        if self.symbol is None and unresolved_instance_ctx(self) is not None:
+            return SchemInstanceUnresolvedSubcursor((self, name))
         return getattr(self.subcursor(), name)
 
     def conns(self):
@@ -382,128 +398,71 @@ class SchemInstanceConn(Node):
 
 
 class SchemInstanceUnresolvedSubcursor(tuple):
-    """Cursor to go through connections of a unresolved schem instance"""
+    """
+    Cursor recording an access path into the future symbol of an unresolved
+    instance (tuple layout: (instance, *path)). Wire ops record deferred
+    connections in the view context. Any other attribute access requires
+    the resolved symbol: it resolves the instance and replays the recorded
+    path through the resolved subcursor.
+    """
     def __repr__(self):
         return f"{type(self).__name__}{tuple.__repr__(self)}"
 
     def __eq__(self, other):
         return type(self) == type(other) and super().__eq__(other)
 
-    def __getitem__(self, name):
-        return SchemInstanceUnresolvedSubcursor(self+(name,))
-    
+    @property
+    def _inst(self):
+        # tuple.__getitem__ to bypass the path-extending __getitem__ below
+        return tuple.__getitem__(self, 0)
+
+    @property
+    def _path(self):
+        return tuple.__getitem__(self, slice(1, None))
+
+    def __getitem__(self, key):
+        return SchemInstanceUnresolvedSubcursor(self + (key,))
+
     def __getattr__(self, name):
-        # Upgrade cursor on failed attribute access
-        return getattr(self._upgrade_cursor(), name)
+        return getattr(self._resolve_cursor(), name)
 
-    def _upgrade_cursor(self):
+    def _resolve_cursor(self):
         """
-        Convert this unresolved cursor into a resolved SchemInstanceSubcursor.
-        Recorded parameters are passed to the resolver so that geometry
-        matches the symbol that resolve_instances() will produce.
+        Resolves the instance (if still unresolved) and replays the recorded
+        path through the resolved SchemInstanceSubcursor, so geometry values
+        transform to schematic space as on resolved instances.
         """
-        ui = self.instanceunresolved
-        cursor = SchemInstanceSubcursor((ui, ui.resolve_symbol()))
-
-        # Walking the path through a SchemInstanceSubcursor transforms
-        # geometry values to schematic space, as on resolved instances.
-        for step in self.instancepath:
+        inst = self._inst
+        ctx = unresolved_instance_ctx(inst)
+        if ctx is not None:
+            ctx.resolve_instance(inst)
+        cursor = inst.subcursor()
+        for step in self._path:
             if isinstance(step, int):
                 cursor = cursor[step]
             else:
                 cursor = getattr(cursor, step)
         return cursor
 
-    @property
-    def instanceunresolved(self):
-        # self[0], but wihtout calling SchemInstanceUnresolvedCursor.__getitem__
-        return tuple.__getitem__(self, 0)
-
-    @property
-    def instancepath(self):
-        # self[1:], but without calling SchemInstanceUnresolvedCursor.__getitem__
-        return tuple.__getitem__(self, slice(1,None))
-
     def __neg__(self):
         return NegatedWireOperand(self)
 
     def __wire_op__(self, here):
-        conn = self.instanceunresolved % \
-            SchemInstanceUnresolvedConn(here=here, there=self.instancepath)
-        return conn
+        if isinstance(here, SchemPort):
+            here = here.ref
+        inst = self._inst
+        ctx = unresolved_instance_ctx(inst)
+        if ctx is None:
+            # The instance was resolved after this cursor was created;
+            # connect through the resolved subcursor instead.
+            return self._resolve_cursor().__wire_op__(here)
+        ctx.record_unresolved_conn(inst, here, self._path)
 
     def __sub__(self, other):
         if isinstance(other, NegatedWireOperand):
             return self.__wire_op__(other.wrapped)
         return NotImplemented
-    
-@public
-class SchemInstanceUnresolved(Node, MixinSourceLoc):
-    """An instance of a Symbol that is not determined yet."""
 
-    class ParamWrapper:
-        def __init__(self, inst):
-            self._inst = inst
-
-        def __setattr__(self, name, value):
-            if name.startswith("_"):
-                return super().__setattr__(name, value)
-            self._inst % SchemInstanceUnresolvedParameter(name=name, value=value)
-
-    in_subgraphs = [Schematic]
-    wire_id = WIRE_DOMAIN | 11
-
-    pos = ConstrainableAttr(Vec2R, placeholder=Vec2LinearTerm,
-        factory=coerce_tuple(Vec2R, 2))
-    orientation = Attr(D4, default=D4.R0)
-
-    resolver = LiveRef(object)
-
-    @property
-    def params(self):
-        return self.ParamWrapper(self)
-
-    def loc_transform(self):
-        return self.pos.transl() * self.orientation
-
-    def __getitem__(self, name):
-        return self.__getattr__(name)
-
-    def __getattr__(self, name):
-        return SchemInstanceUnresolvedSubcursor((self, name))
-
-    def resolve_symbol(self, remove_params_sgu: 'SubgraphUpdater'=None) -> Symbol:
-        param_dict = {}
-        for param in self.root.all(SchemInstanceUnresolvedParameter.ref_idx.query(self)):
-            param_dict[param.name] = param.value
-            if remove_params_sgu:
-                remove_params_sgu.remove_nid(param.nid)
-
-        return self.resolver(**param_dict)
-
-@public
-class SchemInstanceUnresolvedConn(Node):
-    """Unresolved SchemInstanceConn."""
-    in_subgraphs = [Schematic]
-    wire_id = WIRE_DOMAIN | 12
-
-    ref = LocalRef(SchemInstanceUnresolved, optional=False)
-    ref_idx = Index(ref)
-
-    here = LocalRef(Net, optional=False,
-        factory=lambda v: v.ref if isinstance(v, SchemPort) else v)
-    there = Attr(tuple, optional=False) #: Tuple of str or int = requested path in future symbol
-
-@public
-class SchemInstanceUnresolvedParameter(Node):
-    in_subgraphs = [Schematic]
-    wire_id = WIRE_DOMAIN | 13
-
-    ref = LocalRef(SchemInstanceUnresolved, optional=False)
-    ref_idx = Index(ref)
-
-    name = Attr(str, optional=False)
-    value = Attr(object, optional=False) #: TODO - should be immutable.
 
 @public
 class SchemTapPoint(Node):

--- a/src/ordec/courses/layout_tutorial/checks.py
+++ b/src/ordec/courses/layout_tutorial/checks.py
@@ -1098,23 +1098,31 @@ def gen_lesson10(g):
             neighborhood.
 
             **1. Build the matched row** at the `EDIT HERE (row)` marker.
-            The unit cell is prepared as `unit`. Instead of positioning
-            each device by hand, chain them: constraining a device's first
-            source/drain strip onto its neighbor's last one makes the two
-            share one diffusion strip, perfectly aligned by construction:
+            Declare all four unit devices in one statement and set their
+            parameters in one loop - a single source of truth, so the
+            branches cannot drift apart. A device's inner geometry
+            (`.sd`, `.poly`) only takes shape once its parameters are
+            known, so the parameter loop must come first; the placement
+            constraints then follow as standalone statements naming each
+            device, instead of living in the instance blocks as in
+            lesson 6. Rather than positioning each device by hand, chain
+            them: constraining a device's first source/drain strip onto
+            its neighbor's last one makes the two share one diffusion
+            strip, perfectly aligned by construction:
 
             ```
-            unit m1a:
-                ! .pos == (0, 0)
-            unit m2a:
-                ! .sd[0].center == m1a.sd[1].center
-                ! .pos.y == m1a.pos.y
-            unit m2b:
-                ! .sd[0].center == m2a.sd[1].center
-                ! .pos.y == m1a.pos.y
-            unit m1b:
-                ! .sd[0].center == m2b.sd[1].center
-                ! .pos.y == m1a.pos.y
+            Nmos m1a, m2a, m2b, m1b
+            for m in m1a, m2a, m2b, m1b:
+                m.$w = 1u
+                m.$l = 130n
+
+            ! m1a.pos == (0, 0)
+            ! m2a.sd[0].center == m1a.sd[1].center
+            ! m2a.pos.y == m1a.pos.y
+            ! m2b.sd[0].center == m2a.sd[1].center
+            ! m2b.pos.y == m1a.pos.y
+            ! m1b.sd[0].center == m2b.sd[1].center
+            ! m1b.pos.y == m1a.pos.y
             ```
 
             The five strips of the row now alternate between the nets
@@ -1164,8 +1172,8 @@ def gen_lesson10(g):
             downward; it is prepared for you in the next lesson.*
         """)
 
-        hint_row = ("Add the four `unit` blocks from step 1 at the "
-            "EDIT HERE (row) marker.")
+        hint_row = ("Add the unit-device declarations and chaining "
+            "constraints from step 1 at the EDIT HERE (row) marker.")
         try:
             row = diffpair_row(g['DiffPair']().layout)
             found = all(i.ref.cell.w == R('1u') and i.ref.cell.l == R('130n')

--- a/src/ordec/courses/layout_tutorial/checks.py
+++ b/src/ordec/courses/layout_tutorial/checks.py
@@ -546,12 +546,14 @@ def gen_lesson6(g):
 
             Transistors are not drawn by hand: the PDK cells generate their
             layouts, and you place them as *instances*. Writing a cell name
-            inside a layout view instantiates its layout, and constraints
-            position it. Place the NMOS at the `EDIT HERE (devices)`
-            marker:
+            inside a layout view instantiates its layout, `.$name = value`
+            sets the cell's parameters, and constraints position it. Place
+            the NMOS at the `EDIT HERE (devices)` marker:
 
             ```
-            Nmos(w=1u, l=130n) mn:
+            Nmos mn:
+                .$w = 1u
+                .$l = 130n
                 ! .pos == (0, 0)
             ```
 
@@ -566,13 +568,19 @@ def gen_lesson6(g):
             centered on its transistor:
 
             ```
-            Pmos(w=1u, l=130n) mp:
+            Pmos mp:
+                .$w = 1u
+                .$l = 130n
                 ! .pos.x == mn.pos.x
                 ! .pos.y == mn.pos.y + 2500
-            Ptap(l=0.7u, w=0.7u) ptap:
+            Ptap ptap:
+                .$l = 0.7u
+                .$w = 0.7u
                 ! .activ.cx == mn.activ.cx
                 ! .activ.uy + 600 == mn.poly[0].ly
-            Ntap(l=0.7u, w=0.7u) ntap:
+            Ntap ntap:
+                .$l = 0.7u
+                .$w = 0.7u
                 ! .activ.cx == mp.activ.cx
                 ! .activ.ly - 600 == mp.poly[0].uy
             ```
@@ -587,8 +595,8 @@ def gen_lesson6(g):
             rotation angles.*
         """)
 
-        hint_mn = ("Add `Nmos(w=1u, l=130n) mn:` with `! .pos == (0, 0)` "
-            "at the EDIT HERE (devices) marker.")
+        hint_mn = ("Add `Nmos mn:` with `.$w = 1u`, `.$l = 130n` and "
+            "`! .pos == (0, 0)` at the EDIT HERE (devices) marker.")
         try:
             insts = instances_of(g['Inv']().layout, ihp130.Nmos)
             found = (len(insts) == 1

--- a/src/ordec/courses/layout_tutorial/lesson1.ord
+++ b/src/ordec/courses/layout_tutorial/lesson1.ord
@@ -13,5 +13,7 @@ cell Example:
         LayoutLabel note: .layer=layers.TEXT; .pos=(0, 1600); .text="hello layout"
 
         # Transistor parametric cell instance (more on this in lesson 6):
-        Nmos(w=1u, l=130n) mn:
+        Nmos mn:
+            .$w = 1u
+            .$l = 130n
             ! .pos == (3800, -200)

--- a/src/ordec/courses/layout_tutorial/lesson10.ord
+++ b/src/ordec/courses/layout_tutorial/lesson10.ord
@@ -28,7 +28,6 @@ cell DiffPair:
     viewgen layout -> Layout:
         .ref_layers = SG13G2().layers
         layers = .ref_layers
-        unit = Nmos(w=1u, l=130n)
 
         # EDIT HERE (row)
 

--- a/src/ordec/courses/layout_tutorial/lesson11.ord
+++ b/src/ordec/courses/layout_tutorial/lesson11.ord
@@ -103,7 +103,9 @@ cell DiffPair:
             ! .size == (500, 200)
 
         # Substrate tap and vss rail below the row:
-        Ptap(l=0.7u, w=0.7u) ptap:
+        Ptap ptap:
+            .$l = 0.7u
+            .$w = 0.7u
             ! .activ.cx == 0.5*m1a.activ.lx + 0.5*m1b.activ.ux
             ! .activ.uy == m1a.pos.y - 1200
         LayoutRect m1_vss:

--- a/src/ordec/courses/layout_tutorial/lesson11.ord
+++ b/src/ordec/courses/layout_tutorial/lesson11.ord
@@ -25,20 +25,19 @@ cell DiffPair:
     viewgen layout -> Layout:
         .ref_layers = SG13G2().layers
         layers = .ref_layers
-        unit = Nmos(w=1u, l=130n)
 
         # The matched row from lesson 10:
-        unit m1a:
-            ! .pos == (0, 0)
-        unit m2a:
-            ! .sd[0].center == m1a.sd[1].center
-            ! .pos.y == m1a.pos.y
-        unit m2b:
-            ! .sd[0].center == m2a.sd[1].center
-            ! .pos.y == m1a.pos.y
-        unit m1b:
-            ! .sd[0].center == m2b.sd[1].center
-            ! .pos.y == m1a.pos.y
+        Nmos m1a, m2a, m2b, m1b
+        for m in m1a, m2a, m2b, m1b:
+            m.$w = 1u
+            m.$l = 130n
+        ! m1a.pos == (0, 0)
+        ! m2a.sd[0].center == m1a.sd[1].center
+        ! m2a.pos.y == m1a.pos.y
+        ! m2b.sd[0].center == m2a.sd[1].center
+        ! m2b.pos.y == m1a.pos.y
+        ! m1b.sd[0].center == m2b.sd[1].center
+        ! m1b.pos.y == m1a.pos.y
 
         # The inn gate comb and contact from lesson 10:
         LayoutRect inn_bar:

--- a/src/ordec/courses/layout_tutorial/lesson7.ord
+++ b/src/ordec/courses/layout_tutorial/lesson7.ord
@@ -23,15 +23,23 @@ cell Inv:
         layers = .ref_layers
 
         # The device column from lesson 6:
-        Nmos(w=1u, l=130n) mn:
+        Nmos mn:
+            .$w = 1u
+            .$l = 130n
             ! .pos == (0, 0)
-        Pmos(w=1u, l=130n) mp:
+        Pmos mp:
+            .$w = 1u
+            .$l = 130n
             ! .pos.x == mn.pos.x
             ! .pos.y == mn.pos.y + 2500
-        Ptap(l=0.7u, w=0.7u) ptap:
+        Ptap ptap:
+            .$l = 0.7u
+            .$w = 0.7u
             ! .activ.cx == mn.activ.cx
             ! .activ.uy + 600 == mn.poly[0].ly
-        Ntap(l=0.7u, w=0.7u) ntap:
+        Ntap ntap:
+            .$l = 0.7u
+            .$w = 0.7u
             ! .activ.cx == mp.activ.cx
             ! .activ.ly - 600 == mp.poly[0].uy
 

--- a/src/ordec/courses/layout_tutorial/lesson8.ord
+++ b/src/ordec/courses/layout_tutorial/lesson8.ord
@@ -23,15 +23,23 @@ cell Inv:
         layers = .ref_layers
 
         # The device column from lesson 6:
-        Nmos(w=1u, l=130n) mn:
+        Nmos mn:
+            .$w = 1u
+            .$l = 130n
             ! .pos == (0, 0)
-        Pmos(w=1u, l=130n) mp:
+        Pmos mp:
+            .$w = 1u
+            .$l = 130n
             ! .pos.x == mn.pos.x
             ! .pos.y == mn.pos.y + 2500
-        Ptap(l=0.7u, w=0.7u) ptap:
+        Ptap ptap:
+            .$l = 0.7u
+            .$w = 0.7u
             ! .activ.cx == mn.activ.cx
             ! .activ.uy + 600 == mn.poly[0].ly
-        Ntap(l=0.7u, w=0.7u) ntap:
+        Ntap ntap:
+            .$l = 0.7u
+            .$w = 0.7u
             ! .activ.cx == mp.activ.cx
             ! .activ.ly - 600 == mp.poly[0].uy
 

--- a/src/ordec/courses/layout_tutorial/lesson9.ord
+++ b/src/ordec/courses/layout_tutorial/lesson9.ord
@@ -23,15 +23,23 @@ cell Inv:
         layers = .ref_layers
 
         # The device column from lesson 6:
-        Nmos(w=1u, l=130n) mn:
+        Nmos mn:
+            .$w = 1u
+            .$l = 130n
             ! .pos == (0, 0)
-        Pmos(w=1u, l=130n) mp:
+        Pmos mp:
+            .$w = 1u
+            .$l = 130n
             ! .pos.x == mn.pos.x
             ! .pos.y == mn.pos.y + 2500
-        Ptap(l=0.7u, w=0.7u) ptap:
+        Ptap ptap:
+            .$l = 0.7u
+            .$w = 0.7u
             ! .activ.cx == mn.activ.cx
             ! .activ.uy + 600 == mn.poly[0].ly
-        Ntap(l=0.7u, w=0.7u) ntap:
+        Ntap ntap:
+            .$l = 0.7u
+            .$w = 0.7u
             ! .activ.cx == mp.activ.cx
             ! .activ.ly - 600 == mp.poly[0].uy
 

--- a/src/ordec/examples/vco_pseudodiff.ord
+++ b/src/ordec/examples/vco_pseudodiff.ord
@@ -348,7 +348,7 @@ cell VcoRing:
             .create_pin(self.symbol.vss_st)
 
         for i in range(2):
-            VcoHalfStage() stage_p[i]:
+            VcoHalfStage stage_p[i]:
                 .orientation=MX
                 if i == 0:
                     .orientation *= MY
@@ -356,7 +356,7 @@ cell VcoRing:
                 ! vdd_st_bar.contains(.vddbar.rect)
                 ! nwell.contains(.nwell.rect)
 
-            VcoHalfStage() stage_n[i]:
+            VcoHalfStage stage_n[i]:
                 if i == 0:
                     .orientation *= MY
                 ! vdd_st_bar.contains(.vddbar.rect)
@@ -595,7 +595,7 @@ cell Vco:
     viewgen layout -> Layout:
         layers = SG13G2().layers
         .ref_layers = layers
-        VcoRing() ring_i:
+        VcoRing ring_i:
             ! .pos == (0,0)
             
         
@@ -642,10 +642,14 @@ cell Vco:
             ! .size == (160, 160)
             ! .center == m3.poly[0].south - (0, 200)
         
-        Ntap(l="0.7u", w="0.7u") ntap_i:
+        Ntap ntap_i:
+            .$l = "0.7u"
+            .$w = "0.7u"
             ! .activ.south == m2.sd[1].north + (0, 1000)
         
-        Ptap(l="0.7u", w="0.7u") ptap_i:
+        Ptap ptap_i:
+            .$l = "0.7u"
+            .$w = "0.7u"
             ! .activ.east == m1.activ.west - (1000, 0)
 
         

--- a/src/ordec/ord/context.py
+++ b/src/ordec/ord/context.py
@@ -33,7 +33,7 @@ def add(name_tuple, ref):
     else:
         recursive_setitem(ctx.root, name_tuple, ref)
         cursor = recursive_getitem(ctx.root, name_tuple)
-    if isinstance(cursor, (SchemInstance, SchemInstanceUnresolved)):
+    if isinstance(cursor, SchemInstance):
         register_in_group(cursor)
     return cursor
 
@@ -184,12 +184,22 @@ def add_element(name_tuple, element, src_line=None, src_column=None):
             return add(name_tuple, ref)
 
     if isinstance(element, type) and issubclass(element, Cell):
-        # Cell class: deferred resolution with parameters
-        ref = SchemInstanceUnresolved(
-            resolver=lambda **params: element(**params).symbol,
-            src_loc=src_loc,
-        )
-        return add(name_tuple, ref)
+        # Cell class: unresolved instance whose parameters are set in the body
+        # (.$name = value) and resolved lazily by the view context.
+        view_ctx = _view_ctx_var.get()
+        if view_ctx is None:
+            raise TypeError(
+                f"Cannot instantiate Cell class {element.__name__} without "
+                "a viewgen context; pass parameters at instantiation "
+                "instead."
+            )
+        if isinstance(ctx.root, Layout):
+            ref = LayoutInstance()
+        else:
+            ref = SchemInstance(src_loc=src_loc)
+        cursor = add(name_tuple, ref)
+        view_ctx.register_unresolved(cursor, element)
+        return cursor
 
     if isinstance(element, Cell):
         # Cell instance: symbol already determined, create SchemInstance directly

--- a/src/ordec/ord/context.py
+++ b/src/ordec/ord/context.py
@@ -180,7 +180,7 @@ def add_element(name_tuple, element, src_line=None, src_column=None):
     # Layout context: create LayoutInstance from Cell instances
     if isinstance(ctx.root, Layout):
         if isinstance(element, Cell):
-            ref = LayoutInstance(ref=element.layout)
+            ref = LayoutInstance(ref=element.layout, src_loc=src_loc)
             return add(name_tuple, ref)
 
     if isinstance(element, type) and issubclass(element, Cell):
@@ -194,7 +194,7 @@ def add_element(name_tuple, element, src_line=None, src_column=None):
                 "instead."
             )
         if isinstance(ctx.root, Layout):
-            ref = LayoutInstance()
+            ref = LayoutInstance(src_loc=src_loc)
         else:
             ref = SchemInstance(src_loc=src_loc)
         cursor = add(name_tuple, ref)

--- a/src/ordec/schematic/__init__.py
+++ b/src/ordec/schematic/__init__.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from .helpers import (
-    symbol_place_pins, schem_place, schem_check, resolve_instances,
+    symbol_place_pins, schem_place, schem_check,
     SchematicError, spice_params,
 )
 from .netlister import Netlister

--- a/src/ordec/schematic/helpers.py
+++ b/src/ordec/schematic/helpers.py
@@ -637,7 +637,9 @@ def schem_check(node: Schematic, add_conn_points: bool=False, add_terminal_taps=
     for inst in node.all(SchemInstance):
         if inst.symbol is None:
             raise SchematicError(
-                f"Instance {inst.full_path_label()} has no symbol.")
+                f"Instance {inst.full_path_label()} has no symbol: it was "
+                "created without one and never registered as an unresolved "
+                "instance.")
     suppress = False
     _check_overlapping_instances(node)
     suppress = suppress or node.has_errors()

--- a/src/ordec/schematic/helpers.py
+++ b/src/ordec/schematic/helpers.py
@@ -118,38 +118,21 @@ def schem_place(schem: Schematic, gap=None, port_margin=None):
     schem.outline = outline
 
 
-def _instance_symbol(inst) -> Symbol:
-    """
-    Returns the Symbol of a SchemInstance or SchemInstanceUnresolved. For
-    unresolved instances, it is generated from the parameters recorded so
-    far (cheap due to view caching).
-    """
-    if isinstance(inst, SchemInstanceUnresolved):
-        return inst.resolve_symbol()
-    return inst.symbol
-
-
 def schem_content_bbox(node: Schematic) -> Rect4R | None:
     """
     Returns the bounding box of the placed schematic content: instance
-    outlines (including unresolved instances), port positions, tap points
-    and wire vertices. Elements whose position is still unresolved
-    (Vec2LinearTerm) are ignored. Returns None for a schematic without
-    placed content.
+    outlines, port positions, tap points and wire vertices. Elements whose
+    position is still unresolved (Vec2LinearTerm) are ignored. Returns None
+    for a schematic without placed content.
 
     Related: routing.adjust_outline_initial(), which assumes placed
     elements and adds space for port labels.
     """
     points = []
-    for inst in itertools.chain(node.all(SchemInstance),
-                                node.all(SchemInstanceUnresolved)):
+    for inst in node.all(SchemInstance):
         if isinstance(inst.pos, Vec2LinearTerm):
             continue
-        if isinstance(inst, SchemInstanceUnresolved):
-            symbol = inst.resolve_symbol()
-        else:
-            symbol = inst.symbol
-        r = inst.loc_transform() * symbol.outline
+        r = inst.loc_transform() * inst.symbol.outline
         points += [Vec2R(r.lx, r.ly), Vec2R(r.ux, r.uy)]
     points += [port.pos for port in node.all(SchemPort)
         if not isinstance(port.pos, Vec2LinearTerm)]
@@ -177,11 +160,11 @@ def schem_place_ports(node: Schematic, clearance: int = 2):
     order, one unit apart, centered on the edge. Occupied positions are
     skipped. Ports whose pos is already defined are left untouched.
     """
-    pending = {East: [], West: [], North: [], South: []}
+    unresolved = {East: [], West: [], North: [], South: []}
     for port in node.all(SchemPort):
         if isinstance(port.pos, Vec2LinearTerm):
-            pending[port.align.unflip()].append(port)
-    if not any(pending.values()):
+            unresolved[port.align.unflip()].append(port)
+    if not any(unresolved.values()):
         return
 
     bbox = schem_content_bbox(node)
@@ -225,7 +208,7 @@ def schem_place_ports(node: Schematic, clearance: int = 2):
     for align, vertical, fixed, step in edges:
         aligned = []
         rest = []
-        for port in pending[align]:
+        for port in unresolved[align]:
             cross = aligned_cross(port, align)
             if cross is None:
                 rest.append(port)
@@ -255,17 +238,12 @@ def place_unplaced_instances(schem: Schematic, spacing=4):
     outline is set yet). The outline is expanded to cover the placed
     instances.
 
-    Intended to run before resolve_instances(), so SchemInstance and
-    SchemInstanceUnresolved are both handled; symbols of unresolved
-    instances are generated from the parameters recorded so far.
-
     Args:
         schem: Mutable schematic.
         spacing: Horizontal gap between adjacent placed instances (and
             between the outline edge and the first placed instance).
     """
-    unplaced = [inst for inst in itertools.chain(
-            schem.all(SchemInstance), schem.all(SchemInstanceUnresolved))
+    unplaced = [inst for inst in schem.all(SchemInstance)
         if isinstance(inst.pos, Vec2LinearTerm)]
     if not unplaced:
         return
@@ -278,11 +256,7 @@ def place_unplaced_instances(schem: Schematic, spacing=4):
 
     for inst in unplaced:
         # Place the instance geometry's left edge at x, with pos.y = 0.
-        if isinstance(inst, SchemInstanceUnresolved):
-            symbol = inst.resolve_symbol()
-        else:
-            symbol = inst.symbol
-        r = TD4R(d4=inst.orientation) * symbol.outline
+        r = TD4R(d4=inst.orientation) * inst.symbol.outline
         inst.pos = Vec2R(x - r.lx, 0)
         placed = inst.pos.transl() * r
         outline = placed if outline is None else outline \
@@ -657,6 +631,13 @@ def schem_check(node: Schematic, add_conn_points: bool=False, add_terminal_taps=
     Returns:
         True if the schematic has errors after checking.
     """
+    # Unresolved instances cannot be checked; a symbol may be missing here
+    # if a schematic is built without a view context (which resolves all
+    # unresolved instances in postprocess).
+    for inst in node.all(SchemInstance):
+        if inst.symbol is None:
+            raise SchematicError(
+                f"Instance {inst.full_path_label()} has no symbol.")
     suppress = False
     _check_overlapping_instances(node)
     suppress = suppress or node.has_errors()
@@ -686,38 +667,4 @@ def recursive_setitem(obj, tup, value):
     else:
         return recursive_setitem(obj[tup[0]], tup[1:], value)
 
-def resolve_instances(schematic: Schematic):
-    """
-    Resolves all SchemInstanceUnresolved objects, replacing them by
-    SchemInstance objects. Corresponding SchemInstanceUnresolvedParameter
-    objects are used in the process and removed afterwards.
-    Corresponding SchemInstanceUnresolvedConn objects are replaced by
-    SchemInstanceConn objects.
-    
-    The node ids (nids) of SchemInstanceUnresolved and
-    SchemInstanceUnresolvedConn objects are preserved.
-    """
-    for ui in schematic.all(SchemInstanceUnresolved):
-        with schematic.subgraph.updater() as sgu:
-            symbol = ui.resolve_symbol(remove_params_sgu=sgu)
-
-            new_scheminstance_tuple = SchemInstance(
-                pos=ui.pos,
-                orientation=ui.orientation,
-                symbol=symbol,
-                src_loc=ui.src_loc,
-                )
-
-            sgu.remove_nid(ui.nid)
-
-            for uc in schematic.all(SchemInstanceUnresolvedConn.ref_idx.query(ui)):
-                pin = recursive_getitem(symbol, uc.there)
-                if not isinstance(pin, Pin):
-                    raise SchematicError("Unresolved attribute {uc.there!r} did not resolve to Pin.")
-                new_conn_tuple = SchemInstanceConn(ref=uc.ref, here=uc.here, there=pin)
-
-                sgu.remove_nid(uc.nid)
-                sgu.add_single(new_conn_tuple, uc.nid, check_nid=False)
-
-            sgu.add_single(new_scheminstance_tuple, ui.nid, check_nid=False)
 

--- a/tests/test_course.py
+++ b/tests/test_course.py
@@ -443,17 +443,18 @@ courses_testdata = {
             InsertSolution("""
             # EDIT HERE (row)
             """, """
-            unit m1a:
-                ! .pos == (0, 0)
-            unit m2a:
-                ! .sd[0].center == m1a.sd[1].center
-                ! .pos.y == m1a.pos.y
-            unit m2b:
-                ! .sd[0].center == m2a.sd[1].center
-                ! .pos.y == m1a.pos.y
-            unit m1b:
-                ! .sd[0].center == m2b.sd[1].center
-                ! .pos.y == m1a.pos.y
+            Nmos m1a, m2a, m2b, m1b
+            for m in m1a, m2a, m2b, m1b:
+                m.$w = 1u
+                m.$l = 130n
+
+            ! m1a.pos == (0, 0)
+            ! m2a.sd[0].center == m1a.sd[1].center
+            ! m2a.pos.y == m1a.pos.y
+            ! m2b.sd[0].center == m2a.sd[1].center
+            ! m2b.pos.y == m1a.pos.y
+            ! m1b.sd[0].center == m2b.sd[1].center
+            ! m1b.pos.y == m1a.pos.y
             """),
             InsertSolution("""
             # EDIT HERE (gates)

--- a/tests/test_ord_runtime.ord
+++ b/tests/test_ord_runtime.ord
@@ -238,6 +238,58 @@ def test_instance_param_on_resolved_cell():
         with pytest.raises(TypeError):
             r1.$r = '2k'
 
+def test_bad_deferred_conn_path():
+    import pytest
+    from ordec.lib import Vdc, Gnd
+
+    root = Schematic()
+    with pytest.raises(QueryException, match="'zzz' not found"):
+        with root.view_context(root):
+            net vss, mid
+            Vdc('1') v1: .p -- mid; .n -- vss; .pos = (0, 6)
+            # zzz is not a pin of Res; resolution at context exit fails.
+            Res r1: .$r = '1k'; .p -- mid; .zzz -- vss; .pos = (5, 6)
+            Gnd() gnd: .p -- vss; .pos = (0, 0)
+
+def test_bad_deferred_conn_path_on_access():
+    import pytest
+    from ordec.lib import Vdc, Gnd
+
+    root = Schematic()
+    # Context exit retries the resolution and must fail with the same
+    # clean error as the first attempt: an aborted resolution leaves the
+    # instance untouched, so no conns from the first attempt survive to
+    # collide on retry.
+    with pytest.raises(QueryException, match="'zzz' not found"):
+        with root.view_context(root):
+            net vss, mid
+            Vdc('1') v1: .p -- mid; .n -- vss; .pos = (0, 6)
+            Res r1: .$r = '1k'; .p -- mid; .zzz -- vss; .pos = (5, 6)
+            Gnd() gnd: .p -- vss; .pos = (0, 0)
+
+            # Forced resolution fails on the bad path...
+            with pytest.raises(QueryException, match="'zzz' not found"):
+                r1.outline.uy
+            # ...and leaves the instance untouched:
+            assert r1.symbol is None
+            assert len(list(root.all(SchemInstanceConn.ref_idx.query(r1)))) == 0
+
+def test_duplicate_deferred_conn():
+    import pytest
+    from ordec.schematic import SchematicError
+    from ordec.lib import Vdc, Gnd
+
+    root = Schematic()
+    with pytest.raises(SchematicError, match="connected more than once"):
+        with root.view_context(root):
+            net vss, mid
+            Vdc('1') v1: .p -- mid; .n -- vss; .pos = (0, 6)
+            # r1.p is deferred-wired twice; resolution rejects this before
+            # touching the instance. (On a resolved instance, the second
+            # wire op raises a UniqueViolation directly.)
+            Res r1: .$r = '1k'; .p -- mid; .p -- vss; .n -- vss; .pos = (5, 6)
+            Gnd() gnd: .p -- vss; .pos = (0, 0)
+
 def test_instance_param_missing():
     import pytest
     from ordec.lib import Vdc, Gnd

--- a/tests/test_ord_runtime.ord
+++ b/tests/test_ord_runtime.ord
@@ -423,6 +423,7 @@ def test_layout_instance_param_missing():
                 ! .pos == (0, 0)
     note, = exc_info.value.__notes__
     assert "instance a" in note
+    assert "test_ord_runtime" in note  # src_loc of the `ParamLayoutCell a` statement
 
 def test_layout_instance_param_missing_on_access():
     import pytest

--- a/tests/test_ord_runtime.ord
+++ b/tests/test_ord_runtime.ord
@@ -93,18 +93,22 @@ def test_multi_name_bodyless_node_stmt():
 
 def test_scheminstance_creation():
     root = Schematic()
-    with root.ctx():
+    with root.view_context(root):
         # Bodyless...
-        # ...using a Cell subclass:
+        # ...using a Cell subclass (unresolved: symbol resolved on context exit):
         Res a
-        assert isinstance(a, SchemInstanceUnresolved)
-        # ...or using a Cell subclass instance (creates SchemInstance directly):
+        assert isinstance(a, SchemInstance)
+        assert a.symbol is None
+        a.$r = '1k'
+        # ...or using a Cell subclass instance (symbol set immediately):
         Res('1k') b
         assert isinstance(b, SchemInstance)
+        assert b.symbol is not None
 
         # With body...
         # ...using a Cell subclass:
         Res c:
+            .$r = '1k'
             .pos=(1,2)
         # ...or using a Cell subclass instance:
         Res('1k') d:
@@ -112,48 +116,49 @@ def test_scheminstance_creation():
 
         assert c.pos == d.pos == Vec2R(1,2)
 
+    # Context exit resolved all unresolved instances:
+    assert a.symbol == c.symbol == Res(r='1k').symbol
+
 def test_mixed_unresolved_resolved_instances():
-    """A schematic with both SchemInstance (from Cell instance) and
-    SchemInstanceUnresolved (from Cell class), wired together. ViewContext
-    automatically resolves all instances on exit."""
+    """A schematic with instances from a Cell instance (symbol set
+    immediately) and from a Cell class (unresolved symbol, params set via
+    body), wired together. ViewContext resolves all unresolved instances on
+    exit."""
     from ordec.lib import Vdc, Gnd
 
     root = Schematic()
     with root.view_context(root):
         net vss, mid
 
-        # Cell instance -> SchemInstance directly
+        # Cell instance -> symbol set immediately
         Vdc('1') v1: .p -- mid; .n -- vss; .pos = (0, 6)
-        # Cell class -> SchemInstanceUnresolved (params set via body)
+        # Cell class -> unresolved instance (params set via body)
         Res r1: .$r = '1k'; .p -- mid; .n -- vss; .pos = (5, 6)
-        # Another Cell instance -> SchemInstance directly
+        # Another Cell instance
         Gnd() gnd: .p -- vss; .pos = (0, 0)
 
-        # Before view_context exit: v1 and gnd are already SchemInstance,
-        # r1 is still SchemInstanceUnresolved
-        assert isinstance(v1, SchemInstance)
-        assert isinstance(gnd, SchemInstance)
-        assert isinstance(r1, SchemInstanceUnresolved)
+        # Before view_context exit: v1 and gnd are resolved, r1 is unresolved
+        assert v1.symbol is not None
+        assert gnd.symbol is not None
+        assert r1.symbol is None
 
         # v1 already has SchemInstanceConn (direct wiring)
         v1_conns = list(root.all(SchemInstanceConn.ref_idx.query(v1)))
         assert len(v1_conns) == 2
 
-        # r1 still has SchemInstanceUnresolvedConn (deferred wiring)
-        r1_conns = list(root.all(SchemInstanceUnresolvedConn.ref_idx.query(r1)))
-        assert len(r1_conns) == 2
+        # r1's wiring is deferred in the view context, not in the graph
+        r1_conns = list(root.all(SchemInstanceConn.ref_idx.query(r1)))
+        assert len(r1_conns) == 0
 
-    # After view_context exit: all instances are SchemInstance
+    # After view_context exit: all instances are resolved
     all_instances = list(root.all(SchemInstance))
     assert len(all_instances) == 3
-    assert not list(root.all(SchemInstanceUnresolved))
+    assert all(inst.symbol is not None for inst in all_instances)
+    assert r1.symbol == Res(r='1k').symbol
 
     # All connections are now SchemInstanceConn
     all_conns = list(root.all(SchemInstanceConn))
     assert len(all_conns) == 5  # v1: 2, r1: 2, gnd: 1
-
-    # No unresolved connections remain
-    assert not list(root.all(SchemInstanceUnresolvedConn))
 
 def test_wire_op():
     # The -- pseudo-operator is commutative: net -- pin and pin -- net should produce the same result.
@@ -174,15 +179,101 @@ def test_wire_op():
         v1_conns = list(root.all(SchemInstanceConn.ref_idx.query(v1)))
         assert len(v1_conns) == 2
 
-        r1_conns = list(root.all(SchemInstanceUnresolvedConn.ref_idx.query(r1)))
-        assert len(r1_conns) == 2
+        # r1's connections are deferred until resolution
+        r1_conns = list(root.all(SchemInstanceConn.ref_idx.query(r1)))
+        assert len(r1_conns) == 0
 
         gnd_conns = list(root.all(SchemInstanceConn.ref_idx.query(gnd)))
         assert len(gnd_conns) == 1
 
-    # After view_context exit: all connections resolved to SchemInstanceConn
+    # After view_context exit: all connections are SchemInstanceConn
     all_conns = list(root.all(SchemInstanceConn))
     assert len(all_conns) == 5
+
+def test_instance_param_last_wins():
+    from ordec.lib import Vdc, Gnd
+
+    root = Schematic()
+    with root.view_context(root):
+        net vss, mid
+        Vdc('1') v1: .p -- mid; .n -- vss; .pos = (0, 6)
+        Res r1: .$r = '1k'; .p -- mid; .n -- vss; .pos = (5, 6)
+        Gnd() gnd: .p -- vss; .pos = (0, 0)
+
+        # While the parameters are open, assignments overwrite (last wins):
+        r1.$r = '2k'
+
+    assert r1.symbol == Res(r='2k').symbol
+
+def test_instance_param_set_after_resolution():
+    import pytest
+    from ordec.lib import Vdc, Gnd
+
+    root = Schematic()
+    with root.view_context(root):
+        net vss, mid
+        Vdc('1') v1: .p -- mid; .n -- vss; .pos = (0, 6)
+        Res r1: .$r = '1k'; .p -- mid; .n -- vss; .pos = (5, 6)
+        Gnd() gnd: .p -- vss; .pos = (0, 0)
+
+        # A geometry read forces resolution; parameters can no longer be set:
+        outline_uy = r1.outline.uy
+        with pytest.raises(TypeError):
+            r1.$r = '2k'
+
+    assert r1.symbol == Res(r='1k').symbol
+
+def test_instance_param_on_resolved_cell():
+    import pytest
+    from ordec.lib import Vdc, Gnd
+
+    root = Schematic()
+    with root.view_context(root):
+        net vss, mid
+        # Cell instance form: parameters are fixed at instantiation.
+        Vdc('1') v1: .p -- mid; .n -- vss; .pos = (0, 6)
+        Res('1k') r1: .p -- mid; .n -- vss; .pos = (5, 6)
+        Gnd() gnd: .p -- vss; .pos = (0, 0)
+
+        with pytest.raises(TypeError):
+            r1.$r = '2k'
+
+def test_instance_param_missing():
+    import pytest
+    from ordec.lib import Vdc, Gnd
+
+    root = Schematic()
+    with pytest.raises(ParameterError, match="'r' is missing") as exc_info:
+        with root.view_context(root):
+            net vss, mid
+            Vdc('1') v1: .p -- mid; .n -- vss; .pos = (0, 6)
+            # r1's mandatory parameter r is never set; resolution at
+            # context exit fails.
+            Res r1: .p -- mid; .n -- vss; .pos = (5, 6)
+            Gnd() gnd: .p -- vss; .pos = (0, 0)
+    note, = exc_info.value.__notes__
+    assert "instance r1" in note
+    assert "test_ord_runtime" in note  # src_loc of the `Res r1` statement
+
+def test_instance_param_missing_on_access():
+    import pytest
+    from ordec.lib import Vdc, Gnd
+
+    root = Schematic()
+    with root.view_context(root):
+        net vss, mid
+        Vdc('1') v1: .p -- mid; .n -- vss; .pos = (0, 6)
+        Res r1: .p -- mid; .n -- vss; .pos = (5, 6)
+        Gnd() gnd: .p -- vss; .pos = (0, 0)
+
+        # Forced resolution fails while r is missing...
+        with pytest.raises(ParameterError, match="'r' is missing"):
+            r1.outline.uy
+        # ...but the failed attempt leaves the instance unresolved: the
+        # parameter can still be supplied.
+        r1.$r = '1k'
+
+    assert r1.symbol == Res(r='1k').symbol
 
 def test_viewgen_return_target_alias():
     ViewgenAlias = Symbol
@@ -272,6 +363,84 @@ def test_layout_instance_shorthand():
         assert isinstance(b, LayoutInstance)
         assert b.ref == tc.layout
         assert b.orientation == D4.MX
+
+cell ParamLayoutCell:
+    w = Parameter(int)
+    viewgen layout -> Layout:
+        .ref_layers = SG13G2().layers
+        layers = .ref_layers
+        LayoutRect r:
+            .layer = layers.Metal1
+        ! .r.width == self.w
+        ! .r.height == 100
+        ! .r.lx == 0
+        ! .r.ly == 0
+
+def test_layout_instance_unresolved():
+    root = Layout()
+    with root.view_context(root):
+        .ref_layers = SG13G2().layers
+        # Cell subclass -> unresolved instance, parametrized via .$ like in
+        # schematics; resolved on context exit.
+        ParamLayoutCell a:
+            .$w = 120
+            ! .pos == (0, 0)
+        assert isinstance(a, LayoutInstance)
+        assert a.ref is None
+
+    assert a.ref == ParamLayoutCell(w=120).layout
+    assert a.r.width == 120
+
+def test_layout_instance_resolved_on_access():
+    import pytest
+
+    root = Layout()
+    with root.view_context(root):
+        .ref_layers = SG13G2().layers
+        ParamLayoutCell a:
+            .$w = 120
+            ! .pos == (0, 0)
+
+        # Any access through the instance requires the resolved layout:
+        # it resolves the instance.
+        a.r
+        assert a.ref is not None
+        with pytest.raises(TypeError):
+            a.$w = 240
+
+    assert a.ref == ParamLayoutCell(w=120).layout
+
+def test_layout_instance_param_missing():
+    import pytest
+
+    root = Layout()
+    with pytest.raises(ParameterError, match="'w' is missing") as exc_info:
+        with root.view_context(root):
+            .ref_layers = SG13G2().layers
+            # a's mandatory parameter w is never set; resolution at
+            # context exit fails.
+            ParamLayoutCell a:
+                ! .pos == (0, 0)
+    note, = exc_info.value.__notes__
+    assert "instance a" in note
+
+def test_layout_instance_param_missing_on_access():
+    import pytest
+
+    root = Layout()
+    with root.view_context(root):
+        .ref_layers = SG13G2().layers
+        ParamLayoutCell a:
+            ! .pos == (0, 0)
+
+        # Forced resolution fails while w is missing...
+        with pytest.raises(ParameterError, match="'w' is missing"):
+            a.r
+        # ...but the failed attempt leaves the instance unresolved: the
+        # parameter can still be supplied.
+        a.$w = 120
+
+    assert a.ref == ParamLayoutCell(w=120).layout
 
 def test_node_as_context_manager():
     root = Symbol()

--- a/tests/test_schematic.py
+++ b/tests/test_schematic.py
@@ -9,6 +9,7 @@ this module instead.
 
 import pytest
 from ordec.core import *
+from ordec.core.context import SchematicViewContext
 from .lib import schematics as lib_test
 from ordec.lib.base import Res
 from ordec.lib.generic_mos import Nmos
@@ -161,7 +162,7 @@ def test_schematic_double_instance():
     errors = list(s.all(SchemErrorMarker))
     assert any(e.error_type == SchemErrorType.OverlappingInstances for e in errors)
 
-def test_scheminstance_unresolved():
+def test_scheminstance_unresolved_resolution():
     s_ref = MutableSubgraph.load({
         0: Schematic.Tuple(symbol=None, outline=None, cell=None, default_supply=None, default_ground=None),
         1: Net.Tuple(pin=None),
@@ -181,39 +182,49 @@ def test_scheminstance_unresolved():
     })
 
     s = Schematic()
+    ctx = SchematicViewContext(s)
 
     s.g = Net()
     s.s = Net()
     s.d = Net()
     s.b = Net()
 
-    s.myinst = SchemInstanceUnresolved(pos=(1, 2), resolver=lambda **params: Nmos(**params).symbol)
-    s.myinst % SchemInstanceUnresolvedConn(here=s.g, there=('g',))
-    s.myinst % SchemInstanceUnresolvedConn(here=s.s, there=('s',))
-    s.myinst % SchemInstanceUnresolvedConn(here=s.d, there=('d',))
-    s.myinst % SchemInstanceUnresolvedConn(here=s.b, there=('b',))
-    s.myinst % SchemInstanceUnresolvedParameter(name='l', value='2u')
-    s.myinst % SchemInstanceUnresolvedParameter(name='w', value='5u')
+    s.myinst = SchemInstance(pos=(1, 2))
+    ctx.register_unresolved(s.myinst, Nmos)
+    ctx.record_unresolved_conn(s.myinst, s.g, ('g',))
+    ctx.record_unresolved_conn(s.myinst, s.s, ('s',))
+    ctx.record_unresolved_conn(s.myinst, s.d, ('d',))
+    ctx.record_unresolved_conn(s.myinst, s.b, ('b',))
+    ctx.set_unresolved_param(s.myinst, 'l', '1u')
+    ctx.set_unresolved_param(s.myinst, 'w', '5u')
+    # Parameters are open until resolution; the last assignment wins:
+    ctx.set_unresolved_param(s.myinst, 'l', '2u')
 
-    s.resolve_instances()
+    assert s.myinst.symbol is None
+    ctx.resolve_all_instances()
+    assert s.myinst.symbol is not None
 
     assert s.matches(s_ref)
 
 def test_scheminstance_unresolved_hierarchical_path():
     s = Schematic()
+    ctx = SchematicViewContext(s)
 
     s.mynet = Net()
 
-    resolver = lambda **params: lib_test.MultibitReg_StructOfArrays(**params).symbol
+    s.myinst = SchemInstance(pos=(0, 0))
+    ctx.register_unresolved(s.myinst, lib_test.MultibitReg_StructOfArrays)
+    ctx.set_unresolved_param(s.myinst, 'bits', 4)
+    ctx.record_unresolved_conn(s.myinst, s.mynet, ('data', 'd', 3))
 
-    s.myinst = SchemInstanceUnresolved(resolver=resolver, pos=(0, 0))
-
-    s.myinst % SchemInstanceUnresolvedParameter(name='bits', value=4)
-    conn_u = s.myinst % SchemInstanceUnresolvedConn(here=s.mynet, there=('data', 'd', 3))
-
-    s.resolve_instances()
+    ctx.resolve_all_instances()
 
     conn = list(s.myinst.conns())[0]
-    assert conn.nid == conn_u.nid
     assert conn.here == s.mynet
     assert conn.there == lib_test.MultibitReg_StructOfArrays(bits=4).symbol.data.d[3]
+
+def test_scheminstance_params_without_view_context():
+    s = Schematic()
+    s.myinst = SchemInstance(pos=(0, 0), symbol=Nmos().symbol)
+    with pytest.raises(TypeError, match="viewgen body"):
+        s.myinst.params.l = '2u'

--- a/tests/test_schematic_constraints.py
+++ b/tests/test_schematic_constraints.py
@@ -1,8 +1,10 @@
 # SPDX-FileCopyrightText: 2025 ORDeC contributors
 # SPDX-License-Identifier: Apache-2.0
 
+import pytest
 from ordec.core import *
 from ordec.core.constraints import LinearTerm, Vec2LinearTerm, Rect4LinearTerm, TD4LinearTerm
+from ordec.core.context import SchematicViewContext
 
 
 class SimpleSymbol(Cell):
@@ -192,15 +194,18 @@ def test_td4linearterm_mul_concrete_td4():
 
 
 def test_unresolved_subcursor_uses_recorded_params():
-    # Geometry reads on a SchemInstanceUnresolved must resolve the symbol
-    # with the parameters recorded so far, not with defaults (MultiPinSymbol
-    # has no default for bits, so this raises if params are dropped).
+    # Geometry reads on an unresolved instance must resolve the symbol with the
+    # parameters recorded so far, not with defaults (MultiPinSymbol has no
+    # default for bits, so this raises if params are dropped). The read also
+    # resolves the instance: setting parameters afterwards must raise.
     sch = Schematic()
-    sch.inst1 = SchemInstanceUnresolved(
-        resolver=lambda **p: MultiPinSymbol(**p).symbol,
-        pos=Vec2R(1, 1),
-    )
-    sch.inst1 % SchemInstanceUnresolvedParameter(name='bits', value=2)
+    with SchematicViewContext(sch) as ctx:
+        sch.inst1 = SchemInstance(pos=Vec2R(1, 1))
+        ctx.register_unresolved(sch.inst1, MultiPinSymbol)
+        sch.inst1.params.bits = 2
 
-    assert sch.inst1['q'][1].pos == Vec2R(5, 3)
-    assert sch.inst1.outline.uy == R(5)
+        assert sch.inst1['q'][1].pos == Vec2R(5, 3)
+        assert sch.inst1.outline.uy == R(5)
+
+        with pytest.raises(TypeError, match="already resolved"):
+            sch.inst1.params.bits = 3


### PR DESCRIPTION
This branch unifies instance parameter syntax between schematic and layout viewgens.

Schematic and layout viewgens used to parametrize subcell instances differently: schematics supported deferred parametrization (`MyCell x:` + `.$param = value`), while layouts required all parameters at instantiation (`MyCell(param=value) x:`). There were reasons for this in earlier version, but this no longer made sense after we adopted the `_resolve_cursor()` mechanism. This led to a inconsistency that we also did not address: geometry reads resolved the instance's symbol from the parameters recorded so far, but nothing stopped later `.$` assignments from silently invalidating that geometry.

This PR makes `.$param = value` mean the same thing in both view types, with one consistent rule: until an instance is resolved, parameters can be assigned; the first access that needs the resolved subcell (e.g. reading its geometry) resolves the instance, and `.$` assignments afterwards raise an exception instead of modifying the existing symbol/layout reference. (`MyCell(param=value) x:` remains supported.)

Under the hood, the deferred state moved from dedicated schema node types (`SchemInstanceUnresolved` & friends, now removed) into the view context, similar to how geometric constraints are handled. Resolution failures now report the offending instance including its ORD source location. For this, `src_loc` was added to `LayoutInstance`.