### PR TITLE
Ihp130 mos sd flags 2

### DIFF
--- a/src/ordec/core/cell.py
+++ b/src/ordec/core/cell.py
@@ -458,7 +458,15 @@ class Cell(metaclass=MetaCell):
         pass
 
     def params_list(self, use_repr=False) -> list[str]:
-        param_items = [(k, getattr(self, k)) for k in self._class_params if getattr(self, k) is not None]
+        param_items = []
+        for k in self._class_params:
+            v = getattr(self, k)
+            if v is None:
+                continue
+            # Hide boolean parameters left at their default:
+            if isinstance(v, bool) and v == self._class_params[k].default:
+                continue
+            param_items.append((k, v))
         if use_repr:
             return [f"{k}={self._class_params[k].value_repr(v)}"
                 for k, v in param_items]

--- a/src/ordec/lib/ihp130.py
+++ b/src/ordec/lib/ihp130.py
@@ -300,9 +300,17 @@ class SG13G2(Cell):
 
         return rs
 
-def layoutgen_mos(cell: Cell, length: R, width: R, num_gates: int, nwell: bool) -> Layout:
+def layoutgen_mos(cell: Cell, length: R, width: R, num_gates: int, nwell: bool,
+    contact_sd_odd: bool=True, contact_sd_even: bool=True) -> Layout:
     """
     Layout generation function shared for Nmos and Pmos cells.
+
+    The num_gates+1 source/drain regions are numbered left to right, starting
+    at 0. contact_sd_odd / contact_sd_even select which of them get a Cont
+    array and a Metal1 strip; the others are left as bare diffusion, which
+    connects the adjacent channels in series. Skipping the odd regions of a
+    device with an even num_gates thus yields a series chain that is only
+    contacted at both ends.
 
     Notice: Placement of Cont vias differs slightly from the foundry-provieded PCell.
 
@@ -320,8 +328,20 @@ def layoutgen_mos(cell: Cell, length: R, width: R, num_gates: int, nwell: bool) 
 
     activ_ext = None
 
+    def sd_contacted(i):
+        return contact_sd_even if i % 2 == 0 else contact_sd_odd
+
     def add_sd(i):
         nonlocal l, s, x_cur, activ_ext
+        if not sd_contacted(i):
+            # Bare diffusion: the region is part of l.activ, so no node of
+            # its own is generated, only the Metal1 pad and the Activ
+            # enlargement (which exists solely for the Cont enclosure) are
+            # omitted. The gate pitch is left unchanged, so the surrounding
+            # geometry does not depend on which regions are contacted, and
+            # devices abutting on the region place it via l.activ.
+            x_cur = x_cur + 160
+            return
         l.sd[i] = LayoutRect(layer=layers.Metal1)
         sd = l.sd[i]
         s.constrain(sd.west == (x_cur, l.activ.cy))
@@ -388,6 +408,8 @@ def layoutgen_mos(cell: Cell, length: R, width: R, num_gates: int, nwell: bool) 
     # the Activ enclosure comes from activ/activ_ext.
     margin_y = 70 if W >= 300 else 0
     for i in range(num_gates + 1):
+        if not sd_contacted(i):
+            continue
         makevias(l, l.sd[i].rect, layers.Cont,
             size=Vec2I(160, 160),
             spacing=Vec2I(180, 180),
@@ -402,6 +424,11 @@ class Mos(SimLeafCell):
     w = Parameter(R)  #: Width
     m = Parameter(int, default=1)  #: Multiplier, i. e. number of devices with separate Activ areas in parallel)
     ng = Parameter(int, default=1)  #: Number of gate fingers
+
+    #: Contact odd-numbered source/drain regions (Cont + Metal1)
+    contact_sd_odd = Parameter(bool, default=True)
+    #: Contact even-numbered source/drain regions (Cont + Metal1)
+    contact_sd_even = Parameter(bool, default=True)
 
     def ngspice_save_params(self):
         # PSP103 (OSDI) operating-point outputs:
@@ -440,7 +467,9 @@ class Nmos(Mos):
     def layout(self) -> Layout:
         if self.m != 1:
             raise ParameterError("m != 1 not supported for layout.")
-        return layoutgen_mos(self, self.l, self.w, self.ng, nwell=False)
+        return layoutgen_mos(self, self.l, self.w, self.ng, nwell=False,
+            contact_sd_odd=self.contact_sd_odd,
+            contact_sd_even=self.contact_sd_even)
 
     @classmethod
     def discoverable_instances(cls):
@@ -456,7 +485,9 @@ class Pmos(Mos):
     def layout(self) -> Layout:
         if self.m != 1:
             raise ParameterError("m != 1 not supported for layout.")
-        return layoutgen_mos(self, self.l, self.w, self.ng, nwell=True)
+        return layoutgen_mos(self, self.l, self.w, self.ng, nwell=True,
+            contact_sd_odd=self.contact_sd_odd,
+            contact_sd_even=self.contact_sd_even)
 
     @classmethod
     def discoverable_instances(cls):

--- a/tests/lib/ihp130_nmos_series.ord
+++ b/tests/lib/ihp130_nmos_series.ord
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: 2026 ORDeC contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Two NMOS devices in series, abutted on a shared source/drain region (see
+tests/test_ihp130_inv.py).
+
+The two devices share one diffusion strip instead of each getting their own
+Activ island: the lower device leaves its drain bare (contact_sd_odd=False),
+the upper device leaves its source bare (contact_sd_even=False), and the two
+regions are constrained to coincide. The internal node is therefore diffusion
+only, with no Cont and no Metal1 of its own.
+"""
+
+from ordec.core import *
+from ordec.lib.ihp130 import Nmos, Ptap, SG13G2, run_drc
+
+cell SeriesNmos:
+    viewgen layout(self) -> Layout:
+        .ref_layers = SG13G2().layers
+        layers = .ref_layers
+
+        # Lower device: source contacted, drain bare.
+        Nmos(w=1u, l=130n, contact_sd_odd=False) m1:
+            ! .pos == (0, 0)
+        # Upper device: source bare, drain contacted. Overlapping the two
+        # Activ islands by 70 Activ margin + 160 S/D strip + 70 Activ margin
+        # merges the two bare regions into one shared diffusion.
+        Nmos(w=1u, l=130n, contact_sd_even=False) m2:
+            ! .activ.lx == m1.activ.ux - 300
+            ! .activ.cy == m1.activ.cy
+        Ptap(l=0.7u, w=0.7u) ptap
+
+        # Source of the lower device tied to the bulk tap, which also places
+        # ptap relative to the devices:
+        LayoutRect m1_s:
+            .layer = layers.Metal1
+            ! .southwest == ptap.m1.southeast
+            ! .southeast == m1.sd[0].southwest
+            ! .height == 160
+            ! .width == 800
+
+        # Drain of the upper device, extended to meet the Metal1 min. area:
+        LayoutRect m1_d:
+            .layer = layers.Metal1
+            ! .south == m2.sd[1].north
+            ! .width == 160
+            ! .height == 500
+
+    viewgen drc(self) -> DrcReport:
+        . = run_drc(self.layout)

--- a/tests/lib/ihp130_nmos_series.ord
+++ b/tests/lib/ihp130_nmos_series.ord
@@ -13,9 +13,32 @@ only, with no Cont and no Metal1 of its own.
 """
 
 from ordec.core import *
-from ordec.lib.ihp130 import Nmos, Ptap, SG13G2, run_drc
+from ordec.lib.ihp130 import Nmos, Ptap, SG13G2, run_drc, run_lvs
 
 cell SeriesNmos:
+    viewgen symbol(self) -> Symbol:
+        # Two independent gates g1/g2, a shared bottom terminal s (also the
+        # bulk tie), and the top drain d. The middle source/drain node is
+        # internal and has no pin.
+        inout d:  .align=North
+        inout s:  .align=South
+        input g1
+        input g2
+
+    viewgen schematic(self) -> Schematic:
+        net mid  # shared source/drain diffusion between the two devices
+
+        port d:  .pos=(2, 13); .align=East
+        port s:  .pos=(2, 1);  .align=East
+        port g1: .pos=(1, 4)
+        port g2: .pos=(1, 10)
+
+        # m1 (lower device): source and bulk on s, drain on the internal node.
+        # m2 (upper device): source on the internal node, drain on d. Both
+        # bulks tie to s, which the layout realises through the ptap.
+        Nmos(w=1u, l=130n) m1: .pos=(3, 2); .d -- mid; .g -- g1; .s -- s;   .b -- s
+        Nmos(w=1u, l=130n) m2: .pos=(3, 8); .d -- d;   .g -- g2; .s -- mid; .b -- s
+
     viewgen layout(self) -> Layout:
         .ref_layers = SG13G2().layers
         layers = .ref_layers
@@ -32,20 +55,61 @@ cell SeriesNmos:
         Ptap(l=0.7u, w=0.7u) ptap
 
         # Source of the lower device tied to the bulk tap, which also places
-        # ptap relative to the devices:
+        # ptap relative to the devices. Carries the s (source/bulk) pin:
         LayoutRect m1_s:
             .layer = layers.Metal1
             ! .southwest == ptap.m1.southeast
             ! .southeast == m1.sd[0].southwest
             ! .height == 160
             ! .width == 800
+            .create_pin(self.symbol.s)
 
-        # Drain of the upper device, extended to meet the Metal1 min. area:
+        # Drain of the upper device, extended to meet the Metal1 min. area.
+        # Carries the d pin:
         LayoutRect m1_d:
             .layer = layers.Metal1
             ! .south == m2.sd[1].north
             ! .width == 160
             ! .height == 500
+            .create_pin(self.symbol.d)
+
+        # Gate contacts. Each gate poly is extended south into the free field
+        # below the devices with a landing pad wide enough for the Cont
+        # enclosure (0.07 um each side), then contacted up to a Metal1 pin.
+        # Routing both gates south keeps them clear of the s/d Metal1 and of
+        # each other (the two 0.32 um pads, 0.51 um apart, keep >= 0.18 um).
+        LayoutRect g1_poly:
+            .layer = layers.GatPoly
+            ! .cx == m1.poly[0].cx
+            ! .north == m1.poly[0].south
+            ! .size == (320, 600)
+        LayoutRect g1_cont:
+            .layer = layers.Cont
+            ! .size == (160, 160)
+            ! .center == g1_poly.center
+        LayoutRect g1_m1:
+            .layer = layers.Metal1
+            ! .center == g1_cont.center
+            ! .size == (320, 400)
+            .create_pin(self.symbol.g1)
+
+        LayoutRect g2_poly:
+            .layer = layers.GatPoly
+            ! .cx == m2.poly[0].cx
+            ! .north == m2.poly[0].south
+            ! .size == (320, 600)
+        LayoutRect g2_cont:
+            .layer = layers.Cont
+            ! .size == (160, 160)
+            ! .center == g2_poly.center
+        LayoutRect g2_m1:
+            .layer = layers.Metal1
+            ! .center == g2_cont.center
+            ! .size == (320, 400)
+            .create_pin(self.symbol.g2)
 
     viewgen drc(self) -> DrcReport:
         . = run_drc(self.layout)
+
+    viewgen lvs(self) -> LvsReport:
+        . = run_lvs(self.layout, self.symbol)

--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -105,6 +105,17 @@ def test_param_inst():
     with pytest.raises(ParameterError, match="has no parameter"):
         A(l=1, w=1, x=123)
 
+def test_params_list_hides_default_bool():
+    class A(Cell):
+        x = Parameter(int)
+        m = Parameter(int, default=1)
+        flag = Parameter(bool, default=True)
+
+    # A boolean parameter at its default is omitted from the canonical name,
+    # while a non-default bool and non-bool defaults (m) are kept.
+    assert repr(A(x=2)) == "A(x=2,m=1)"
+    assert repr(A(x=2, flag=False)) == "A(x=2,m=1,flag=False)"
+
 # -- Concurrency semantics of Future-based view caching ----------------------
 
 import threading

--- a/tests/test_ihp130_inv.py
+++ b/tests/test_ihp130_inv.py
@@ -5,9 +5,12 @@
 Tests basic DRC + LVS in IHP130.
 """
 
+import ordec.importer
+
 from ordec.core.schema import LvsItem, LvsItemType
 from ordec.lib import ihp130
 from .lib.ihp130_inv import Inv
+from .lib.ihp130_nmos_series import SeriesNmos
 
 def test_lvs_clean():
     c = Inv()
@@ -37,3 +40,8 @@ def test_drc_clean():
 def test_drc_violation():
     res = ihp130.run_drc(Inv(variant="thin_m1").layout, use_tempdir=True)
     assert res.summary() == {'M1.a': 2}
+
+
+def test_series_nmos_drc_clean():
+    """The uncontacted source/drain needs no Activ of its own to pass DRC."""
+    assert SeriesNmos().drc.summary() == {}

--- a/tests/test_ihp130_inv.py
+++ b/tests/test_ihp130_inv.py
@@ -45,3 +45,9 @@ def test_drc_violation():
 def test_series_nmos_drc_clean():
     """The uncontacted source/drain needs no Activ of its own to pass DRC."""
     assert SeriesNmos().drc.summary() == {}
+
+
+def test_series_nmos_lvs_clean():
+    """The abutted pair matches its two-transistor series schematic, with the
+    shared bare diffusion as the internal source/drain node."""
+    assert SeriesNmos().lvs.clean()


### PR DESCRIPTION
Adds the contact_sd_odd / contact_sd_even flags to ihp130.Nmos and Pmos. Follow-up from old ihp130_mos_sd_flags branch.