### PR TITLE
Make net and port node statements

### DIFF
--- a/docs/ref/ord.rst
+++ b/docs/ref/ord.rst
@@ -63,13 +63,14 @@ A **node statement** is the ``A B`` construct that creates and names an element 
 
 1. **Node class statements** — the type is a Node subclass, e.g., ``LayoutRect x``
 2. **Node instance statements** — the type is a Cell class or instance, e.g., ``Nmos x``
-3. **Node keyword statements** — the type is a built-in keyword, e.g., ``input x``, ``output y``, ``port z``
+3. **Node keyword statements** — the type is a built-in keyword, e.g., ``input x``, ``output y``, ``port z``, ``net a``, ``path p``
 
-Node keyword statements come with direction-based align defaults: ``input``
+The pin and port keywords come with direction-based align defaults: ``input``
 pins face ``West``, ``output`` pins ``East``, and ``inout`` pins ``South``. A
 ``port`` defaults to the flipped align of its symbol pin, so e.g. a
 West-facing input pin yields an East-facing port. An ``.align=`` assignment
-in the statement body overrides these defaults.
+in the statement body overrides these defaults. ``net`` and ``path`` create a
+``Net`` or ``PathNode``, e.g. ``net clk: .auto_wire = False``.
 
 A node statement may have an optional body (indented block after ``:``) for setting attributes:
 

--- a/docs/ref/ord.rst
+++ b/docs/ref/ord.rst
@@ -69,8 +69,10 @@ The pin and port keywords come with direction-based align defaults: ``input``
 pins face ``West``, ``output`` pins ``East``, and ``inout`` pins ``South``. A
 ``port`` defaults to the flipped align of its symbol pin, so e.g. a
 West-facing input pin yields an East-facing port. An ``.align=`` assignment
-in the statement body overrides these defaults. ``net`` and ``path`` create a
-``Net`` or ``PathNode``, e.g. ``net clk: .auto_wire = False``.
+in the statement body overrides these defaults.
+
+The ``net`` and ``path`` keywords create a ``Net`` or ``PathNode``, e.g.
+``net clk: .auto_wire = False``.
 
 A node statement may have an optional body (indented block after ``:``) for setting attributes:
 

--- a/docs/ref/ord.rst
+++ b/docs/ref/ord.rst
@@ -50,11 +50,11 @@ Python to supply the necessary constructs during execution.
 
 .. code-block::
 
-    # Type 1
+    # Indented body
     port xyz:
         .pos=(1,2)
-    # Type 2
-    port xyz(.pos=(1,2))
+    # Inline body
+    port xyz: .pos=(1,2)
 
 Node Statements
 ^^^^^^^^^^^^^^^
@@ -93,16 +93,16 @@ To demonstrate how the ORD context works and how the conversion from ORD to Pyth
 
     cell Inv:
         viewgen symbol(self) -> Symbol:
-            inout vdd(.align=North)
-            inout vss(.align=South)
-            input a(.align=West)
-            output y(.align=East)
+            inout vdd: .align=North
+            inout vss: .align=South
+            input a: .align=West
+            output y: .align=East
 
         viewgen schematic(self) -> Schematic:
-            port vdd(.pos=(2,13); .align=North)
-            port vss(.pos=(2,1); .align=South)
-            port y (.pos=(9,7); .align=West)
-            port a (.pos=(1,7); .align=East)
+            port vdd: .pos=(2,13); .align=North
+            port vss: .pos=(2,1); .align=South
+            port y: .pos=(9,7); .align=West
+            port a: .pos=(1,7); .align=East
 
             Nmos pd:
                 .s -- vss
@@ -206,14 +206,14 @@ of the example.
 
         @viewgen
         def schematic(self) -> Schematic:
-            vss = context.add_port(('vss',))
-            with vss.ctx():
-                context.root().pos = (2,1)
-                context.root().align = South
             vdd = context.add_port(('vdd',))
             with vdd.ctx():
                 context.root().pos = (2,13)
                 context.root().align = North
+            vss = context.add_port(('vss',))
+            with vss.ctx():
+                context.root().pos = (2,1)
+                context.root().align = South
             y = context.add_port(('y',))
             with y.ctx():
                 context.root().pos = (9,7)

--- a/src/ordec/lsp/analysis/parser_pass.py
+++ b/src/ordec/lsp/analysis/parser_pass.py
@@ -1024,12 +1024,17 @@ class OrdAnalysisBuilder:
                     ))
             return
 
-        if node.data in ("path_stmt", "net_stmt"):
+        if node.data in ("path_stmt", "net_stmt", "path_stmt_nobody", "net_stmt_nobody"):
+            kind_name = "net" if node.data.startswith("net") else "path"
+            type_names = ["Net"] if kind_name == "net" else ["PathNode"]
             names = []
             selection_node = None
-            type_names = ["Net"] if node.data == "net_stmt" else ["PathNode"]
+            body_node = None
             for child in node.children:
                 if not isinstance(child, Tree):
+                    continue
+                if child.data == "context_body":
+                    body_node = child
                     continue
 
                 if selection_node is None:
@@ -1038,7 +1043,7 @@ class OrdAnalysisBuilder:
                 # Each declared name is its own node statement record, so cell
                 # member collection sees multi-name declarations too.
                 self.node_statements.append({
-                    "kind_name": node.data[:-5],
+                    "kind_name": kind_name,
                     "kind_range": tree_range(node),
                     "kind_binding_id": None,
                     "target_name": tree_text(child),
@@ -1065,11 +1070,15 @@ class OrdAnalysisBuilder:
             if names and selection_node is not None:
                 self.symbols.append(AnalysisSymbol(
                     name=", ".join(names),
-                    kind=node.data[:-5],
+                    kind=kind_name,
                     range=tree_range(node),
                     selection_range=tree_range(selection_node),
                     content_end_line=content_end_line(node),
                 ))
+            # Bodied form: analyze the statement body like node_stmt does, so
+            # bindings and references inside it are recorded.
+            if body_node is not None:
+                self.visit(body_node, scope_id, context_type_names=type_names)
             return
 
         if node.data == "import_name":

--- a/src/ordec/ord/ord.lark
+++ b/src/ordec/ord/ord.lark
@@ -96,8 +96,8 @@ lambda_kwparams: "**" name ","?
             | nonlocal_stmt
             | assert_stmt
             | type_alias_stmt
-            | path_stmt
-            | net_stmt
+            | path_stmt_nobody
+            | net_stmt_nobody
             | constrain_stmt
             | node_stmt_nobody | anon_node_stmt_nobody)
 
@@ -137,7 +137,7 @@ assert_stmt: "assert" test ["," test]
 
 ?compound_stmt: if_stmt | while_stmt | for_stmt | try_stmt | match_stmt
               | with_stmt | funcdef | classdef | celldef | decorated | async_stmt | viewgen
-              | node_stmt | anon_node_stmt
+              | node_stmt | anon_node_stmt | net_stmt | path_stmt
 async_stmt: "async" (funcdef | with_stmt | for_stmt)
 if_stmt: "if" test ":" suite elifs ["else" ":" suite]
 elifs: elif_*
@@ -447,6 +447,8 @@ _ANONYMOUS_STMT.3: /anonymous(?![\t \f]*[:=])(?=[\t \f]+)/
                | name -> var
 
 dotted_atom: "." name?
-path_stmt: "path" context_target ("," context_target)*
-net_stmt: "net" context_target ("," context_target)*
+path_stmt: "path" context_target context_body
+path_stmt_nobody: "path" context_target ("," context_target)*
+net_stmt: "net" context_target context_body
+net_stmt_nobody: "net" context_target ("," context_target)*
 // END OF ORD DEFINITIONS

--- a/src/ordec/ord/ord_transformer.py
+++ b/src/ordec/ord/ord_transformer.py
@@ -162,7 +162,7 @@ class OrdTransformer(PythonTransformer):
         There are three types of node statements:
         - Node class statements: e.g., LayoutRect x
         - Node instance statements: e.g., Nmos x
-        - Node keyword statements: e.g., input x, port x
+        - Node keyword statements: e.g., input x, port x, net x, path x
         """
         context_type = nodes[0]
         context_name = nodes[1]
@@ -228,6 +228,22 @@ class OrdTransformer(PythonTransformer):
             args = [ast.Tuple(elts=context_name_tuple, ctx=ast.Load())]
             func = self.ast_ord_context("add_port")
             rhs = ast.Call(func=func, args=args, keywords=[])
+
+        # Case for net/path statements
+        elif context_type_name in ("net", "path"):
+            node_type = "Net" if context_type_name == "net" else "PathNode"
+            rhs = ast.Call(
+                func=self.ast_ord_context("add"),
+                args=[
+                    ast.Tuple(elts=context_name_tuple, ctx=ast.Load()),
+                    ast.Call(
+                        func=self.ast_core(node_type),
+                        args=[],
+                        keywords=[]
+                    )
+                ],
+                keywords=[]
+            )
 
         # Case for any other element type (Cell class/instance, Node class/instance)
         else:
@@ -360,41 +376,31 @@ class OrdTransformer(PythonTransformer):
             ), attr, ctx=ctx
         )
 
-    def net_and_path_stmt_helper(self, nodes, stmt):
-        """Helper for similar code from net and path statements"""
-        stmt_list = list()
-        for name in nodes:
-            # Names can be attributes or subscript accesses
-            context_name_tuple = self.extract_path(name)
-            name_length = len(context_name_tuple)
-            rhs = ast.Call(
-                func=self.ast_ord_context("add"),
-                args=[
-                    ast.Tuple(elts=context_name_tuple, ctx=ast.Load()),
-                    ast.Call(
-                        func=self.ast_core(stmt),
-                        keywords=[],
-                        args=[]
-                    )
-                ],
-                keywords=[]
-            )
-            # Path access must not be assigned
-            if name_length > 1:
-                stmt_list.append(ast.Expr(rhs))
-            else:
-                lhs = copy.copy(name)
-                self._set_ctx(lhs, ast.Store())
-                stmt_list.append(ast.Assign([lhs], rhs))
-        return stmt_list
+    @v_args(meta=True)
+    def net_stmt(self, meta, nodes):
+        """ Net statement with body (net x: ...) """
+        return self.node_stmt(meta, ["net", *nodes])
 
-    def net_stmt(self, nodes):
-        """ Add net (net x)"""
-        return self.net_and_path_stmt_helper(nodes, "Net")
+    @v_args(meta=True)
+    def path_stmt(self, meta, nodes):
+        """ Path statement with body (path x: ...) """
+        return self.node_stmt(meta, ["path", *nodes])
 
-    def path_stmt(self, nodes):
-        """ Add path (path x) """
-        return self.net_and_path_stmt_helper(nodes, "PathNode")
+    @v_args(meta=True)
+    def net_stmt_nobody(self, meta, nodes):
+        """ Net statement without body, supports multiple names (net a, b) """
+        result = []
+        for context_target in nodes:
+            result.extend(self.node_stmt(meta, ["net", context_target]))
+        return result
+
+    @v_args(meta=True)
+    def path_stmt_nobody(self, meta, nodes):
+        """ Path statement without body, supports multiple names (path a, b) """
+        result = []
+        for context_target in nodes:
+            result.extend(self.node_stmt(meta, ["path", context_target]))
+        return result
 
     def _flatten(self, items):
         """ Flatten the body of a node statement suite"""

--- a/src/ordec/ord/ord_transformer.py
+++ b/src/ordec/ord/ord_transformer.py
@@ -169,13 +169,10 @@ class OrdTransformer(PythonTransformer):
         context_body = nodes[2] if len(nodes) > 2 else None
         if isinstance(context_type, str):
             context_type_name = context_type
-            context_type_expr = ast.Name(id=context_type, ctx=ast.Load())
         elif isinstance(context_type, ast.Name):
             context_type_name = context_type.id
-            context_type_expr = context_type
         else:
             context_type_name = None
-            context_type_expr = context_type
         inout = ''
 
         context_name_tuple = self.extract_path(context_name)
@@ -249,7 +246,7 @@ class OrdTransformer(PythonTransformer):
         else:
             args = [
                 ast.Tuple(elts=context_name_tuple, ctx=ast.Load()),
-                context_type_expr
+                context_type
             ]
             func = self.ast_ord_context("add_element")
             rhs = ast.Call(

--- a/support/editors/jetbrains/src/main/java/org/ordec/intellij/OrdStatementParsing.java
+++ b/support/editors/jetbrains/src/main/java/org/ordec/intellij/OrdStatementParsing.java
@@ -153,7 +153,7 @@ public class OrdStatementParsing extends StatementParsing {
         return false;
     }
 
-    // path_stmt/net_stmt: keyword context_target ("," context_target)*
+    // path_stmt/net_stmt: keyword context_target (context_body | ("," context_target)*)
     private boolean parsePathNetStatement() {
         SyntaxTreeBuilder.Marker marker = myBuilder.mark();
         myBuilder.advanceLexer();
@@ -161,14 +161,21 @@ public class OrdStatementParsing extends StatementParsing {
             marker.rollbackTo();
             return false;
         }
-        do {
+        parseContextTarget();
+        if (myBuilder.getTokenType() == PyTokenTypes.COLON) {
+            myBuilder.advanceLexer();
+            parseOrdSuite();
+            marker.done(OrdElementTypes.PATH_NET_STATEMENT);
+            return true;
+        }
+        while (matchToken(PyTokenTypes.COMMA)) {
             // tolerate a trailing comma instead of swallowing whatever
             // token follows it into a context target
             if (myBuilder.getTokenType() != PyTokenTypes.IDENTIFIER) {
                 break;
             }
             parseContextTarget();
-        } while (matchToken(PyTokenTypes.COMMA));
+        }
         endOfLine();
         marker.done(OrdElementTypes.PATH_NET_STATEMENT);
         return true;

--- a/support/editors/jetbrains/src/test/java/org/ordec/intellij/OrdDialectParsingTest.java
+++ b/support/editors/jetbrains/src/test/java/org/ordec/intellij/OrdDialectParsingTest.java
@@ -79,6 +79,8 @@ public class OrdDialectParsingTest extends BasePlatformTestCase {
             "net vdd, ring.vx",
             "path ctr[0], ctr[1].sub",
             "path ctr[1:2]",
+            "net clk:\n            .auto_wire = False",
+            "path grp:\n            net a",
             "print foo:\n            pass",
         };
         for (String statement : statements) {

--- a/support/editors/sublime/Ord.sublime-syntax
+++ b/support/editors/sublime/Ord.sublime-syntax
@@ -156,6 +156,9 @@ contexts:
   # net ring.vx / path ctr[0]
   ord-path-net-targets:
     - include: comments
+    - match: ':'
+      scope: punctuation.section.block.begin.ord
+      pop: 1
     - match: ';'
       scope: punctuation.terminator.ord
       pop: 1

--- a/support/editors/tests/test_editor_grammars.py
+++ b/support/editors/tests/test_editor_grammars.py
@@ -33,6 +33,8 @@ KEYWORD_RULES = {
     'viewgen': 'viewgen',
     'path_stmt': 'path_net',
     'net_stmt': 'path_net',
+    'path_stmt_nobody': 'path_net',
+    'net_stmt_nobody': 'path_net',
 }
 
 # Soft keywords as plain names that must not match declarations or node
@@ -53,14 +55,16 @@ ATOM_EXPR_POSITIVES = [
     ('rows[0] r0:', 'node_stmt'),
     ('anonymous lib.Vdc(dc=1) v0:', 'anon_node_stmt'),
     ('lib.Inv i2, i3', 'node_stmt_nobody'),
-    ('net vdd, ring.vx', 'net_stmt'),
-    ('path ctr[0], ctr[1].sub', 'path_stmt'),
+    ('net vdd, ring.vx', 'net_stmt_nobody'),
+    ('path ctr[0], ctr[1].sub', 'path_stmt_nobody'),
+    ('net ring.vx:', 'net_stmt'),
+    ('path ctr[0]:', 'path_stmt'),
 ]
 
 
 def wrap_in_viewgen(line, rule):
     """Embed a synthetic statement in a minimal cell/viewgen skeleton."""
-    body = '\n            pass' if rule in NODE_RULES else ''
+    body = '' if rule.endswith('_nobody') else '\n            pass'
     return f'cell C:\n    viewgen v(self) -> Schematic:\n        {line}{body}\n'
 
 
@@ -306,6 +310,8 @@ TREE_SITTER_RULES = {
     'viewgen': 'viewgen_definition',
     'path_stmt': 'path_net_statement',
     'net_stmt': 'path_net_statement',
+    'path_stmt_nobody': 'path_net_statement',
+    'net_stmt_nobody': 'path_net_statement',
 }
 
 

--- a/support/editors/tree-sitter-ord/grammar.js
+++ b/support/editors/tree-sitter-ord/grammar.js
@@ -43,6 +43,7 @@ module.exports = grammar(python, {
     [$.cell_definition, $._node_kind],
     [$.viewgen_definition, $._node_kind],
     [$.path_net_statement, $._node_kind],
+    [$.path_net_statement, $._path_net_definition, $._node_kind],
     [$.type_alias_statement, $._node_kind],
     [$.node_statement, $.node_statement_nobody, $.primary_expression],
     [$.node_statement, $.node_statement_nobody, $._node_kind],
@@ -83,6 +84,7 @@ module.exports = grammar(python, {
       $.with_statement,
       $.cell_definition,
       $.viewgen_definition,
+      alias($._path_net_definition, $.path_net_statement),
       $.node_statement,
       $.function_definition,
       $.class_definition,
@@ -164,6 +166,13 @@ module.exports = grammar(python, {
     path_net_statement: $ => prec.dynamic(1, seq(
       field('keyword', choice('path', 'net')),
       commaSep1(field('name', $.context_target)),
+    )),
+
+    _path_net_definition: $ => prec.dynamic(1, seq(
+      field('keyword', choice('path', 'net')),
+      field('name', $.context_target),
+      ':',
+      field('body', $._suite),
     )),
 
     context_target: $ => seq(

--- a/support/editors/tree-sitter-ord/test/corpus/ord.txt
+++ b/support/editors/tree-sitter-ord/test/corpus/ord.txt
@@ -658,3 +658,40 @@ viewgen top() -> Symbol:
       (identifier))
     (block
       (pass_statement))))
+
+================================================================================
+Net and path statements with a body
+================================================================================
+
+viewgen schematic(self) -> Schematic:
+    net clk:
+        .auto_wire = False
+    path grp:
+        net a
+
+--------------------------------------------------------------------------------
+
+(module
+  (viewgen_definition
+    (identifier)
+    (parameters
+      (identifier))
+    (type
+      (identifier))
+    (block
+      (path_net_statement
+        (context_target
+          (identifier))
+        (block
+          (expression_statement
+            (assignment
+              (ord_local_attribute
+                (identifier))
+              (false)))))
+      (path_net_statement
+        (context_target
+          (identifier))
+        (block
+          (path_net_statement
+            (context_target
+              (identifier))))))))

--- a/tests/test_analysis_ord.py
+++ b/tests/test_analysis_ord.py
@@ -373,6 +373,30 @@ def test_reused_symbol_members():
     assert session.definition(uri, position_at(source, "g --"))["name"] == "g"
 
 
+def test_net_path_statement_bodies():
+    source = dedent("""\
+        from ordec.core import *
+
+        cell Inv:
+            viewgen schematic(self) -> Schematic:
+                net vss
+                net clk:
+                    .auto_wire = False
+                    vss.auto_wire = False
+                path grp:
+                    net inner
+                clk.auto_wire = True
+        """)
+    session = AnalysisSession()
+    uri = "file:///tmp/net_path_bodies.ord"
+    session.open_document(uri, source)
+
+    assert session.diagnostics(uri) == []
+    # References inside and after a statement body resolve to the net targets.
+    assert session.definition(uri, position_at(source, "vss.auto_wire"))["name"] == "vss"
+    assert session.definition(uri, position_at(source, "clk.auto_wire = True"))["name"] == "clk"
+
+
 def test_cell_member_sources():
     source = dedent("""\
         from ordec.core import *

--- a/tests/test_ord_compiler.py
+++ b/tests/test_ord_compiler.py
@@ -1167,6 +1167,11 @@ def test_name_net_assignment():
     ord_string = "net = 1"
     compare_asts(ord_string)
 
+def test_net_multi_target_with_body():
+    # Like node statements, the bodied form allows only a single target.
+    ord_string = "net a, b: x"
+    compare_syntax_errors(ord_string)
+
 def test_name_viewgen_assignment():
     ord_string = "viewgen = 1"
     compare_asts(ord_string)

--- a/tests/test_ord_compiler.py
+++ b/tests/test_ord_compiler.py
@@ -5,9 +5,12 @@ from ordec.ord import ord_to_py
 import ast
 import pytest
 
-def compare_asts(ord_code_string):
+def compare_asts(ord_code_string, py_code_string=None):
+    """Compare compiled ORD code against Python code (itself by default)."""
+    if py_code_string is None:
+        py_code_string = ord_code_string
     ord_ast = ord_to_py(ord_code_string)
-    python_ast = ast.parse(ord_code_string)
+    python_ast = ast.parse(py_code_string)
     assert (ast.dump(ord_ast) ==
             ast.dump(python_ast))
 
@@ -1171,6 +1174,16 @@ def test_net_multi_target_with_body():
     # Like node statements, the bodied form allows only a single target.
     ord_string = "net a, b: x"
     compare_syntax_errors(ord_string)
+
+def test_net_with_body():
+    compare_asts(
+        "net clk:\n"
+        "    .auto_wire = False\n",
+
+        "clk = __ord_context__.add(('clk',), __ordec_core__.Net())\n"
+        "with clk.ctx():\n"
+        "    __ord_context__.root().auto_wire = False\n",
+    )
 
 def test_name_viewgen_assignment():
     ord_string = "viewgen = 1"

--- a/tests/test_ord_runtime.ord
+++ b/tests/test_ord_runtime.ord
@@ -49,6 +49,25 @@ def test_symbol_pin_creation():
     assert root.d.pintype == PinType.Inout
     assert root.d.align == D4.R180
 
+def test_net_path_statements():
+    root = Schematic()
+    with root.ctx():
+        # Bodyless net statement, with multiple names:
+        net vss, mid
+        # Net statement with body:
+        net clk:
+            .auto_wire = False
+            assert .parent == root
+        # A path statement body opens the path's node context:
+        path grp:
+            net a
+
+    assert isinstance(root.vss, Net)
+    assert isinstance(root.mid, Net)
+    assert root.vss.auto_wire == True
+    assert root.clk.auto_wire == False
+    assert isinstance(root.grp.a, Net)
+
 def test_nested_contexts():
     root1 = Symbol()
     root2 = Symbol()


### PR DESCRIPTION
I think `net` and `port` should support the full node statement syntax, i.e. have an optional body.

This implementation is just a first attempt.